### PR TITLE
Add option to remove temporary integration and component after a component:dev:test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "4.6.3",
+  "version": "4.6.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/prism",
-      "version": "4.6.3",
+      "version": "4.6.4",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "4.6.3",
+  "version": "4.6.4",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": [
     "prismatic",

--- a/src/commands/instances/create.ts
+++ b/src/commands/instances/create.ts
@@ -13,7 +13,8 @@ export default class CreateCommand extends Command {
     integration: Flags.string({
       char: "i",
       required: true,
-      description: "ID of the integration or a specific integration version ID this is an instance of",
+      description:
+        "ID of the integration or a specific integration version ID this is an instance of",
     }),
     customer: Flags.string({
       char: "c",

--- a/src/commands/instances/update.ts
+++ b/src/commands/instances/update.ts
@@ -36,9 +36,19 @@ export default class UpdateCommand extends Command {
 
     const result = await gqlRequest({
       document: gql`
-        mutation updateInstance($id: ID!, $name: String, $description: String, $version: ID! ) {
+        mutation updateInstance(
+          $id: ID!
+          $name: String
+          $description: String
+          $version: ID!
+        ) {
           updateInstance(
-            input: { id: $id, name: $name, description: $description, integration: $version}
+            input: {
+              id: $id
+              name: $name
+              description: $description
+              integration: $version
+            }
           ) {
             instance {
               id

--- a/src/utils/component/deleteByKey.ts
+++ b/src/utils/component/deleteByKey.ts
@@ -1,11 +1,11 @@
 import { gql, gqlRequest } from "../../graphql";
 
 export const deleteComponentByKey = async (key: string) => {
-  // Retrieve the existing signature of the component if it exists.
+  // Fetch a component by key
   const result = await gqlRequest({
     document: gql`
       query component($key: String!) {
-        components(key: $key) {
+        components(key: $key, public: false) {
           nodes {
             id
           }
@@ -16,6 +16,7 @@ export const deleteComponentByKey = async (key: string) => {
       key,
     },
   });
+  // Delete the component by ID
   await gqlRequest({
     document: gql`
       mutation deleteComponent($id: ID!) {

--- a/src/utils/component/deleteByKey.ts
+++ b/src/utils/component/deleteByKey.ts
@@ -1,0 +1,32 @@
+import { gql, gqlRequest } from "../../graphql";
+
+export const deleteComponentByKey = async (key: string) => {
+  // Retrieve the existing signature of the component if it exists.
+  const result = await gqlRequest({
+    document: gql`
+      query component($key: String!) {
+        components(key: $key) {
+          nodes {
+            id
+          }
+        }
+      }
+    `,
+    variables: {
+      key,
+    },
+  });
+  await gqlRequest({
+    document: gql`
+      mutation deleteComponent($id: ID!) {
+        deleteComponent(input: { id: $id }) {
+          errors {
+            field
+            messages
+          }
+        }
+      }
+    `,
+    variables: { id: result.components.nodes[0].id },
+  });
+};

--- a/src/utils/integration/invoke.ts
+++ b/src/utils/integration/invoke.ts
@@ -49,6 +49,23 @@ export const getIntegrationFlow = async (
   return flows[0].id;
 };
 
+/** Delete a specified integration by ID */
+export const deleteIntegration = async (integrationId: string) => {
+  await gqlRequest({
+    document: gql`
+      mutation deleteIntegration($id: ID!) {
+        deleteIntegration(input: { id: $id }) {
+          errors {
+            field
+            messages
+          }
+        }
+      }
+    `,
+    variables: { id: integrationId },
+  });
+};
+
 interface IntegrationFlowRunProps {
   integrationId: string;
   flowId?: string;


### PR DESCRIPTION
Running a `component:dev:test` leaves behind a temporary integration and component. That's sometimes useful (so you don't need to re-authenticate with OAuth, etc), but often it just leaves orphaned integrations/components that you need to clean up manually. 

This allows you to pass a `--clean-up` flag to your `components:dev:test` command to automatically clean up the temporary integration/component.