### PR TITLE
Add filters to integraitons:list to only show specific customer or org-only integrations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "4.6.6",
+  "version": "4.6.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/prism",
-      "version": "4.6.6",
+      "version": "4.6.7",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "4.6.6",
+  "version": "4.6.7",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": [
     "prismatic",

--- a/src/commands/integrations/list.ts
+++ b/src/commands/integrations/list.ts
@@ -10,11 +10,20 @@ export default class ListCommand extends Command {
       description:
         "If specified this command returns all versions of all integrations rather than only the latest version",
     }),
+    customer: Flags.string({
+      char: "c",
+      description:
+        "If specified this command returns only integrations that are available to the specified customer ID",
+    }),
+    "org-only": Flags.boolean({
+      char: "o",
+      description: "If specified this command returns only org integrations",
+    }),
   };
 
   async run() {
     const { flags } = await this.parse(ListCommand);
-    const { showAllVersions } = flags;
+    const { showAllVersions, customer, "org-only": orgOnly } = flags;
 
     let integrations: any[] = [];
     let hasNextPage = true;
@@ -25,8 +34,18 @@ export default class ListCommand extends Command {
         integrations: { nodes, pageInfo },
       } = await gqlRequest({
         document: gql`
-          query listIntegrations($showAllVersions: Boolean, $after: String) {
-            integrations(allVersions: $showAllVersions, after: $after) {
+          query listIntegrations(
+            $showAllVersions: Boolean
+            $after: String
+            $customer: ID
+            $customerIsnull: Boolean
+          ) {
+            integrations(
+              allVersions: $showAllVersions
+              after: $after
+              customer: $customer
+              customer_Isnull: $customerIsnull
+            ) {
               nodes {
                 id
                 name
@@ -34,6 +53,11 @@ export default class ListCommand extends Command {
                 versionNumber
                 labels
                 category
+                customer {
+                  id
+                  name
+                  externalId
+                }
               }
               pageInfo {
                 hasNextPage
@@ -45,6 +69,8 @@ export default class ListCommand extends Command {
         variables: {
           showAllVersions,
           after: cursor,
+          customer,
+          customerIsnull: orgOnly,
         },
       });
       integrations = [...integrations, ...nodes];
@@ -64,6 +90,15 @@ export default class ListCommand extends Command {
         versionNumber: { header: "Version" },
         labels: { extended: true },
         category: { extended: true },
+        customerId: { extended: true, get: (row) => row.customer?.id ?? "" },
+        customerName: {
+          extended: true,
+          get: (row) => row.customer?.name ?? "",
+        },
+        customerExternalId: {
+          extended: true,
+          get: (row) => row.customer?.externalId ?? "",
+        },
       },
       { ...flags }
     );


### PR DESCRIPTION
If you run `prism integrations:list --filter "name=^<INTEGRATION_NAME>$" --columns id --no-header`, you may now get multiple integrations back, as an org and several customers can all have integrations with the same name.

This adds two optional flags that can be used to query for specific integrations. Changes are backwards-compatible: flags are optional and the query runs the same as it did before if the flags aren't specified.
- `--org-only`: Show only org-owned integrations
- `--customer ID`: Show only integrations owned by the customer with this ID