### PR TITLE
Allow a user to negate the --available flag for integrations:available

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "4.6.8",
+  "version": "4.6.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/prism",
-      "version": "4.6.8",
+      "version": "4.6.9",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "4.6.8",
+  "version": "4.6.9",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": [
     "prismatic",

--- a/src/commands/integrations/available.ts
+++ b/src/commands/integrations/available.ts
@@ -16,6 +16,7 @@ export default class AvailableCommand extends Command {
       required: true,
       char: "a",
       description: "Version is available or unavailable",
+      allowNo: true,
     }),
   };
 


### PR DESCRIPTION
This allows a user to run `prism integrations:available --no-available` to mark an integration version as not available.