### PR TITLE
Add an allow-multiple-instances flag to integrations:marketplace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/prism",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": [
     "prismatic",

--- a/src/commands/integrations/marketplace.ts
+++ b/src/commands/integrations/marketplace.ts
@@ -26,6 +26,13 @@ export default class MarketplaceCommand extends Command {
       allowNo: true,
       default: true,
     }),
+    "allow-multiple-instances": Flags.boolean({
+      char: "m",
+      description:
+        "Allow a customer to deploy multiple instances of this integration",
+      allowNo: false,
+      default: false,
+    }),
     overview: Flags.string({
       char: "o",
       required: true,
@@ -36,7 +43,12 @@ export default class MarketplaceCommand extends Command {
   async run() {
     const {
       args: { integration },
-      flags: { available, deployable, overview },
+      flags: {
+        available,
+        deployable,
+        overview,
+        "allow-multiple-instances": multipleInstances,
+      },
     } = await this.parse(MarketplaceCommand);
 
     const marketplaceConfiguration = available
@@ -51,12 +63,14 @@ export default class MarketplaceCommand extends Command {
           $id: ID
           $marketplaceConfiguration: String!
           $overview: String!
+          $multipleInstances: Boolean
         ) {
           updateIntegrationMarketplaceConfiguration(
             input: {
               id: $id
               marketplaceConfiguration: $marketplaceConfiguration
               overview: $overview
+              allowMultipleMarketplaceInstances: $multipleInstances
             }
           ) {
             integration {
@@ -73,6 +87,7 @@ export default class MarketplaceCommand extends Command {
         id: integration,
         marketplaceConfiguration,
         overview,
+        multipleInstances,
       },
     });
 

--- a/src/commands/integrations/marketplace.ts
+++ b/src/commands/integrations/marketplace.ts
@@ -30,8 +30,7 @@ export default class MarketplaceCommand extends Command {
       char: "m",
       description:
         "Allow a customer to deploy multiple instances of this integration",
-      allowNo: false,
-      default: false,
+      allowNo: true,
     }),
     overview: Flags.string({
       char: "o",


### PR DESCRIPTION
This adds an optional `--allow-multiple-instances` flag to the `integrations:marketplace` command which, when set, will toggle the "Allow multiple instances" flag on the marketplace offering and will allow customers to deploy multiple instances of the given integration.
![image](https://github.com/prismatic-io/prism/assets/3622586/326726e8-da80-404f-accd-00dbc6b8425a)
