### PR TITLE
Add --label flags to instances:create and instances:update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@prismatic-io/prism",
-      "version": "5.2.1",
+      "version": "5.2.2",
       "license": "MIT",
       "dependencies": {
         "@msgpack/msgpack": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": [
     "prismatic",

--- a/src/commands/instances/create.mdx
+++ b/src/commands/instances/create.mdx
@@ -29,5 +29,7 @@ prism instances:create \
             \"key\": \"Acme Basic Auth\",
             \"values\": \"${CREDENTIALS}\"
         }
-    ]"
+    ]" \
+    --label 'Production' \
+    --label 'Paid'
 ```

--- a/src/commands/instances/create.ts
+++ b/src/commands/instances/create.ts
@@ -31,6 +31,11 @@ export default class CreateCommand extends Command {
       char: "v",
       description: "config variables to bind to steps of your instance",
     }),
+    label: Flags.string({
+      char: "l",
+      description: "a label or set of labels to apply to the instance",
+      multiple: true,
+    }),
   };
 
   async run() {
@@ -41,6 +46,7 @@ export default class CreateCommand extends Command {
         integration,
         customer,
         "config-vars": configVars,
+        label,
       },
     } = await this.parse(CreateCommand);
 
@@ -52,6 +58,7 @@ export default class CreateCommand extends Command {
           $integration: ID!
           $customer: ID!
           $configVariables: [InputInstanceConfigVariable]
+          $labels: [String]
         ) {
           createInstance(
             input: {
@@ -60,6 +67,7 @@ export default class CreateCommand extends Command {
               integration: $integration
               customer: $customer
               configVariables: $configVariables
+              labels: $labels
             }
           ) {
             instance {
@@ -78,6 +86,7 @@ export default class CreateCommand extends Command {
         integration,
         customer,
         configVariables: parseJsonOrUndefined(configVars),
+        labels: label,
       },
     });
 

--- a/src/commands/instances/update.ts
+++ b/src/commands/instances/update.ts
@@ -27,12 +27,17 @@ export default class UpdateCommand extends Command {
     deploy: Flags.boolean({
       description: "Deploy the instance after updating",
     }),
+    label: Flags.string({
+      char: "l",
+      description: "a label or set of labels to apply to the instance",
+      multiple: true,
+    }),
   };
 
   async run() {
     const {
       args: { instance },
-      flags: { name, description, version, deploy },
+      flags: { name, description, version, deploy, label },
     } = await this.parse(UpdateCommand);
 
     const result = await gqlRequest({
@@ -42,6 +47,7 @@ export default class UpdateCommand extends Command {
           $name: String
           $description: String
           $version: ID
+          $labels: [String]
         ) {
           updateInstance(
             input: {
@@ -49,6 +55,7 @@ export default class UpdateCommand extends Command {
               name: $name
               description: $description
               integration: $version
+              labels: $labels
             }
           ) {
             instance {
@@ -66,6 +73,7 @@ export default class UpdateCommand extends Command {
         name,
         description,
         version,
+        labels: label,
       },
     });
 


### PR DESCRIPTION
Users can now run `prism instances:create` with one or more `--label` flags to apply labels to an instance.