### PR TITLE
Add commands related to managing embedded marketplace signing keys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "4.3.5",
+  "version": "4.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/prism",
-      "version": "4.3.5",
+      "version": "4.4.0",
       "license": "MIT",
       "dependencies": {
         "@jest/types": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "4.3.5",
+  "version": "4.4.0",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": [
     "prismatic",

--- a/src/commands/organization/signingkeys/delete.ts
+++ b/src/commands/organization/signingkeys/delete.ts
@@ -1,0 +1,38 @@
+import { Command } from "@oclif/core";
+import { gql, gqlRequest } from "../../../graphql";
+
+export default class DeleteCommand extends Command {
+  static description = "Delete an embedded marketplace signing key";
+  static args = [
+    {
+      name: "signingKeyId",
+      required: true,
+      description: "ID of the signing key to delete",
+    },
+  ];
+
+  async run() {
+    const {
+      args: { signingKeyId },
+    } = await this.parse(DeleteCommand);
+
+    await gqlRequest({
+      document: gql`
+        mutation ($id: ID!) {
+          deleteOrganizationSigningKey(input: { id: $id }) {
+            organizationSigningKey {
+              id
+            }
+            errors {
+              field
+              messages
+            }
+          }
+        }
+      `,
+      variables: {
+        id: signingKeyId,
+      },
+    });
+  }
+}

--- a/src/commands/organization/signingkeys/generate.mdx
+++ b/src/commands/organization/signingkeys/generate.mdx
@@ -1,0 +1,3 @@
+`organization:signingkeys:generate` will generate a new embedded marketplace signing key.
+The RSA public key is saved in Prismatic, and the private key is returned and immediately removed from Prismatic.
+Once the private key is returned, it cannot be retrieved again.

--- a/src/commands/organization/signingkeys/generate.ts
+++ b/src/commands/organization/signingkeys/generate.ts
@@ -1,0 +1,21 @@
+import { Command } from "@oclif/core";
+import { gql, gqlRequest } from "../../../graphql";
+
+export default class GenerateCommand extends Command {
+  static description = "Generate an embedded marketplace signing key";
+
+  async run() {
+    const result = await gqlRequest({
+      document: gql`
+        mutation generateSigningKey {
+          createOrganizationSigningKey(input: {}) {
+            result {
+              privateKey
+            }
+          }
+        }
+      `,
+    });
+    this.log(result.createOrganizationSigningKey.result.privateKey);
+  }
+}

--- a/src/commands/organization/signingkeys/import.mdx
+++ b/src/commands/organization/signingkeys/import.mdx
@@ -1,0 +1,17 @@
+`organization:signingkeys:import` allows you import your own RSA public key.
+You can use `openssl` to generate a new RSA key pair:
+
+First, run `openssl genrsa -out my-private-key.pem 4096` to generate an RSA private key.
+
+Next, run `openssl rsa -in my-private-key.pem -pubout > my-public-key.pub` to generate the associated RSA public key.
+It should look something like this:
+
+```
+-----BEGIN PUBLIC KEY-----
+EXAMPLE
+-----END PUBLIC KEY-----
+```
+
+Finally, import the _public_ key:
+
+`prism organization:signingkeys:import -p my-public-key.pub`

--- a/src/commands/organization/signingkeys/import.ts
+++ b/src/commands/organization/signingkeys/import.ts
@@ -1,0 +1,46 @@
+import { Command, Flags } from "@oclif/core";
+import { readFileSync } from "fs";
+import { gql, gqlRequest } from "../../../graphql";
+
+export default class ImportCommand extends Command {
+  static description =
+    "Import a RSA public key for use with embedded marketplace";
+
+  static flags = {
+    "public-key-file": Flags.string({
+      char: "p",
+      required: true,
+      description: "public key file",
+    }),
+  };
+
+  async run() {
+    const {
+      flags: { "public-key-file": publicKeyFile },
+    } = await this.parse(ImportCommand);
+
+    const publicKey = await readFileSync(publicKeyFile, {
+      encoding: "utf-8",
+      flag: "r",
+    });
+
+    const result = await gqlRequest({
+      document: gql`
+        mutation importPublicKey($publicKey: String!) {
+          importOrganizationSigningKey(input: { publicKey: $publicKey }) {
+            organizationSigningKey {
+              id
+            }
+            errors {
+              field
+              messages
+            }
+          }
+        }
+      `,
+      variables: { publicKey },
+    });
+
+    this.log(result.importOrganizationSigningKey.organizationSigningKey.id);
+  }
+}

--- a/src/commands/organization/signingkeys/list.ts
+++ b/src/commands/organization/signingkeys/list.ts
@@ -1,0 +1,41 @@
+import { Command, CliUx } from "@oclif/core";
+import { gql, gqlRequest } from "../../../graphql";
+
+export default class ListCommand extends Command {
+  static description = "List embedded signing keys for embedded marketplace";
+  static flags = { ...CliUx.ux.table.flags() };
+
+  async run() {
+    const { flags } = await this.parse(ListCommand);
+
+    const result = await gqlRequest({
+      document: gql`
+        query listOrganizationSigningKeys {
+          organization {
+            signingKeys {
+              nodes {
+                id
+                publicKey
+                privateKeyPreview
+                issuedAt
+                imported
+              }
+            }
+          }
+        }
+      `,
+    });
+
+    CliUx.ux.table(
+      result.organization.signingKeys.nodes,
+      {
+        id: { minWidth: 8, extended: true },
+        privateKeyPreview: { header: "Private Key Preview" },
+        publicKey: { header: "Public Key", extended: true },
+        issuedAt: { header: "Timestamp" },
+        imported: { header: "Imported?" },
+      },
+      { ...flags }
+    );
+  }
+}


### PR DESCRIPTION
Some customers would like to manage their embedded marketplace signing keys via CLI. This PR adds commands that:
- List existing signing keys
- Delete a signing key by ID
- Generate a new signing key. This returns the private key to the user (private keys are not saved in Prismatic)
- Import a signing key. This allows a user to generate their own public-private RSA key pair using `openssl`, and import the public key into Prismatic.