### PR TITLE
Restore ability to import icon when importing an integration YAML definition

### DIFF
--- a/src/commands/integrations/import.ts
+++ b/src/commands/integrations/import.ts
@@ -52,7 +52,7 @@ export default class ImportCommand extends Command {
 
     const integrationImportId = path
       ? // A path was specified, so assume we're importing a YAML Integration.
-        await importYamlIntegration(path, integrationId)
+        await importYamlIntegration(path, integrationId, iconPath)
       : // No path was specified, so assume the current directory is a Code Native Integration and import it.
         await importCodeNativeIntegration(integrationId);
 


### PR DESCRIPTION
When importing an integration that is defined in YAML, you can specify an `--icon-path` flag to set your integration's icon. A recent PR that implemented code-native integration importing missed that flag. This restores the icon-setting functionality.