### PR TITLE
Override environment variables with dotenv when running components:dev:test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "4.3.3",
+  "version": "4.3.4",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": [
     "prismatic",

--- a/src/commands/components/dev/test.ts
+++ b/src/commands/components/dev/test.ts
@@ -154,7 +154,7 @@ export default class TestCommand extends Command {
     } = await this.parse(TestCommand);
 
     if (await exists(envPath)) {
-      const { error } = dotenv.config({ path: envPath });
+      const { error } = dotenv.config({ path: envPath, override: true });
       if (error) {
         CliUx.ux.error(`Failed to load specified dotenv file: ${error}`, {
           exit: 1,


### PR DESCRIPTION
If an action has an input with a key that is also a common environment variable, `components:dev:test` currently uses that environment variable, even if you've specified a value for it.

For example, the Dropbox component uses `path` as an input. MacOS computers have an environment variable `PATH`, and `components:dev:test` slots in `/User/treece/.....` for the input when running a test... even if you have a `PATH=/` in your `.env` file. That's obviously not desirable.

This change causes values in `.env` to override system-set environment variables for `components:dev:test`.