### PR TITLE
Add the ability to set an icon when an integration is imported

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/prism",
-      "version": "4.5.0",
+      "version": "4.6.0",
       "license": "MIT",
       "dependencies": {
         "@jest/types": "27.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "4.5.0",
+  "version": "4.6.0",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": [
     "prismatic",

--- a/src/utils/avatar.ts
+++ b/src/utils/avatar.ts
@@ -1,0 +1,53 @@
+import axios from "axios";
+import { fs } from "../fs";
+import { gql, gqlRequest } from "../graphql";
+import mimetypes from "mime-types";
+import { basename, extname } from "path";
+
+interface GetPresignedUrlResponse {
+  uploadMedia: {
+    uploadUrl: string;
+    objectUrl: string;
+  };
+}
+
+/**
+ *
+ * @param objectId The Prismatic ID of the object to set the avatar for (integration ID, user ID, etc)
+ * @param iconPath The path to the icon file
+ * @returns The media URL for the file that was uploaded
+ */
+export const uploadAvatar = async (objectId: string, iconPath: string) => {
+  const {
+    uploadMedia: { uploadUrl, objectUrl },
+  } = await gqlRequest<GetPresignedUrlResponse>({
+    document: gql`
+      query getPresignedUrl(
+        $objectId: ID!
+        $fileName: String!
+        $mediaType: MediaType!
+      ) {
+        uploadMedia(
+          objectId: $objectId
+          fileName: $fileName
+          mediaType: $mediaType
+        ) {
+          uploadUrl
+          objectUrl
+          error
+        }
+      }
+    `,
+    variables: {
+      objectId,
+      fileName: basename(iconPath),
+      mediaType: "AVATAR",
+    },
+  });
+
+  await axios.put(uploadUrl, await fs.readFile(iconPath), {
+    headers: { "Content-Type": mimetypes.contentType(extname(iconPath)) },
+  });
+
+  return objectUrl;
+};


### PR DESCRIPTION
If you export an integration and then import it, you lose the integration's icon. This adds the ability to specify an integration icon when someone runs `integrations:import`. You can now run something like

```
prism integrations:import -p ./integration.yaml --icon-path ./icon.png 
```

`uploadAvatar` was written in a generic enough way that it could be used in the future for setting avatars for organizations, users, customers, etc.