### PR TITLE
Improvements to components:dev:test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/prism",
-      "version": "4.3.4",
+      "version": "4.3.5",
       "license": "MIT",
       "dependencies": {
         "@jest/types": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "4.3.4",
+  "version": "4.3.5",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": [
     "prismatic",

--- a/src/commands/components/dev/run.ts
+++ b/src/commands/components/dev/run.ts
@@ -1,23 +1,7 @@
 import { Command, Flags, CliUx } from "@oclif/core";
 import { isEmpty } from "lodash";
 import { gqlRequest, gql } from "../../../graphql";
-import { spawn } from "child_process";
-
-const spawnProcess = (
-  [command, ...args]: string[],
-  env: Record<string, string>
-): Promise<void> => {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      env: { ...process.env, ...env },
-    });
-
-    child.stdout.pipe(process.stdout);
-    child.stderr.pipe(process.stderr);
-
-    child.on("close", (code) => (code === 0 ? resolve() : reject()));
-  });
-};
+import { spawnProcess } from "../../../utils/process";
 
 export default class RunCommand extends Command {
   static description = `Fetch an integration's active connection and execute a CLI command with that connection's fields as an environment variable.`;

--- a/src/commands/components/dev/test.ts
+++ b/src/commands/components/dev/test.ts
@@ -148,11 +148,12 @@ export default class TestCommand extends Command {
       char: "e",
       description: "Path to dotenv file to load for supplying testing values",
     }),
