### PR TITLE
Add integrations:marketplace configuration subcommand

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+max_line_length = 80
+trim_trailing_whitespace = true
+
+[*.{md,mdx}]
+trim_trailing_whitespace = false

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/prism",
-      "version": "4.6.1",
+      "version": "4.6.2",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": [
     "prismatic",

--- a/src/commands/integrations/marketplace.ts
+++ b/src/commands/integrations/marketplace.ts
@@ -1,0 +1,82 @@
+import { Command, Flags } from "@oclif/core";
+import { gql, gqlRequest } from "../../graphql";
+
+export default class MarketplaceCommand extends Command {
+  static description =
+    "Make a version of an Integration available in the Marketplace";
+
+  static args = [
+    {
+      name: "integration",
+      required: true,
+      description: "ID of an integration version to make marketplace available",
+    },
+  ];
+
+  static flags = {
+    available: Flags.boolean({
+      char: "a",
+      description: "Mark this Integration version available in the marketplace",
+      allowNo: true,
+      required: true,
+    }),
+    deployable: Flags.boolean({
+      char: "d",
+      description:
+        "Mark this Integration version as deployable in the marketplace; does not apply if not also marked available",
+      allowNo: true,
+      default: true,
+    }),
+    overview: Flags.string({
+      char: "o",
+      required: true,
+      description: "Overview to describe the purpose of the integration",
+    }),
+  };
+
+  async run() {
+    const {
+      args: { integration },
+      flags: { available, deployable, overview },
+    } = await this.parse(MarketplaceCommand);
+
+    const marketplaceConfiguration = available
+      ? deployable
+        ? "AVAILABLE_AND_DEPLOYABLE"
+        : "AVAILABLE_NOT_DEPLOYABLE"
+      : "NOT_AVAILABLE_IN_MARKETPLACE";
+
+    const result = await gqlRequest({
+      document: gql`
+        mutation updateMarketplaceConfiguration(
+          $id: ID
+          $marketplaceConfiguration: String!
+          $overview: String!
+        ) {
+          updateIntegrationMarketplaceConfiguration(
+            input: {
+              id: $id
+              marketplaceConfiguration: $marketplaceConfiguration
+              overview: $overview
+            }
+          ) {
+            integration {
+              id
+            }
+            errors {
+              field
+              messages
+            }
+          }
+        }
+      `,
+      variables: {
+        id: integration,
+        marketplaceConfiguration,
+        overview,
+      },
+    });
+
+    this.log(result.updateIntegrationMarketplaceConfiguration.integration.id);
+  }
+}


### PR DESCRIPTION
Usage:
`prism integrations:marketplace <id> --available --deployable`

There's a bit of logic in the oclif-based flags to try to constrain to the three states we support while being relatively ergonomic from the CLI. For instance, `deployable` is defaulted to true but can be disabled by negating the flag (`--no-deployable`) and similar can be achieved by negating the available flag (but they both require the negation since they're likely less common).