### PR TITLE
Fix version flag on instances:update and add deploy flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/prism",
-      "version": "4.7.0",
+      "version": "4.7.1",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": [
     "prismatic",


### PR DESCRIPTION
It ends up being pretty common to update a version and want to deploy it immediately so this adds an optional flag to combine update/deploy.