-    "no-build": Flags.boolean({
+    build: Flags.boolean({
       required: false,
-      default: false,
-      char: "n",
-      description: "Skip building the component prior to testing",
+      default: true,
+      allowNo: true,
+      char: "b",
+      description: "Build the component prior to testing",
     }),
     "output-file": Flags.string({
       required: false,
@@ -163,13 +164,13 @@ export default class TestCommand extends Command {
 
   async run() {
     const {
-      flags: { envPath, "no-build": noBuild, "output-file": outputFile },
+      flags: { envPath, build, "output-file": outputFile },
     } = await this.parse(TestCommand);
 
     // Save the current working directory, so we can return later after moving to dist/
     const cwd = process.cwd();
 
-    if (!noBuild) {
+    if (build) {
       console.log("Building component...");
       await spawnProcess(["npm", "run", "build"], {});
     }

--- a/src/commands/components/dev/test.ts
+++ b/src/commands/components/dev/test.ts
@@ -25,6 +25,8 @@ import { pollForActiveConfigVarState } from "../../../utils/integration/query";
 import { Expression } from "../../../utils/integration/export";
 import { exists } from "../../../fs";
 import { whoAmI } from "../../../utils/user/query";
+import { spawnProcess } from "../../../utils/process";
+import { writeFinalStepResults } from "../../../utils/execution/stepResults";
 
 const setTimeoutPromise = promisify(setTimeout);
 
@@ -138,7 +140,7 @@ const valuesFromAnswers = ({
 
 export default class TestCommand extends Command {
   static description =
-    "Run a Component in Prismatic by publishing it into a test Integration";
+    "Run an action of a component within a test integration in the integration runner";
   static flags = {
     envPath: Flags.string({
       required: false,
@@ -146,12 +148,31 @@ export default class TestCommand extends Command {
       char: "e",
       description: "Path to dotenv file to load for supplying testing values",
     }),
+    "no-build": Flags.boolean({
+      required: false,
+      default: false,
+      char: "n",
+      description: "Skip building the component prior to testing",
+    }),
+    "output-file": Flags.string({
+      required: false,
+      char: "o",
+      description: "Output the results of the action to a specified file",
+    }),
   };
 
   async run() {
     const {
-      flags: { envPath },
+      flags: { envPath, "no-build": noBuild, "output-file": outputFile },
     } = await this.parse(TestCommand);
+
+    // Save the current working directory, so we can return later after moving to dist/
+    const cwd = process.cwd();
+
+    if (!noBuild) {
+      console.log("Building component...");
+      await spawnProcess(["npm", "run", "build"], {});
+    }
 
     if (await exists(envPath)) {
       const { error } = dotenv.config({ path: envPath, override: true });
@@ -333,6 +354,12 @@ export default class TestCommand extends Command {
     const { executionId } = await runIntegrationFlow({ integrationId, flowId });
 
     await displayLogs(executionId);
+
+    if (outputFile) {
+      process.chdir(cwd);
+      console.log(`Writing step results to ${outputFile}`);
+      await writeFinalStepResults(executionId, outputFile);
+    }
 
     CliUx.ux.action.stop();
   }

--- a/src/commands/executions/step-result/get.ts
+++ b/src/commands/executions/step-result/get.ts
@@ -2,42 +2,11 @@ import { fs } from "../../../fs";
 import { Command, Flags } from "@oclif/core";
 import { gql, gqlRequest } from "../../../graphql";
 import axios from "axios";
-import { decode } from "@msgpack/msgpack";
-import { extension } from "mime-types";
-
-interface DeserializeResult {
-  data: unknown;
-  contentType: string;
-}
-
-const deserialize = (data: Buffer): DeserializeResult | unknown => decode(data);
-
-export const parseData = (data: string, contentType = ""): string => {
-  if (data === null || data === undefined) {
-    return "";
-  }
-  // Some content-types require additional processing.
-  const dataType = extension(contentType);
-  if (
-    contentType.startsWith("text/") ||
-    (dataType && ["json", "xml", "csv", "xhtml"].includes(dataType))
-  ) {
-    // If the content-types specifies that the data is text/, or if the extension
-    // is a well-known text-like type, convert the data to a string.
-    if (dataType === "json") {
-      try {
-        // If the payload is supposed to be JSON, ensure that it can be parsed.
-        return JSON.parse(data.toString());
-      } catch {
-        throw new Error("Received malformed JSON payload.");
-      }
-    }
-    return data;
-  } else if (contentType.startsWith("binary/")) {
-    return data;
-  }
-  return JSON.stringify(data);
-};
+import {
+  deserialize,
+  DeserializeResult,
+  parseData,
+} from "../../../utils/execution/stepResults";
 
 export default class GetCommand extends Command {
   static description =

--- a/src/utils/execution/stepResults.ts
+++ b/src/utils/execution/stepResults.ts
@@ -1,0 +1,84 @@
+import { decode } from "@msgpack/msgpack";
+import axios from "axios";
+import { fs } from "../../fs";
+import { gql, gqlRequest } from "../../graphql";
+import { extension } from "mime-types";
+
+export interface DeserializeResult {
+  data: unknown;
+  contentType: string;
+}
+
+export const deserialize = (data: Buffer): DeserializeResult | unknown =>
+  decode(data);
+
+export const parseData = (data: any, contentType = ""): string | Buffer => {
+  if (data === null || data === undefined) {
+    return "";
+  }
+  // Some content-types require additional processing.
+  const dataType = extension(contentType);
+  if (
+    contentType.startsWith("text/") ||
+    (dataType && ["json", "xml", "csv", "xhtml"].includes(dataType))
+  ) {
+    // If the content-types specifies that the data is text/, or if the extension
+    // is a well-known text-like type, convert the data to a string.
+    if (dataType === "json") {
+      try {
+        // If the payload is supposed to be JSON, ensure that it can be parsed.
+        return JSON.parse(data.toString());
+      } catch {
+        throw new Error("Received malformed JSON payload.");
+      }
+    }
+    return data;
+  } else if (contentType.startsWith("binary/")) {
+    return data;
+  }
+
+  return typeof data === "string" ||
+    (typeof data === "object" && Buffer.isBuffer(data))
+    ? data
+    : JSON.stringify(data);
+};
+
+const getFinalStepResult = async (executionId: string) => {
+  const result = await gqlRequest({
+    document: gql`
+      query executionResults($executionId: ID!) {
+        executionResult(id: $executionId) {
+          stepResults(last: 1) {
+            nodes {
+              id
+              stepName
+              resultsUrl
+            }
+          }
+        }
+      }
+    `,
+    variables: { executionId },
+  });
+  const { resultsUrl } = result.executionResult.stepResults.nodes[0];
+  const response = await axios.get(resultsUrl, {
+    responseType: "arraybuffer",
+  });
+  const resultsBuffer = Buffer.from(await response.data);
+  const { data: deserializedResult, contentType } = decode(
+    resultsBuffer
+  ) as DeserializeResult;
+
+  return {
+    data: parseData(deserializedResult as string, contentType),
+    contentType,
+  };
+};
+
+export const writeFinalStepResults = async (
+  executionId: string,
+  fileName: string
+): Promise<void> => {
+  const result = await getFinalStepResult(executionId);
+  await fs.writeFile(fileName, result.data);
+};

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -1,0 +1,17 @@
+import { spawn } from "child_process";
+
+export const spawnProcess = (
+  [command, ...args]: string[],
+  env: Record<string, string>
+): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      env: { ...process.env, ...env },
+    });
+
+    child.stdout.pipe(process.stdout);
+    child.stderr.pipe(process.stderr);
+
+    child.on("close", (code) => (code === 0 ? resolve() : reject()));
+  });
+};


### PR DESCRIPTION
This commit adds two additional features to `prism components:dev:test`:

- An `npm run build` is now automatically issued when the subcommand is run. It's far to easy to forget to build prior to testing. This ensures that you build before running a test. You can opt out of the build behavior with `--no-build`.
- You can now choose to write the results of your action's step to a file. If your action returns a JSON-serializable object, it's serialized to JSON and written out. If it returns a string, that string is written out. If it returns a Buffer or a binary file (png, pdf, etc), those are also written out properly. This lets you verify quickly that your action returns the structure of data that you'd expect it to. You can choose to write out step result data with the flag `--output-file my-file.png` (replacing the file name with whatever makes sense for you).

Additionally, some functionality (like spawning child processes or fetching step results) were abstracted into utility functions so multiple subcommands could use them.