### PR TITLE
Add option to print step results to stdout with components:dev:test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/prism",
-      "version": "4.4.0",
+      "version": "4.4.1",
       "license": "MIT",
       "dependencies": {
         "@jest/types": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": [
     "prismatic",

--- a/src/commands/components/dev/test.ts
+++ b/src/commands/components/dev/test.ts
@@ -26,7 +26,10 @@ import { Expression } from "../../../utils/integration/export";
 import { exists } from "../../../fs";
 import { whoAmI } from "../../../utils/user/query";
 import { spawnProcess } from "../../../utils/process";
-import { writeFinalStepResults } from "../../../utils/execution/stepResults";
+import {
+  printFinalStepResults,
+  writeFinalStepResults,
+} from "../../../utils/execution/stepResults";
 
 const setTimeoutPromise = promisify(setTimeout);
 
@@ -160,11 +163,21 @@ export default class TestCommand extends Command {
       char: "o",
       description: "Output the results of the action to a specified file",
     }),
+    "print-results": Flags.boolean({
+      required: false,
+      default: false,
+      description: "Print the results of the action to stdout",
+    }),
   };
 
   async run() {
     const {
-      flags: { envPath, build, "output-file": outputFile },
+      flags: {
+        envPath,
+        build,
+        "output-file": outputFile,
+        "print-results": printResults,
+      },
     } = await this.parse(TestCommand);
 
     // Save the current working directory, so we can return later after moving to dist/
@@ -360,6 +373,10 @@ export default class TestCommand extends Command {
       process.chdir(cwd);
       console.log(`Writing step results to ${outputFile}`);
       await writeFinalStepResults(executionId, outputFile);
+    }
+
+    if (printResults) {
+      await printFinalStepResults(executionId);
     }
 
     CliUx.ux.action.stop();

--- a/src/utils/execution/logs.ts
+++ b/src/utils/execution/logs.ts
@@ -36,7 +36,7 @@ export const waitForExecutionCompletion = (
 
           // Grace period to let logs finish flowing; logs are fully async and are
           // not guaranteed to be added in chronological order.
-          await setTimeoutPromise(1000);
+          await setTimeoutPromise(2000);
 
           resolve();
         }

--- a/src/utils/execution/stepResults.ts
+++ b/src/utils/execution/stepResults.ts
@@ -82,3 +82,16 @@ export const writeFinalStepResults = async (
   const result = await getFinalStepResult(executionId);
   await fs.writeFile(fileName, result.data);
 };
+
+export const printFinalStepResults = async (
+  executionId: string
+): Promise<void> => {
+  const result = await getFinalStepResult(executionId);
+  console.log(`
+======== Step Results ========
+
+${result.data}
+
+==============================
+`);
+};


### PR DESCRIPTION
This allows you to optionally run `prism components:dev:test` with `--print-results` to print the action's step results to stdout.