### PR TITLE
Squash bugs and get OpenAPI-based component generation back under test

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 github-cli 2.43.1
 nodejs 18.19.1
-bun 1.1.1
+bun 1.1.7

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": ["prismatic", "cli"],
   "homepage": "https://prismatic.io",

--- a/src/commands/components/init/__snapshots__/index.test.ts.snap
+++ b/src/commands/components/init/__snapshots__/index.test.ts.snap
@@ -1,6 +1,994 @@
 // Bun Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`component generation tests wsdl NumberConversion.wsdl generation should match actions.ts snapshot: numberconversion-actions.ts 1`] = `
+exports[`component generation tests openApi - petstore-expanded should match scaffolding snapshots: petstore-expanded/jest.config.js 1`] = `
+"module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+};
+"
+`;
+
+exports[`component generation tests openApi - petstore-expanded should match scaffolding snapshots: petstore-expanded/package.json 1`] = `
+"{
+  "name": "petstoreExpanded",
+  "private": true,
+  "version": "0.0.1",
+  "scripts": {
+    "build": "webpack",
+    "test": "jest --runInBand",
+    "lint": "eslint --quiet --ext .ts .",
+    "lint-fix": "eslint --quiet --ext .ts --fix .",
+    "format": "npm run lint-fix && prettier --log-level error --write ."
+  },
+  "eslintConfig": {
+    "root": true,
+    "extends": ["@prismatic-io/eslint-config-spectral"]
+  },
+  "dependencies": {
+    "@prismatic-io/spectral": "8.0.6"
+  },
+  "devDependencies": {
+    "@prismatic-io/eslint-config-spectral": "2.0.1",
+    "@types/jest": "25.2.3",
+    "copy-webpack-plugin": "10.2.4",
+    "jest": "26.6.3",
+    "ts-jest": "26.4.0",
+    "ts-loader": "9.3.0",
+    "typescript": "4.6.3",
+    "webpack": "5.72.0",
+    "webpack-cli": "4.9.2",
+    "prettier": "3.0.3"
+  }
+}
+"
+`;
+
+exports[`component generation tests openApi - petstore-expanded should match scaffolding snapshots: petstore-expanded/petstoreExpanded-openapi-spec.json 1`] = `
+"{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team",
+      "email": "apiteam@swagger.io",
+      "url": "http://swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://petstore.swagger.io/v2"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "description": "Returns all pets from the system that the user has access to\nNam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.\n\nSed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.\n",
+        "operationId": "findPets",
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "tags to filter by",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new pet in the store. Duplicates are allowed",
+        "operationId": "addPet",
+        "requestBody": {
+          "description": "Pet to add to the store",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewPet"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{id}": {
+      "get": {
+        "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId": "find pet by id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to fetch",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "deletes a single pet based on the ID supplied",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to delete",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pet deleted"
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NewPet"
+          },
+          {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          }
+        ]
+      },
+      "NewPet": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}
+"
+`;
+
+exports[`component generation tests openApi - petstore-expanded should match scaffolding snapshots: petstore-expanded/tsconfig.json 1`] = `
+"{
+  "compilerOptions": {
+    "target": "es6",
+    "lib": ["esnext"],
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node"
+  },
+  "include": ["src"]
+}
+"
+`;
+
+exports[`component generation tests openApi - petstore-expanded should match scaffolding snapshots: petstore-expanded/src/connections.ts 1`] = `
+"import "@prismatic-io/spectral";
+
+export default [];
+"
+`;
+
+exports[`component generation tests openApi - petstore-expanded should match scaffolding snapshots: petstore-expanded/src/client.ts 1`] = `
+"import { Connection, ConnectionError, util } from "@prismatic-io/spectral";
+import { HttpClient, createClient as createHttpClient } from "@prismatic-io/spectral/dist/clients/http";
+import {  } from "./connections.js";
+
+export const baseUrl = "https://petstore.swagger.io/v2";
+
+const toAuthorizationHeaders = (connection: Connection): { Authorization: string } => {
+const accessToken = util.types.toString(connection.token?.access_token);
+if (accessToken) {
+return { Authorization: \`Bearer ${accessToken}\` };
+}
+
+const apiKey = util.types.toString(connection.fields?.apiKey);
+if (apiKey) {
+return { Authorization: \`Bearer ${apiKey}\` };
+}
+
+const username = util.types.toString(connection.fields?.username);
+const password = util.types.toString(connection.fields?.password);
+if (username && password) {
+const encoded = Buffer.from(\`${username}:${password}\`).toString("base64");
+return { Authorization: \`Basic ${encoded}\` };
+}
+
+throw new Error(
+\`Failed to guess at authorization parameters for Connection: ${connection.key}\`
+);
+};
+
+export const createClient = (connection: Connection): HttpClient => {
+if (![].includes(connection.key)) {
+throw new ConnectionError(connection, \`Received unexpected connection type: ${connection.key}\`);
+}
+
+const client = createHttpClient({
+baseUrl,
+headers: {
+...toAuthorizationHeaders(connection),
+Accept: "application/json",
+},
+responseType: "json",
+});
+return client;
+};
+"
+`;
+
+exports[`component generation tests openApi - petstore-expanded should match scaffolding snapshots: petstore-expanded/src/actions/pets.ts 1`] = `
+"import { action, input, util } from "@prismatic-io/spectral";
+import { createClient } from "../client";
+
+const 
+
+    findPets = action({
+        display: {
+            label: "Find Pets",
+            description: "Returns all pets from the system that the user has access to",
+        }
+        ,perform: 
+        async (context, { connection, tags, limit }) => {
+
+        const client = createClient(connection);
+        const {data} = await client.get(\`/pets\`, { params: { tags, limit } });
+        return {data};
+        }
+        ,inputs: {
+            connection: input({
+            label: "Connection",
+            type: "connection",
+            required: true,
+            }),
+            tags: input({
+            label: "Tags",
+            type: "string",
+            required: false,
+            clean: (value): string | undefined => util.types.toString(value) || undefined,
+            comments: "tags to filter by",
+            }),
+            limit: input({
+            label: "Limit",
+            type: "string",
+            required: false,
+            clean: (value): number => util.types.toNumber(value),
+            comments: "maximum number of results to return",
+            }),
+        }
+        ,
+        })
+
+    ;
+const 
+
+    addPet = action({
+        display: {
+            label: "Add Pet",
+            description: "Creates a new pet in the store",
+        }
+        ,perform: 
+        async (context, { connection, name, tag }) => {
+
+        const client = createClient(connection);
+        const {data} = await client.post(\`/pets\`, { name,tag });
+        return {data};
+        }
+        ,inputs: {
+            connection: input({
+            label: "Connection",
+            type: "connection",
+            required: true,
+            }),
+            name: input({
+            label: "Name",
+            type: "string",
+            required: true,
+            clean: (value): string | undefined => util.types.toString(value) || undefined,
+            }),
+            tag: input({
+            label: "Tag",
+            type: "string",
+            required: false,
+            clean: (value): string | undefined => util.types.toString(value) || undefined,
+            }),
+        }
+        ,
+        })
+
+    ;
+const 
+
+    findPetById = action({
+        display: {
+            label: "Find Pet By Id",
+            description: "Returns a user based on a single ID, if the user does not have access to the pet",
+        }
+        ,perform: 
+        async (context, { connection, id }) => {
+
+        const client = createClient(connection);
+        const {data} = await client.get(\`/pets/${id}\`);
+        return {data};
+        }
+        ,inputs: {
+            connection: input({
+            label: "Connection",
+            type: "connection",
+            required: true,
+            }),
+            id: input({
+            label: "Id",
+            type: "string",
+            required: true,
+            clean: (value): number => util.types.toNumber(value),
+            comments: "ID of pet to fetch",
+            }),
+        }
+        ,
+        })
+
+    ;
+const 
+
+    deletePet = action({
+        display: {
+            label: "Delete Pet",
+            description: "deletes a single pet based on the ID supplied",
+        }
+        ,perform: 
+        async (context, { connection, id }) => {
+
+        const client = createClient(connection);
+        const {data} = await client.delete(\`/pets/${id}\`);
+        return {data};
+        }
+        ,inputs: {
+            connection: input({
+            label: "Connection",
+            type: "connection",
+            required: true,
+            }),
+            id: input({
+            label: "Id",
+            type: "string",
+            required: true,
+            clean: (value): number => util.types.toNumber(value),
+            comments: "ID of pet to delete",
+            }),
+        }
+        ,
+        })
+
+    ;
+
+export default {
+        findPets,
+        addPet,
+        findPetById,
+        deletePet,
+    };
+"
+`;
+
+exports[`component generation tests openApi - petstore-expanded should match scaffolding snapshots: petstore-expanded/src/actions/index.ts 1`] = `
+"import { buildRawRequestAction } from "@prismatic-io/spectral/dist/clients/http";
+import { baseUrl } from "../client";
+import pets from "./pets";
+
+export default {
+        ...pets,
+        rawRequest: buildRawRequestAction(baseUrl),
+    };
+"
+`;
+
+exports[`component generation tests openApi - petstore-expanded should match scaffolding snapshots: petstore-expanded/src/index.ts 1`] = `
+"import { component } from "@prismatic-io/spectral";
+import { handleErrors } from "@prismatic-io/spectral/dist/clients/http";
+import actions from "./actions";
+import connections from "./connections";
+
+export default component({
+    key: "petstoreExpanded",
+    display: {
+    label: "Swagger Petstore",
+    description: "A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3",
+    iconPath: "icon.png",
+    },
+    hooks: { error: handleErrors },
+    actions,
+    connections,
+    })
+;
+"
+`;
+
+exports[`component generation tests openApi - petstore-expanded should match scaffolding snapshots: petstore-expanded/src/component.test.ts 1`] = `
+"import { testing } from "@prismatic-io/spectral";
+import component from ".";
+
+describe("petstoreExpanded", () => {
+const harness = testing.createHarness(component);
+
+it("should invoke action", async () => {
+const result = await harness.action("findPets", 
+{
+    tags: undefined,
+    limit: undefined,
+}
+);
+expect(result?.data).toBeDefined();
+});
+});
+"
+`;
+
+exports[`component generation tests wsdl - numberconversion should match scaffolding snapshots: numberconversion/numberConversion.wsdl 1`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:tns="http://www.dataaccess.com/webservicesserver/" name="NumberConversion" targetNamespace="http://www.dataaccess.com/webservicesserver/">
+  <types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://www.dataaccess.com/webservicesserver/">
+      <xs:element name="NumberToWords">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ubiNum" type="xs:unsignedLong"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="NumberToWordsResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="NumberToWordsResult" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="NumberToDollars">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="dNum" type="xs:decimal"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="NumberToDollarsResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="NumberToDollarsResult" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+  </types>
+  <message name="NumberToWordsSoapRequest">
+    <part name="parameters" element="tns:NumberToWords"/>
+  </message>
+  <message name="NumberToWordsSoapResponse">
+    <part name="parameters" element="tns:NumberToWordsResponse"/>
+  </message>
+  <message name="NumberToDollarsSoapRequest">
+    <part name="parameters" element="tns:NumberToDollars"/>
+  </message>
+  <message name="NumberToDollarsSoapResponse">
+    <part name="parameters" element="tns:NumberToDollarsResponse"/>
+  </message>
+  <portType name="NumberConversionSoapType">
+    <operation name="NumberToWords">
+      <documentation>Returns the word corresponding to the positive number passed as parameter. Limited to quadrillions.</documentation>
+      <input message="tns:NumberToWordsSoapRequest"/>
+      <output message="tns:NumberToWordsSoapResponse"/>
+    </operation>
+    <operation name="NumberToDollars">
+      <documentation>Returns the non-zero dollar amount of the passed number.</documentation>
+      <input message="tns:NumberToDollarsSoapRequest"/>
+      <output message="tns:NumberToDollarsSoapResponse"/>
+    </operation>
+  </portType>
+  <binding name="NumberConversionSoapBinding" type="tns:NumberConversionSoapType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="NumberToWords">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="NumberToDollars">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+  </binding>
+  <binding name="NumberConversionSoapBinding12" type="tns:NumberConversionSoapType">
+    <soap12:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="NumberToWords">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="NumberToDollars">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+  </binding>
+  <service name="NumberConversion">
+    <documentation>The Number Conversion Web Service, implemented with Visual DataFlex, provides functions that convert numbers into words or dollar amounts.</documentation>
+    <port name="NumberConversionSoap" binding="tns:NumberConversionSoapBinding">
+      <soap:address location="https://www.dataaccess.com/webservicesserver/NumberConversion.wso"/>
+    </port>
+    <port name="NumberConversionSoap12" binding="tns:NumberConversionSoapBinding12">
+      <soap12:address location="https://www.dataaccess.com/webservicesserver/NumberConversion.wso"/>
+    </port>
+  </service>
+</definitions>"
+`;
+
+exports[`component generation tests wsdl - numberconversion should match scaffolding snapshots: numberconversion/jest.config.js 1`] = `
+"module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+};
+"
+`;
+
+exports[`component generation tests wsdl - numberconversion should match scaffolding snapshots: numberconversion/package.json 1`] = `
+"{
+  "name": "numberconversion",
+  "version": "0.0.1",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "build": "webpack",
+    "publish": "npm run build && prism components:publish",
+    "test": "jest",
+    "lint": "eslint --ext .ts ."
+  },
+  "eslintConfig": {
+    "root": true,
+    "extends": ["@prismatic-io/eslint-config-spectral"]
+  },
+  "dependencies": {
+    "@prismatic-io/spectral": "8.0.6",
+    "soap": "0.40.0"
+  },
+  "devDependencies": {
+    "@prismatic-io/eslint-config-spectral": "2.0.1",
+    "@types/jest": "29.5.11",
+    "copy-webpack-plugin": "11.0.0",
+    "eslint": "8.57.0",
+    "jest": "29.7.0",
+    "ts-jest": "29.1.1",
+    "ts-loader": "9.2.3",
+    "typescript": "4.3.5",
+    "webpack": "5.76.3",
+    "webpack-cli": "5.0.1"
+  }
+}
+"
+`;
+
+exports[`component generation tests wsdl - numberconversion should match scaffolding snapshots: numberconversion/tsconfig.json 1`] = `
+"{
+  "compilerOptions": {
+    "target": "es6",
+    "lib": ["esnext"],
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node"
+  },
+  "include": ["src"]
+}
+"
+`;
+
+exports[`component generation tests wsdl - numberconversion should match scaffolding snapshots: numberconversion/numberconversion/client.ts 1`] = `
+"import {
+  Client as SoapClient,
+  createClientAsync as soapCreateClientAsync,
+  IExOptions as ISoapExOptions,
+} from "soap";
+import { NumberToWords } from "./definitions/NumberToWords";
+import { NumberToWordsResponse } from "./definitions/NumberToWordsResponse";
+import { NumberToDollars } from "./definitions/NumberToDollars";
+import { NumberToDollarsResponse } from "./definitions/NumberToDollarsResponse";
+import { NumberConversion } from "./services/NumberConversion";
+
+export interface NumberConversionClient extends SoapClient {
+  NumberConversion: NumberConversion;
+  NumberToWordsAsync(
+    numberToWords: NumberToWords,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: NumberToWordsResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  NumberToDollarsAsync(
+    numberToDollars: NumberToDollars,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: NumberToDollarsResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  NumberToWordsAsync(
+    numberToWords: NumberToWords,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: NumberToWordsResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  NumberToDollarsAsync(
+    numberToDollars: NumberToDollars,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: NumberToDollarsResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+}
+
+/** Create NumberConversionClient */
+export function createClientAsync(
+  ...args: Parameters<typeof soapCreateClientAsync>
+): Promise<NumberConversionClient> {
+  return soapCreateClientAsync(args[0], args[1], args[2]) as any;
+}
+"
+`;
+
+exports[`component generation tests wsdl - numberconversion should match scaffolding snapshots: numberconversion/numberconversion/index.ts 1`] = `
+"export { NumberToWords } from "./definitions/NumberToWords";
+export { NumberToWordsResponse } from "./definitions/NumberToWordsResponse";
+export { NumberToDollars } from "./definitions/NumberToDollars";
+export { NumberToDollarsResponse } from "./definitions/NumberToDollarsResponse";
+export { createClientAsync, NumberConversionClient } from "./client";
+export { NumberConversion } from "./services/NumberConversion";
+export { NumberConversionSoap } from "./ports/NumberConversionSoap";
+export { NumberConversionSoap12 } from "./ports/NumberConversionSoap12";
+"
+`;
+
+exports[`component generation tests wsdl - numberconversion should match scaffolding snapshots: numberconversion/numberconversion/definitions/NumberToDollarsResponse.ts 1`] = `
+"/** NumberToDollarsResponse */
+export interface NumberToDollarsResponse {
+  /** xs:string */
+  NumberToDollarsResult?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - numberconversion should match scaffolding snapshots: numberconversion/numberconversion/definitions/NumberToWordsResponse.ts 1`] = `
+"/** NumberToWordsResponse */
+export interface NumberToWordsResponse {
+  /** xs:string */
+  NumberToWordsResult?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - numberconversion should match scaffolding snapshots: numberconversion/numberconversion/definitions/NumberToDollars.ts 1`] = `
+"/** NumberToDollars */
+export interface NumberToDollars {
+  /** xs:decimal */
+  dNum?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - numberconversion should match scaffolding snapshots: numberconversion/numberconversion/definitions/NumberToWords.ts 1`] = `
+"/** NumberToWords */
+export interface NumberToWords {
+  /** xs:unsignedLong */
+  ubiNum?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - numberconversion should match scaffolding snapshots: numberconversion/numberconversion/ports/NumberConversionSoap12.ts 1`] = `
+"import { NumberToWords } from "../definitions/NumberToWords";
+import { NumberToWordsResponse } from "../definitions/NumberToWordsResponse";
+import { NumberToDollars } from "../definitions/NumberToDollars";
+import { NumberToDollarsResponse } from "../definitions/NumberToDollarsResponse";
+
+export interface NumberConversionSoap12 {
+  NumberToWords(
+    numberToWords: NumberToWords,
+    callback: (
+      err: any,
+      result: NumberToWordsResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  NumberToDollars(
+    numberToDollars: NumberToDollars,
+    callback: (
+      err: any,
+      result: NumberToDollarsResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+}
+"
+`;
+
+exports[`component generation tests wsdl - numberconversion should match scaffolding snapshots: numberconversion/numberconversion/ports/NumberConversionSoap.ts 1`] = `
+"import { NumberToWords } from "../definitions/NumberToWords";
+import { NumberToWordsResponse } from "../definitions/NumberToWordsResponse";
+import { NumberToDollars } from "../definitions/NumberToDollars";
+import { NumberToDollarsResponse } from "../definitions/NumberToDollarsResponse";
+
+export interface NumberConversionSoap {
+  NumberToWords(
+    numberToWords: NumberToWords,
+    callback: (
+      err: any,
+      result: NumberToWordsResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  NumberToDollars(
+    numberToDollars: NumberToDollars,
+    callback: (
+      err: any,
+      result: NumberToDollarsResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+}
+"
+`;
+
+exports[`component generation tests wsdl - numberconversion should match scaffolding snapshots: numberconversion/numberconversion/services/NumberConversion.ts 1`] = `
+"import { NumberConversionSoap } from "../ports/NumberConversionSoap";
+import { NumberConversionSoap12 } from "../ports/NumberConversionSoap12";
+
+export interface NumberConversion {
+  readonly NumberConversionSoap: NumberConversionSoap;
+  readonly NumberConversionSoap12: NumberConversionSoap12;
+}
+"
+`;
+
+exports[`component generation tests wsdl - numberconversion should match scaffolding snapshots: numberconversion/src/inputs.ts 1`] = `
+"import { input } from "@prismatic-io/spectral";
+export const dNum = input({
+  label: "DNum",
+  type: "data",
+  required: true,
+});
+export const options = input({
+  label: "Options",
+  type: "data",
+  required: true,
+});
+export const ubiNum = input({
+  label: "UbiNum",
+  type: "data",
+  required: true,
+});
+"
+`;
+
+exports[`component generation tests wsdl - numberconversion should match scaffolding snapshots: numberconversion/src/dataSources.ts 1`] = `
+"import { dataSource, input } from "@prismatic-io/spectral";
+import { createClient } from "./client";
+
+const myConnectionField = input({
+  label: "Connection",
+  type: "connection",
+  required: true,
+});
+
+const myInputField = input({
+  label: "My Input",
+  type: "string",
+  required: true,
+});
+
+export const myDataSource = dataSource({
+  display: {
+    label: "My Data Source",
+    description: "This is my data source",
+  },
+  perform: async (context, { connection, myInput }) => {
+    const client = createClient(connection);
+    return {
+      result: await client.call(myInput),
+    };
+  },
+  inputs: {
+    connection: myConnectionField,
+    myInput: myInputField,
+  },
+  dataSourceType: "string",
+});
+
+export default { myDataSource };
+"
+`;
+
+exports[`component generation tests wsdl - numberconversion should match scaffolding snapshots: numberconversion/src/actions.ts 1`] = `
 "import { action } from "@prismatic-io/spectral";
 import * as path from "path";
 import { createClientAsync } from "../numberconversion/index";
@@ -67,30 +1055,50 @@ export default {
 "
 `;
 
-exports[`component generation tests wsdl NumberConversion.wsdl generation should match triggers.ts snapshot: numberconversion-triggers.ts 1`] = `
-"import { trigger } from "@prismatic-io/spectral";
+exports[`component generation tests wsdl - numberconversion should match scaffolding snapshots: numberconversion/src/connections.ts 1`] = `
+"import { connection } from "@prismatic-io/spectral";
 
-export const myTrigger = trigger({
-  display: {
-    label: "My Trigger",
-    description: "This is my trigger",
+export const myConnection = connection({
+  key: "myConnection",
+  label: "My Connection",
+  comments: "This is my connection",
+  inputs: {
+    username: {
+      label: "Username",
+      placeholder: "Username",
+      type: "string",
+      required: true,
+      comments: "Username for my Connection",
+    },
+    password: {
+      label: "Password",
+      placeholder: "Password",
+      type: "password",
+      required: true,
+      comments: "Password for my Connection",
+    },
   },
-  perform: async (context, payload, params) => {
-    console.log("My Trigger params", params);
-    return Promise.resolve({
-      payload,
-    });
-  },
-  inputs: {},
-  synchronousResponseSupport: "valid",
-  scheduleSupport: "valid",
 });
 
-export default { myTrigger };
+export default [myConnection];
 "
 `;
 
-exports[`component generation tests wsdl NumberConversion.wsdl generation should match index.ts snapshot: numberconversion-index.ts 1`] = `
+exports[`component generation tests wsdl - numberconversion should match scaffolding snapshots: numberconversion/src/client.ts 1`] = `
+"import { Connection } from "@prismatic-io/spectral";
+
+export const createClient = (connection: Connection) => {
+  // Create a client using the provided Connection for the
+  // service you're consuming from this Component.
+  return {
+    call: async (name: unknown) =>
+      Promise.resolve(\`Hello, ${name} using connection ${connection.key}\`),
+  };
+};
+"
+`;
+
+exports[`component generation tests wsdl - numberconversion should match scaffolding snapshots: numberconversion/src/index.ts 1`] = `
 "import { component } from "@prismatic-io/spectral";
 import actions from "./actions";
 import triggers from "./triggers";
@@ -113,27 +1121,3448 @@ export default component({
 "
 `;
 
-exports[`component generation tests wsdl NumberConversion.wsdl generation should match inputs.ts snapshot: numberconversion-inputs.ts 1`] = `
-"import { input } from "@prismatic-io/spectral";
-export const dNum = input({
-  label: "DNum",
-  type: "data",
-  required: true,
+exports[`component generation tests wsdl - numberconversion should match scaffolding snapshots: numberconversion/src/triggers.ts 1`] = `
+"import { trigger } from "@prismatic-io/spectral";
+
+export const myTrigger = trigger({
+  display: {
+    label: "My Trigger",
+    description: "This is my trigger",
+  },
+  perform: async (context, payload, params) => {
+    console.log("My Trigger params", params);
+    return Promise.resolve({
+      payload,
+    });
+  },
+  inputs: {},
+  synchronousResponseSupport: "valid",
+  scheduleSupport: "valid",
 });
+
+export default { myTrigger };
+"
+`;
+
+exports[`component generation tests openApi - petstore-expanded-uuid-paths should match scaffolding snapshots: petstore-expanded-uuid-paths/jest.config.js 1`] = `
+"module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+};
+"
+`;
+
+exports[`component generation tests openApi - petstore-expanded-uuid-paths should match scaffolding snapshots: petstore-expanded-uuid-paths/petstoreExpandedUuidPaths-openapi-spec.json 1`] = `
+"{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team",
+      "email": "apiteam@swagger.io",
+      "url": "http://swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://petstore.swagger.io/v2"
+    }
+  ],
+  "paths": {
+    "/82dbb5d5-b5fb-47ea-b3dc-1748750470e2": {
+      "get": {
+        "description": "Returns all pets from the system that the user has access to\nNam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.\n\nSed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.\n",
+        "operationId": "findPets",
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "tags to filter by",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new pet in the store. Duplicates are allowed",
+        "operationId": "addPet",
+        "requestBody": {
+          "description": "Pet to add to the store",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewPet"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/82dbb5d5-b5fb-47ea-b3dc-1748750470e2/{id}": {
+      "get": {
+        "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId": "find pet by id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to fetch",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "deletes a single pet based on the ID supplied",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to delete",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pet deleted"
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NewPet"
+          },
+          {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          }
+        ]
+      },
+      "NewPet": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}
+"
+`;
+
+exports[`component generation tests openApi - petstore-expanded-uuid-paths should match scaffolding snapshots: petstore-expanded-uuid-paths/package.json 1`] = `
+"{
+  "name": "petstoreExpandedUuidPaths",
+  "private": true,
+  "version": "0.0.1",
+  "scripts": {
+    "build": "webpack",
+    "test": "jest --runInBand",
+    "lint": "eslint --quiet --ext .ts .",
+    "lint-fix": "eslint --quiet --ext .ts --fix .",
+    "format": "npm run lint-fix && prettier --log-level error --write ."
+  },
+  "eslintConfig": {
+    "root": true,
+    "extends": ["@prismatic-io/eslint-config-spectral"]
+  },
+  "dependencies": {
+    "@prismatic-io/spectral": "8.0.6"
+  },
+  "devDependencies": {
+    "@prismatic-io/eslint-config-spectral": "2.0.1",
+    "@types/jest": "25.2.3",
+    "copy-webpack-plugin": "10.2.4",
+    "jest": "26.6.3",
+    "ts-jest": "26.4.0",
+    "ts-loader": "9.3.0",
+    "typescript": "4.6.3",
+    "webpack": "5.72.0",
+    "webpack-cli": "4.9.2",
+    "prettier": "3.0.3"
+  }
+}
+"
+`;
+
+exports[`component generation tests openApi - petstore-expanded-uuid-paths should match scaffolding snapshots: petstore-expanded-uuid-paths/tsconfig.json 1`] = `
+"{
+  "compilerOptions": {
+    "target": "es6",
+    "lib": ["esnext"],
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node"
+  },
+  "include": ["src"]
+}
+"
+`;
+
+exports[`component generation tests openApi - petstore-expanded-uuid-paths should match scaffolding snapshots: petstore-expanded-uuid-paths/src/connections.ts 1`] = `
+"import "@prismatic-io/spectral";
+
+export default [];
+"
+`;
+
+exports[`component generation tests openApi - petstore-expanded-uuid-paths should match scaffolding snapshots: petstore-expanded-uuid-paths/src/client.ts 1`] = `
+"import { Connection, ConnectionError, util } from "@prismatic-io/spectral";
+import { HttpClient, createClient as createHttpClient } from "@prismatic-io/spectral/dist/clients/http";
+import {  } from "./connections.js";
+
+export const baseUrl = "https://petstore.swagger.io/v2";
+
+const toAuthorizationHeaders = (connection: Connection): { Authorization: string } => {
+const accessToken = util.types.toString(connection.token?.access_token);
+if (accessToken) {
+return { Authorization: \`Bearer ${accessToken}\` };
+}
+
+const apiKey = util.types.toString(connection.fields?.apiKey);
+if (apiKey) {
+return { Authorization: \`Bearer ${apiKey}\` };
+}
+
+const username = util.types.toString(connection.fields?.username);
+const password = util.types.toString(connection.fields?.password);
+if (username && password) {
+const encoded = Buffer.from(\`${username}:${password}\`).toString("base64");
+return { Authorization: \`Basic ${encoded}\` };
+}
+
+throw new Error(
+\`Failed to guess at authorization parameters for Connection: ${connection.key}\`
+);
+};
+
+export const createClient = (connection: Connection): HttpClient => {
+if (![].includes(connection.key)) {
+throw new ConnectionError(connection, \`Received unexpected connection type: ${connection.key}\`);
+}
+
+const client = createHttpClient({
+baseUrl,
+headers: {
+...toAuthorizationHeaders(connection),
+Accept: "application/json",
+},
+responseType: "json",
+});
+return client;
+};
+"
+`;
+
+exports[`component generation tests openApi - petstore-expanded-uuid-paths should match scaffolding snapshots: petstore-expanded-uuid-paths/src/actions/a82Dbb5D5B5Fb47EaB3Dc1748750470E2.ts 1`] = `
+"import { action, input, util } from "@prismatic-io/spectral";
+import { createClient } from "../client";
+
+const 
+
+    findPets = action({
+        display: {
+            label: "Find Pets",
+            description: "Returns all pets from the system that the user has access to",
+        }
+        ,perform: 
+        async (context, { connection, tags, limit }) => {
+
+        const client = createClient(connection);
+        const {data} = await client.get(\`/82dbb5d5-b5fb-47ea-b3dc-1748750470e2\`, { params: { tags, limit } });
+        return {data};
+        }
+        ,inputs: {
+            connection: input({
+            label: "Connection",
+            type: "connection",
+            required: true,
+            }),
+            tags: input({
+            label: "Tags",
+            type: "string",
+            required: false,
+            clean: (value): string | undefined => util.types.toString(value) || undefined,
+            comments: "tags to filter by",
+            }),
+            limit: input({
+            label: "Limit",
+            type: "string",
+            required: false,
+            clean: (value): number => util.types.toNumber(value),
+            comments: "maximum number of results to return",
+            }),
+        }
+        ,
+        })
+
+    ;
+const 
+
+    addPet = action({
+        display: {
+            label: "Add Pet",
+            description: "Creates a new pet in the store",
+        }
+        ,perform: 
+        async (context, { connection, name, tag }) => {
+
+        const client = createClient(connection);
+        const {data} = await client.post(\`/82dbb5d5-b5fb-47ea-b3dc-1748750470e2\`, { name,tag });
+        return {data};
+        }
+        ,inputs: {
+            connection: input({
+            label: "Connection",
+            type: "connection",
+            required: true,
+            }),
+            name: input({
+            label: "Name",
+            type: "string",
+            required: true,
+            clean: (value): string | undefined => util.types.toString(value) || undefined,
+            }),
+            tag: input({
+            label: "Tag",
+            type: "string",
+            required: false,
+            clean: (value): string | undefined => util.types.toString(value) || undefined,
+            }),
+        }
+        ,
+        })
+
+    ;
+const 
+
+    findPetById = action({
+        display: {
+            label: "Find Pet By Id",
+            description: "Returns a user based on a single ID, if the user does not have access to the pet",
+        }
+        ,perform: 
+        async (context, { connection, id }) => {
+
+        const client = createClient(connection);
+        const {data} = await client.get(\`/82dbb5d5-b5fb-47ea-b3dc-1748750470e2/${id}\`);
+        return {data};
+        }
+        ,inputs: {
+            connection: input({
+            label: "Connection",
+            type: "connection",
+            required: true,
+            }),
+            id: input({
+            label: "Id",
+            type: "string",
+            required: true,
+            clean: (value): number => util.types.toNumber(value),
+            comments: "ID of pet to fetch",
+            }),
+        }
+        ,
+        })
+
+    ;
+const 
+
+    deletePet = action({
+        display: {
+            label: "Delete Pet",
+            description: "deletes a single pet based on the ID supplied",
+        }
+        ,perform: 
+        async (context, { connection, id }) => {
+
+        const client = createClient(connection);
+        const {data} = await client.delete(\`/82dbb5d5-b5fb-47ea-b3dc-1748750470e2/${id}\`);
+        return {data};
+        }
+        ,inputs: {
+            connection: input({
+            label: "Connection",
+            type: "connection",
+            required: true,
+            }),
+            id: input({
+            label: "Id",
+            type: "string",
+            required: true,
+            clean: (value): number => util.types.toNumber(value),
+            comments: "ID of pet to delete",
+            }),
+        }
+        ,
+        })
+
+    ;
+
+export default {
+        findPets,
+        addPet,
+        findPetById,
+        deletePet,
+    };
+"
+`;
+
+exports[`component generation tests openApi - petstore-expanded-uuid-paths should match scaffolding snapshots: petstore-expanded-uuid-paths/src/actions/index.ts 1`] = `
+"import { buildRawRequestAction } from "@prismatic-io/spectral/dist/clients/http";
+import { baseUrl } from "../client";
+import a82Dbb5D5B5Fb47EaB3Dc1748750470E2 from "./a82Dbb5D5B5Fb47EaB3Dc1748750470E2";
+
+export default {
+        ...a82Dbb5D5B5Fb47EaB3Dc1748750470E2,
+        rawRequest: buildRawRequestAction(baseUrl),
+    };
+"
+`;
+
+exports[`component generation tests openApi - petstore-expanded-uuid-paths should match scaffolding snapshots: petstore-expanded-uuid-paths/src/index.ts 1`] = `
+"import { component } from "@prismatic-io/spectral";
+import { handleErrors } from "@prismatic-io/spectral/dist/clients/http";
+import actions from "./actions";
+import connections from "./connections";
+
+export default component({
+    key: "petstoreExpandedUuidPaths",
+    display: {
+    label: "Swagger Petstore",
+    description: "A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3",
+    iconPath: "icon.png",
+    },
+    hooks: { error: handleErrors },
+    actions,
+    connections,
+    })
+;
+"
+`;
+
+exports[`component generation tests openApi - petstore-expanded-uuid-paths should match scaffolding snapshots: petstore-expanded-uuid-paths/src/component.test.ts 1`] = `
+"import { testing } from "@prismatic-io/spectral";
+import component from ".";
+
+describe("petstoreExpandedUuidPaths", () => {
+const harness = testing.createHarness(component);
+
+it("should invoke action", async () => {
+const result = await harness.action("findPets", 
+{
+    tags: undefined,
+    limit: undefined,
+}
+);
+expect(result?.data).toBeDefined();
+});
+});
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/jest.config.js 1`] = `
+"module.exports = {
+  preset: "ts-jest",
+  testEnvironment: "node",
+};
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/client.ts 1`] = `
+"import {
+  Client as SoapClient,
+  createClientAsync as soapCreateClientAsync,
+  IExOptions as ISoapExOptions,
+} from "soap";
+import { ListOfContinentsByName } from "./definitions/ListOfContinentsByName";
+import { ListOfContinentsByNameResponse } from "./definitions/ListOfContinentsByNameResponse";
+import { ListOfContinentsByCode } from "./definitions/ListOfContinentsByCode";
+import { ListOfContinentsByCodeResponse } from "./definitions/ListOfContinentsByCodeResponse";
+import { ListOfCurrenciesByName } from "./definitions/ListOfCurrenciesByName";
+import { ListOfCurrenciesByNameResponse } from "./definitions/ListOfCurrenciesByNameResponse";
+import { ListOfCurrenciesByCode } from "./definitions/ListOfCurrenciesByCode";
+import { ListOfCurrenciesByCodeResponse } from "./definitions/ListOfCurrenciesByCodeResponse";
+import { CurrencyName } from "./definitions/CurrencyName";
+import { CurrencyNameResponse } from "./definitions/CurrencyNameResponse";
+import { ListOfCountryNamesByCode } from "./definitions/ListOfCountryNamesByCode";
+import { ListOfCountryNamesByCodeResponse } from "./definitions/ListOfCountryNamesByCodeResponse";
+import { ListOfCountryNamesByName } from "./definitions/ListOfCountryNamesByName";
+import { ListOfCountryNamesByNameResponse } from "./definitions/ListOfCountryNamesByNameResponse";
+import { ListOfCountryNamesGroupedByContinent } from "./definitions/ListOfCountryNamesGroupedByContinent";
+import { ListOfCountryNamesGroupedByContinentResponse } from "./definitions/ListOfCountryNamesGroupedByContinentResponse";
+import { CountryName } from "./definitions/CountryName";
+import { CountryNameResponse } from "./definitions/CountryNameResponse";
+import { CountryIsoCode } from "./definitions/CountryIsoCode";
+import { CountryIsoCodeResponse } from "./definitions/CountryIsoCodeResponse";
+import { CapitalCity } from "./definitions/CapitalCity";
+import { CapitalCityResponse } from "./definitions/CapitalCityResponse";
+import { CountryCurrency } from "./definitions/CountryCurrency";
+import { CountryCurrencyResponse } from "./definitions/CountryCurrencyResponse";
+import { CountryFlag } from "./definitions/CountryFlag";
+import { CountryFlagResponse } from "./definitions/CountryFlagResponse";
+import { CountryIntPhoneCode } from "./definitions/CountryIntPhoneCode";
+import { CountryIntPhoneCodeResponse } from "./definitions/CountryIntPhoneCodeResponse";
+import { FullCountryInfo } from "./definitions/FullCountryInfo";
+import { FullCountryInfoResponse } from "./definitions/FullCountryInfoResponse";
+import { FullCountryInfoAllCountries } from "./definitions/FullCountryInfoAllCountries";
+import { FullCountryInfoAllCountriesResponse } from "./definitions/FullCountryInfoAllCountriesResponse";
+import { CountriesUsingCurrency } from "./definitions/CountriesUsingCurrency";
+import { CountriesUsingCurrencyResponse } from "./definitions/CountriesUsingCurrencyResponse";
+import { ListOfLanguagesByName } from "./definitions/ListOfLanguagesByName";
+import { ListOfLanguagesByNameResponse } from "./definitions/ListOfLanguagesByNameResponse";
+import { ListOfLanguagesByCode } from "./definitions/ListOfLanguagesByCode";
+import { ListOfLanguagesByCodeResponse } from "./definitions/ListOfLanguagesByCodeResponse";
+import { LanguageName } from "./definitions/LanguageName";
+import { LanguageNameResponse } from "./definitions/LanguageNameResponse";
+import { LanguageIsoCode } from "./definitions/LanguageIsoCode";
+import { LanguageIsoCodeResponse } from "./definitions/LanguageIsoCodeResponse";
+import { CountryIsoCode1 } from "./definitions/CountryIsoCode1";
+import { CountryIsoCodeResponse1 } from "./definitions/CountryIsoCodeResponse1";
+import { LanguageIsoCode1 } from "./definitions/LanguageIsoCode1";
+import { LanguageIsoCodeResponse1 } from "./definitions/LanguageIsoCodeResponse1";
+import { CountryInfoService } from "./services/CountryInfoService";
+
+export interface CountryInfoServiceClient extends SoapClient {
+  CountryInfoService: CountryInfoService;
+  ListOfContinentsByNameAsync(
+    listOfContinentsByName: ListOfContinentsByName,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: ListOfContinentsByNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  ListOfContinentsByCodeAsync(
+    listOfContinentsByCode: ListOfContinentsByCode,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: ListOfContinentsByCodeResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  ListOfCurrenciesByNameAsync(
+    listOfCurrenciesByName: ListOfCurrenciesByName,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: ListOfCurrenciesByNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  ListOfCurrenciesByCodeAsync(
+    listOfCurrenciesByCode: ListOfCurrenciesByCode,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: ListOfCurrenciesByCodeResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  CurrencyNameAsync(
+    currencyName: CurrencyName,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: CurrencyNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  ListOfCountryNamesByCodeAsync(
+    listOfCountryNamesByCode: ListOfCountryNamesByCode,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: ListOfCountryNamesByCodeResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  ListOfCountryNamesByNameAsync(
+    listOfCountryNamesByName: ListOfCountryNamesByName,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: ListOfCountryNamesByNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  ListOfCountryNamesGroupedByContinentAsync(
+    listOfCountryNamesGroupedByContinent: ListOfCountryNamesGroupedByContinent,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: ListOfCountryNamesGroupedByContinentResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  CountryNameAsync(
+    countryName: CountryName,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: CountryNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  CountryISOCodeAsync(
+    countryIsoCode: CountryIsoCode,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: CountryIsoCodeResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  CapitalCityAsync(
+    capitalCity: CapitalCity,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: CapitalCityResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  CountryCurrencyAsync(
+    countryCurrency: CountryCurrency,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: CountryCurrencyResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  CountryFlagAsync(
+    countryFlag: CountryFlag,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: CountryFlagResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  CountryIntPhoneCodeAsync(
+    countryIntPhoneCode: CountryIntPhoneCode,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: CountryIntPhoneCodeResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  FullCountryInfoAsync(
+    fullCountryInfo: FullCountryInfo,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: FullCountryInfoResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  FullCountryInfoAllCountriesAsync(
+    fullCountryInfoAllCountries: FullCountryInfoAllCountries,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: FullCountryInfoAllCountriesResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  CountriesUsingCurrencyAsync(
+    countriesUsingCurrency: CountriesUsingCurrency,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: CountriesUsingCurrencyResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  ListOfLanguagesByNameAsync(
+    listOfLanguagesByName: ListOfLanguagesByName,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: ListOfLanguagesByNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  ListOfLanguagesByCodeAsync(
+    listOfLanguagesByCode: ListOfLanguagesByCode,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: ListOfLanguagesByCodeResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  LanguageNameAsync(
+    languageName: LanguageName,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: LanguageNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  LanguageISOCodeAsync(
+    languageIsoCode: LanguageIsoCode,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: LanguageIsoCodeResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  ListOfContinentsByNameAsync(
+    listOfContinentsByName: ListOfContinentsByName,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: ListOfContinentsByNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  ListOfContinentsByCodeAsync(
+    listOfContinentsByCode: ListOfContinentsByCode,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: ListOfContinentsByCodeResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  ListOfCurrenciesByNameAsync(
+    listOfCurrenciesByName: ListOfCurrenciesByName,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: ListOfCurrenciesByNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  ListOfCurrenciesByCodeAsync(
+    listOfCurrenciesByCode: ListOfCurrenciesByCode,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: ListOfCurrenciesByCodeResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  CurrencyNameAsync(
+    currencyName: CurrencyName,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: CurrencyNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  ListOfCountryNamesByCodeAsync(
+    listOfCountryNamesByCode: ListOfCountryNamesByCode,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: ListOfCountryNamesByCodeResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  ListOfCountryNamesByNameAsync(
+    listOfCountryNamesByName: ListOfCountryNamesByName,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: ListOfCountryNamesByNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  ListOfCountryNamesGroupedByContinentAsync(
+    listOfCountryNamesGroupedByContinent: ListOfCountryNamesGroupedByContinent,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: ListOfCountryNamesGroupedByContinentResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  CountryNameAsync(
+    countryName: CountryName,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: CountryNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  CountryISOCodeAsync(
+    countryIsoCode: CountryIsoCode1,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: CountryIsoCodeResponse1,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  CapitalCityAsync(
+    capitalCity: CapitalCity,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: CapitalCityResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  CountryCurrencyAsync(
+    countryCurrency: CountryCurrency,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: CountryCurrencyResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  CountryFlagAsync(
+    countryFlag: CountryFlag,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: CountryFlagResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  CountryIntPhoneCodeAsync(
+    countryIntPhoneCode: CountryIntPhoneCode,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: CountryIntPhoneCodeResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  FullCountryInfoAsync(
+    fullCountryInfo: FullCountryInfo,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: FullCountryInfoResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  FullCountryInfoAllCountriesAsync(
+    fullCountryInfoAllCountries: FullCountryInfoAllCountries,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: FullCountryInfoAllCountriesResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  CountriesUsingCurrencyAsync(
+    countriesUsingCurrency: CountriesUsingCurrency,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: CountriesUsingCurrencyResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  ListOfLanguagesByNameAsync(
+    listOfLanguagesByName: ListOfLanguagesByName,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: ListOfLanguagesByNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  ListOfLanguagesByCodeAsync(
+    listOfLanguagesByCode: ListOfLanguagesByCode,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: ListOfLanguagesByCodeResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  LanguageNameAsync(
+    languageName: LanguageName,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: LanguageNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+  LanguageISOCodeAsync(
+    languageIsoCode: LanguageIsoCode1,
+    options?: ISoapExOptions,
+  ): Promise<
+    [
+      result: LanguageIsoCodeResponse1,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ]
+  >;
+}
+
+/** Create CountryInfoServiceClient */
+export function createClientAsync(
+  ...args: Parameters<typeof soapCreateClientAsync>
+): Promise<CountryInfoServiceClient> {
+  return soapCreateClientAsync(args[0], args[1], args[2]) as any;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/index.ts 1`] = `
+"export { ListOfContinentsByName } from "./definitions/ListOfContinentsByName";
+export { ListOfContinentsByNameResponse } from "./definitions/ListOfContinentsByNameResponse";
+export { ListOfContinentsByNameResult } from "./definitions/ListOfContinentsByNameResult";
+export { TContinent } from "./definitions/TContinent";
+export { ListOfContinentsByCode } from "./definitions/ListOfContinentsByCode";
+export { ListOfContinentsByCodeResponse } from "./definitions/ListOfContinentsByCodeResponse";
+export { ListOfCurrenciesByName } from "./definitions/ListOfCurrenciesByName";
+export { ListOfCurrenciesByNameResponse } from "./definitions/ListOfCurrenciesByNameResponse";
+export { ListOfCurrenciesByNameResult } from "./definitions/ListOfCurrenciesByNameResult";
+export { TCurrency } from "./definitions/TCurrency";
+export { ListOfCurrenciesByCode } from "./definitions/ListOfCurrenciesByCode";
+export { ListOfCurrenciesByCodeResponse } from "./definitions/ListOfCurrenciesByCodeResponse";
+export { CurrencyName } from "./definitions/CurrencyName";
+export { CurrencyNameResponse } from "./definitions/CurrencyNameResponse";
+export { ListOfCountryNamesByCode } from "./definitions/ListOfCountryNamesByCode";
+export { ListOfCountryNamesByCodeResponse } from "./definitions/ListOfCountryNamesByCodeResponse";
+export { ListOfCountryNamesByCodeResult } from "./definitions/ListOfCountryNamesByCodeResult";
+export { TCountryCodeAndName } from "./definitions/TCountryCodeAndName";
+export { ListOfCountryNamesByName } from "./definitions/ListOfCountryNamesByName";
+export { ListOfCountryNamesByNameResponse } from "./definitions/ListOfCountryNamesByNameResponse";
+export { ListOfCountryNamesGroupedByContinent } from "./definitions/ListOfCountryNamesGroupedByContinent";
+export { ListOfCountryNamesGroupedByContinentResponse } from "./definitions/ListOfCountryNamesGroupedByContinentResponse";
+export { ListOfCountryNamesGroupedByContinentResult } from "./definitions/ListOfCountryNamesGroupedByContinentResult";
+export { TCountryCodeAndNameGroupedByContinent } from "./definitions/TCountryCodeAndNameGroupedByContinent";
+export { CountryName } from "./definitions/CountryName";
+export { CountryNameResponse } from "./definitions/CountryNameResponse";
+export { CountryIsoCode } from "./definitions/CountryIsoCode";
+export { CountryIsoCodeResponse } from "./definitions/CountryIsoCodeResponse";
+export { CapitalCity } from "./definitions/CapitalCity";
+export { CapitalCityResponse } from "./definitions/CapitalCityResponse";
+export { CountryCurrency } from "./definitions/CountryCurrency";
+export { CountryCurrencyResponse } from "./definitions/CountryCurrencyResponse";
+export { CountryFlag } from "./definitions/CountryFlag";
+export { CountryFlagResponse } from "./definitions/CountryFlagResponse";
+export { CountryIntPhoneCode } from "./definitions/CountryIntPhoneCode";
+export { CountryIntPhoneCodeResponse } from "./definitions/CountryIntPhoneCodeResponse";
+export { FullCountryInfo } from "./definitions/FullCountryInfo";
+export { FullCountryInfoResponse } from "./definitions/FullCountryInfoResponse";
+export { FullCountryInfoResult } from "./definitions/FullCountryInfoResult";
+export { Languages } from "./definitions/Languages";
+export { TLanguage } from "./definitions/TLanguage";
+export { FullCountryInfoAllCountries } from "./definitions/FullCountryInfoAllCountries";
+export { FullCountryInfoAllCountriesResponse } from "./definitions/FullCountryInfoAllCountriesResponse";
+export { FullCountryInfoAllCountriesResult } from "./definitions/FullCountryInfoAllCountriesResult";
+export { CountriesUsingCurrency } from "./definitions/CountriesUsingCurrency";
+export { CountriesUsingCurrencyResponse } from "./definitions/CountriesUsingCurrencyResponse";
+export { ListOfLanguagesByName } from "./definitions/ListOfLanguagesByName";
+export { ListOfLanguagesByNameResponse } from "./definitions/ListOfLanguagesByNameResponse";
+export { ListOfLanguagesByCode } from "./definitions/ListOfLanguagesByCode";
+export { ListOfLanguagesByCodeResponse } from "./definitions/ListOfLanguagesByCodeResponse";
+export { LanguageName } from "./definitions/LanguageName";
+export { LanguageNameResponse } from "./definitions/LanguageNameResponse";
+export { LanguageIsoCode } from "./definitions/LanguageIsoCode";
+export { LanguageIsoCodeResponse } from "./definitions/LanguageIsoCodeResponse";
+export { CountryIsoCode1 } from "./definitions/CountryIsoCode1";
+export { CountryIsoCodeResponse1 } from "./definitions/CountryIsoCodeResponse1";
+export { LanguageIsoCode1 } from "./definitions/LanguageIsoCode1";
+export { LanguageIsoCodeResponse1 } from "./definitions/LanguageIsoCodeResponse1";
+export { createClientAsync, CountryInfoServiceClient } from "./client";
+export { CountryInfoService } from "./services/CountryInfoService";
+export { CountryInfoServiceSoap } from "./ports/CountryInfoServiceSoap";
+export { CountryInfoServiceSoap12 } from "./ports/CountryInfoServiceSoap12";
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/ListOfContinentsByCode.ts 1`] = `
+"/** ListOfContinentsByCode */
+export interface ListOfContinentsByCode {}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/LanguageNameResponse.ts 1`] = `
+"/** LanguageNameResponse */
+export interface LanguageNameResponse {
+  /** xs:string */
+  LanguageNameResult?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/ListOfCountryNamesByName.ts 1`] = `
+"/** ListOfCountryNamesByName */
+export interface ListOfCountryNamesByName {}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/ListOfLanguagesByCode.ts 1`] = `
+"/** ListOfLanguagesByCode */
+export interface ListOfLanguagesByCode {}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/CountryFlag.ts 1`] = `
+"/** CountryFlag */
+export interface CountryFlag {
+  /** xs:string */
+  sCountryISOCode?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/TCountryCodeAndNameGroupedByContinent.ts 1`] = `
+"import { TContinent } from "./TContinent";
+import { ListOfCountryNamesByCodeResult } from "./ListOfCountryNamesByCodeResult";
+
+/**
+ * tCountryCodeAndNameGroupedByContinent
+ * @targetNSAlias \`tns\`
+ * @targetNamespace \`http://www.oorsprong.org/websamples.countryinfo\`
+ */
+export interface TCountryCodeAndNameGroupedByContinent {
+  /** Continent */
+  Continent?: TContinent;
+  /** CountryCodeAndNames */
+  CountryCodeAndNames?: ListOfCountryNamesByCodeResult;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/Languages.ts 1`] = `
+"import { TLanguage } from "./TLanguage";
+
+/**
+ * Languages
+ * @targetNSAlias \`tns\`
+ * @targetNamespace \`http://www.oorsprong.org/websamples.countryinfo\`
+ */
+export interface Languages {
+  /** tLanguage[] */
+  tLanguage?: Array<TLanguage>;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/CountryIsoCodeResponse1.ts 1`] = `
+"/** CountryISOCodeResponse */
+export interface CountryIsoCodeResponse1 {
+  /** xs:string */
+  CountryISOCodeResult?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/FullCountryInfoAllCountriesResponse.ts 1`] = `
+"import { FullCountryInfoAllCountriesResult } from "./FullCountryInfoAllCountriesResult";
+
+/** FullCountryInfoAllCountriesResponse */
+export interface FullCountryInfoAllCountriesResponse {
+  /** FullCountryInfoAllCountriesResult */
+  FullCountryInfoAllCountriesResult?: FullCountryInfoAllCountriesResult;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/TContinent.ts 1`] = `
+"/**
+ * tContinent
+ * @targetNSAlias \`tns\`
+ * @targetNamespace \`http://www.oorsprong.org/websamples.countryinfo\`
+ */
+export interface TContinent {
+  /** xs:string */
+  sCode?: string;
+  /** xs:string */
+  sName?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/ListOfContinentsByNameResult.ts 1`] = `
+"import { TContinent } from "./TContinent";
+
+/**
+ * ListOfContinentsByNameResult
+ * @targetNSAlias \`tns\`
+ * @targetNamespace \`http://www.oorsprong.org/websamples.countryinfo\`
+ */
+export interface ListOfContinentsByNameResult {
+  /** tContinent[] */
+  tContinent?: Array<TContinent>;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/FullCountryInfoResult.ts 1`] = `
+"import { Languages } from "./Languages";
+
+/**
+ * FullCountryInfoResult
+ * @targetNSAlias \`tns\`
+ * @targetNamespace \`http://www.oorsprong.org/websamples.countryinfo\`
+ */
+export interface FullCountryInfoResult {
+  /** xs:string */
+  sISOCode?: string;
+  /** xs:string */
+  sName?: string;
+  /** xs:string */
+  sCapitalCity?: string;
+  /** xs:string */
+  sPhoneCode?: string;
+  /** xs:string */
+  sContinentCode?: string;
+  /** xs:string */
+  sCurrencyISOCode?: string;
+  /** xs:string */
+  sCountryFlag?: string;
+  /** Languages */
+  Languages?: Languages;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/CountryIntPhoneCodeResponse.ts 1`] = `
+"/** CountryIntPhoneCodeResponse */
+export interface CountryIntPhoneCodeResponse {
+  /** xs:string */
+  CountryIntPhoneCodeResult?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/ListOfCurrenciesByCode.ts 1`] = `
+"/** ListOfCurrenciesByCode */
+export interface ListOfCurrenciesByCode {}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/CountryIsoCodeResponse.ts 1`] = `
+"/** CountryISOCodeResponse */
+export interface CountryIsoCodeResponse {
+  /** xs:string */
+  CountryISOCodeResult?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/ListOfCountryNamesGroupedByContinentResult.ts 1`] = `
+"import { TCountryCodeAndNameGroupedByContinent } from "./TCountryCodeAndNameGroupedByContinent";
+
+/**
+ * ListOfCountryNamesGroupedByContinentResult
+ * @targetNSAlias \`tns\`
+ * @targetNamespace \`http://www.oorsprong.org/websamples.countryinfo\`
+ */
+export interface ListOfCountryNamesGroupedByContinentResult {
+  /** tCountryCodeAndNameGroupedByContinent[] */
+  tCountryCodeAndNameGroupedByContinent?: Array<TCountryCodeAndNameGroupedByContinent>;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/CountryCurrency.ts 1`] = `
+"/** CountryCurrency */
+export interface CountryCurrency {
+  /** xs:string */
+  sCountryISOCode?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/CountryNameResponse.ts 1`] = `
+"/** CountryNameResponse */
+export interface CountryNameResponse {
+  /** xs:string */
+  CountryNameResult?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/LanguageIsoCodeResponse.ts 1`] = `
+"/** LanguageISOCodeResponse */
+export interface LanguageIsoCodeResponse {
+  /** xs:string */
+  LanguageISOCodeResult?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/ListOfContinentsByNameResponse.ts 1`] = `
+"import { ListOfContinentsByNameResult } from "./ListOfContinentsByNameResult";
+
+/** ListOfContinentsByNameResponse */
+export interface ListOfContinentsByNameResponse {
+  /** ListOfContinentsByNameResult */
+  ListOfContinentsByNameResult?: ListOfContinentsByNameResult;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/ListOfLanguagesByCodeResponse.ts 1`] = `
+"import { Languages } from "./Languages";
+
+/** ListOfLanguagesByCodeResponse */
+export interface ListOfLanguagesByCodeResponse {
+  /** ListOfLanguagesByCodeResult */
+  ListOfLanguagesByCodeResult?: Languages;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/CurrencyName.ts 1`] = `
+"/** CurrencyName */
+export interface CurrencyName {
+  /** xs:string */
+  sCurrencyISOCode?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/ListOfCurrenciesByNameResponse.ts 1`] = `
+"import { ListOfCurrenciesByNameResult } from "./ListOfCurrenciesByNameResult";
+
+/** ListOfCurrenciesByNameResponse */
+export interface ListOfCurrenciesByNameResponse {
+  /** ListOfCurrenciesByNameResult */
+  ListOfCurrenciesByNameResult?: ListOfCurrenciesByNameResult;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/FullCountryInfoResponse.ts 1`] = `
+"import { FullCountryInfoResult } from "./FullCountryInfoResult";
+
+/** FullCountryInfoResponse */
+export interface FullCountryInfoResponse {
+  /** FullCountryInfoResult */
+  FullCountryInfoResult?: FullCountryInfoResult;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/ListOfCountryNamesByCodeResponse.ts 1`] = `
+"import { ListOfCountryNamesByCodeResult } from "./ListOfCountryNamesByCodeResult";
+
+/** ListOfCountryNamesByCodeResponse */
+export interface ListOfCountryNamesByCodeResponse {
+  /** ListOfCountryNamesByCodeResult */
+  ListOfCountryNamesByCodeResult?: ListOfCountryNamesByCodeResult;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/CapitalCityResponse.ts 1`] = `
+"/** CapitalCityResponse */
+export interface CapitalCityResponse {
+  /** xs:string */
+  CapitalCityResult?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/FullCountryInfoAllCountriesResult.ts 1`] = `
+"import { FullCountryInfoResult } from "./FullCountryInfoResult";
+
+/**
+ * FullCountryInfoAllCountriesResult
+ * @targetNSAlias \`tns\`
+ * @targetNamespace \`http://www.oorsprong.org/websamples.countryinfo\`
+ */
+export interface FullCountryInfoAllCountriesResult {
+  /** tCountryInfo[] */
+  tCountryInfo?: Array<FullCountryInfoResult>;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/CapitalCity.ts 1`] = `
+"/** CapitalCity */
+export interface CapitalCity {
+  /** xs:string */
+  sCountryISOCode?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/TCurrency.ts 1`] = `
+"/**
+ * tCurrency
+ * @targetNSAlias \`tns\`
+ * @targetNamespace \`http://www.oorsprong.org/websamples.countryinfo\`
+ */
+export interface TCurrency {
+  /** xs:string */
+  sISOCode?: string;
+  /** xs:string */
+  sName?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/ListOfLanguagesByNameResponse.ts 1`] = `
+"import { Languages } from "./Languages";
+
+/** ListOfLanguagesByNameResponse */
+export interface ListOfLanguagesByNameResponse {
+  /** ListOfLanguagesByNameResult */
+  ListOfLanguagesByNameResult?: Languages;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/CurrencyNameResponse.ts 1`] = `
+"/** CurrencyNameResponse */
+export interface CurrencyNameResponse {
+  /** xs:string */
+  CurrencyNameResult?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/ListOfCurrenciesByCodeResponse.ts 1`] = `
+"import { ListOfCurrenciesByNameResult } from "./ListOfCurrenciesByNameResult";
+
+/** ListOfCurrenciesByCodeResponse */
+export interface ListOfCurrenciesByCodeResponse {
+  /** ListOfCurrenciesByCodeResult */
+  ListOfCurrenciesByCodeResult?: ListOfCurrenciesByNameResult;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/ListOfCurrenciesByName.ts 1`] = `
+"/** ListOfCurrenciesByName */
+export interface ListOfCurrenciesByName {}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/LanguageName.ts 1`] = `
+"/** LanguageName */
+export interface LanguageName {
+  /** xs:string */
+  sISOCode?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/CountryIntPhoneCode.ts 1`] = `
+"/** CountryIntPhoneCode */
+export interface CountryIntPhoneCode {
+  /** xs:string */
+  sCountryISOCode?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/ListOfCountryNamesByNameResponse.ts 1`] = `
+"import { ListOfCountryNamesByCodeResult } from "./ListOfCountryNamesByCodeResult";
+
+/** ListOfCountryNamesByNameResponse */
+export interface ListOfCountryNamesByNameResponse {
+  /** ListOfCountryNamesByNameResult */
+  ListOfCountryNamesByNameResult?: ListOfCountryNamesByCodeResult;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/ListOfCountryNamesGroupedByContinentResponse.ts 1`] = `
+"import { ListOfCountryNamesGroupedByContinentResult } from "./ListOfCountryNamesGroupedByContinentResult";
+
+/** ListOfCountryNamesGroupedByContinentResponse */
+export interface ListOfCountryNamesGroupedByContinentResponse {
+  /** ListOfCountryNamesGroupedByContinentResult */
+  ListOfCountryNamesGroupedByContinentResult?: ListOfCountryNamesGroupedByContinentResult;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/CountryCurrencyResponse.ts 1`] = `
+"import { TCurrency } from "./TCurrency";
+
+/** CountryCurrencyResponse */
+export interface CountryCurrencyResponse {
+  /** CountryCurrencyResult */
+  CountryCurrencyResult?: TCurrency;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/CountriesUsingCurrencyResponse.ts 1`] = `
+"import { ListOfCountryNamesByCodeResult } from "./ListOfCountryNamesByCodeResult";
+
+/** CountriesUsingCurrencyResponse */
+export interface CountriesUsingCurrencyResponse {
+  /** CountriesUsingCurrencyResult */
+  CountriesUsingCurrencyResult?: ListOfCountryNamesByCodeResult;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/ListOfLanguagesByName.ts 1`] = `
+"/** ListOfLanguagesByName */
+export interface ListOfLanguagesByName {}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/ListOfCountryNamesByCode.ts 1`] = `
+"/** ListOfCountryNamesByCode */
+export interface ListOfCountryNamesByCode {}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/ListOfContinentsByCodeResponse.ts 1`] = `
+"import { ListOfContinentsByNameResult } from "./ListOfContinentsByNameResult";
+
+/** ListOfContinentsByCodeResponse */
+export interface ListOfContinentsByCodeResponse {
+  /** ListOfContinentsByCodeResult */
+  ListOfContinentsByCodeResult?: ListOfContinentsByNameResult;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/ListOfContinentsByName.ts 1`] = `
+"/** ListOfContinentsByName */
+export interface ListOfContinentsByName {}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/ListOfCountryNamesGroupedByContinent.ts 1`] = `
+"/** ListOfCountryNamesGroupedByContinent */
+export interface ListOfCountryNamesGroupedByContinent {}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/CountryIsoCode1.ts 1`] = `
+"/** CountryISOCode */
+export interface CountryIsoCode1 {
+  /** xs:string */
+  sCountryName?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/LanguageIsoCodeResponse1.ts 1`] = `
+"/** LanguageISOCodeResponse */
+export interface LanguageIsoCodeResponse1 {
+  /** xs:string */
+  LanguageISOCodeResult?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/TCountryCodeAndName.ts 1`] = `
+"/**
+ * tCountryCodeAndName
+ * @targetNSAlias \`tns\`
+ * @targetNamespace \`http://www.oorsprong.org/websamples.countryinfo\`
+ */
+export interface TCountryCodeAndName {
+  /** xs:string */
+  sISOCode?: string;
+  /** xs:string */
+  sName?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/CountryName.ts 1`] = `
+"/** CountryName */
+export interface CountryName {
+  /** xs:string */
+  sCountryISOCode?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/FullCountryInfo.ts 1`] = `
+"/** FullCountryInfo */
+export interface FullCountryInfo {
+  /** xs:string */
+  sCountryISOCode?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/ListOfCountryNamesByCodeResult.ts 1`] = `
+"import { TCountryCodeAndName } from "./TCountryCodeAndName";
+
+/**
+ * ListOfCountryNamesByCodeResult
+ * @targetNSAlias \`tns\`
+ * @targetNamespace \`http://www.oorsprong.org/websamples.countryinfo\`
+ */
+export interface ListOfCountryNamesByCodeResult {
+  /** tCountryCodeAndName[] */
+  tCountryCodeAndName?: Array<TCountryCodeAndName>;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/LanguageIsoCode1.ts 1`] = `
+"/** LanguageISOCode */
+export interface LanguageIsoCode1 {
+  /** xs:string */
+  sLanguageName?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/ListOfCurrenciesByNameResult.ts 1`] = `
+"import { TCurrency } from "./TCurrency";
+
+/**
+ * ListOfCurrenciesByNameResult
+ * @targetNSAlias \`tns\`
+ * @targetNamespace \`http://www.oorsprong.org/websamples.countryinfo\`
+ */
+export interface ListOfCurrenciesByNameResult {
+  /** tCurrency[] */
+  tCurrency?: Array<TCurrency>;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/FullCountryInfoAllCountries.ts 1`] = `
+"/** FullCountryInfoAllCountries */
+export interface FullCountryInfoAllCountries {}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/CountriesUsingCurrency.ts 1`] = `
+"/** CountriesUsingCurrency */
+export interface CountriesUsingCurrency {
+  /** xs:string */
+  sISOCurrencyCode?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/CountryFlagResponse.ts 1`] = `
+"/** CountryFlagResponse */
+export interface CountryFlagResponse {
+  /** xs:string */
+  CountryFlagResult?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/CountryIsoCode.ts 1`] = `
+"/** CountryISOCode */
+export interface CountryIsoCode {
+  /** xs:string */
+  sCountryName?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/TLanguage.ts 1`] = `
+"/**
+ * tLanguage
+ * @targetNSAlias \`tns\`
+ * @targetNamespace \`http://www.oorsprong.org/websamples.countryinfo\`
+ */
+export interface TLanguage {
+  /** xs:string */
+  sISOCode?: string;
+  /** xs:string */
+  sName?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/definitions/LanguageIsoCode.ts 1`] = `
+"/** LanguageISOCode */
+export interface LanguageIsoCode {
+  /** xs:string */
+  sLanguageName?: string;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/ports/CountryInfoServiceSoap.ts 1`] = `
+"import { ListOfContinentsByName } from "../definitions/ListOfContinentsByName";
+import { ListOfContinentsByNameResponse } from "../definitions/ListOfContinentsByNameResponse";
+import { ListOfContinentsByCode } from "../definitions/ListOfContinentsByCode";
+import { ListOfContinentsByCodeResponse } from "../definitions/ListOfContinentsByCodeResponse";
+import { ListOfCurrenciesByName } from "../definitions/ListOfCurrenciesByName";
+import { ListOfCurrenciesByNameResponse } from "../definitions/ListOfCurrenciesByNameResponse";
+import { ListOfCurrenciesByCode } from "../definitions/ListOfCurrenciesByCode";
+import { ListOfCurrenciesByCodeResponse } from "../definitions/ListOfCurrenciesByCodeResponse";
+import { CurrencyName } from "../definitions/CurrencyName";
+import { CurrencyNameResponse } from "../definitions/CurrencyNameResponse";
+import { ListOfCountryNamesByCode } from "../definitions/ListOfCountryNamesByCode";
+import { ListOfCountryNamesByCodeResponse } from "../definitions/ListOfCountryNamesByCodeResponse";
+import { ListOfCountryNamesByName } from "../definitions/ListOfCountryNamesByName";
+import { ListOfCountryNamesByNameResponse } from "../definitions/ListOfCountryNamesByNameResponse";
+import { ListOfCountryNamesGroupedByContinent } from "../definitions/ListOfCountryNamesGroupedByContinent";
+import { ListOfCountryNamesGroupedByContinentResponse } from "../definitions/ListOfCountryNamesGroupedByContinentResponse";
+import { CountryName } from "../definitions/CountryName";
+import { CountryNameResponse } from "../definitions/CountryNameResponse";
+import { CountryIsoCode } from "../definitions/CountryIsoCode";
+import { CountryIsoCodeResponse } from "../definitions/CountryIsoCodeResponse";
+import { CapitalCity } from "../definitions/CapitalCity";
+import { CapitalCityResponse } from "../definitions/CapitalCityResponse";
+import { CountryCurrency } from "../definitions/CountryCurrency";
+import { CountryCurrencyResponse } from "../definitions/CountryCurrencyResponse";
+import { CountryFlag } from "../definitions/CountryFlag";
+import { CountryFlagResponse } from "../definitions/CountryFlagResponse";
+import { CountryIntPhoneCode } from "../definitions/CountryIntPhoneCode";
+import { CountryIntPhoneCodeResponse } from "../definitions/CountryIntPhoneCodeResponse";
+import { FullCountryInfo } from "../definitions/FullCountryInfo";
+import { FullCountryInfoResponse } from "../definitions/FullCountryInfoResponse";
+import { FullCountryInfoAllCountries } from "../definitions/FullCountryInfoAllCountries";
+import { FullCountryInfoAllCountriesResponse } from "../definitions/FullCountryInfoAllCountriesResponse";
+import { CountriesUsingCurrency } from "../definitions/CountriesUsingCurrency";
+import { CountriesUsingCurrencyResponse } from "../definitions/CountriesUsingCurrencyResponse";
+import { ListOfLanguagesByName } from "../definitions/ListOfLanguagesByName";
+import { ListOfLanguagesByNameResponse } from "../definitions/ListOfLanguagesByNameResponse";
+import { ListOfLanguagesByCode } from "../definitions/ListOfLanguagesByCode";
+import { ListOfLanguagesByCodeResponse } from "../definitions/ListOfLanguagesByCodeResponse";
+import { LanguageName } from "../definitions/LanguageName";
+import { LanguageNameResponse } from "../definitions/LanguageNameResponse";
+import { LanguageIsoCode } from "../definitions/LanguageIsoCode";
+import { LanguageIsoCodeResponse } from "../definitions/LanguageIsoCodeResponse";
+
+export interface CountryInfoServiceSoap {
+  ListOfContinentsByName(
+    listOfContinentsByName: ListOfContinentsByName,
+    callback: (
+      err: any,
+      result: ListOfContinentsByNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  ListOfContinentsByCode(
+    listOfContinentsByCode: ListOfContinentsByCode,
+    callback: (
+      err: any,
+      result: ListOfContinentsByCodeResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  ListOfCurrenciesByName(
+    listOfCurrenciesByName: ListOfCurrenciesByName,
+    callback: (
+      err: any,
+      result: ListOfCurrenciesByNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  ListOfCurrenciesByCode(
+    listOfCurrenciesByCode: ListOfCurrenciesByCode,
+    callback: (
+      err: any,
+      result: ListOfCurrenciesByCodeResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  CurrencyName(
+    currencyName: CurrencyName,
+    callback: (
+      err: any,
+      result: CurrencyNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  ListOfCountryNamesByCode(
+    listOfCountryNamesByCode: ListOfCountryNamesByCode,
+    callback: (
+      err: any,
+      result: ListOfCountryNamesByCodeResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  ListOfCountryNamesByName(
+    listOfCountryNamesByName: ListOfCountryNamesByName,
+    callback: (
+      err: any,
+      result: ListOfCountryNamesByNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  ListOfCountryNamesGroupedByContinent(
+    listOfCountryNamesGroupedByContinent: ListOfCountryNamesGroupedByContinent,
+    callback: (
+      err: any,
+      result: ListOfCountryNamesGroupedByContinentResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  CountryName(
+    countryName: CountryName,
+    callback: (
+      err: any,
+      result: CountryNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  CountryISOCode(
+    countryIsoCode: CountryIsoCode,
+    callback: (
+      err: any,
+      result: CountryIsoCodeResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  CapitalCity(
+    capitalCity: CapitalCity,
+    callback: (
+      err: any,
+      result: CapitalCityResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  CountryCurrency(
+    countryCurrency: CountryCurrency,
+    callback: (
+      err: any,
+      result: CountryCurrencyResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  CountryFlag(
+    countryFlag: CountryFlag,
+    callback: (
+      err: any,
+      result: CountryFlagResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  CountryIntPhoneCode(
+    countryIntPhoneCode: CountryIntPhoneCode,
+    callback: (
+      err: any,
+      result: CountryIntPhoneCodeResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  FullCountryInfo(
+    fullCountryInfo: FullCountryInfo,
+    callback: (
+      err: any,
+      result: FullCountryInfoResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  FullCountryInfoAllCountries(
+    fullCountryInfoAllCountries: FullCountryInfoAllCountries,
+    callback: (
+      err: any,
+      result: FullCountryInfoAllCountriesResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  CountriesUsingCurrency(
+    countriesUsingCurrency: CountriesUsingCurrency,
+    callback: (
+      err: any,
+      result: CountriesUsingCurrencyResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  ListOfLanguagesByName(
+    listOfLanguagesByName: ListOfLanguagesByName,
+    callback: (
+      err: any,
+      result: ListOfLanguagesByNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  ListOfLanguagesByCode(
+    listOfLanguagesByCode: ListOfLanguagesByCode,
+    callback: (
+      err: any,
+      result: ListOfLanguagesByCodeResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  LanguageName(
+    languageName: LanguageName,
+    callback: (
+      err: any,
+      result: LanguageNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  LanguageISOCode(
+    languageIsoCode: LanguageIsoCode,
+    callback: (
+      err: any,
+      result: LanguageIsoCodeResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/ports/CountryInfoServiceSoap12.ts 1`] = `
+"import { ListOfContinentsByName } from "../definitions/ListOfContinentsByName";
+import { ListOfContinentsByNameResponse } from "../definitions/ListOfContinentsByNameResponse";
+import { ListOfContinentsByCode } from "../definitions/ListOfContinentsByCode";
+import { ListOfContinentsByCodeResponse } from "../definitions/ListOfContinentsByCodeResponse";
+import { ListOfCurrenciesByName } from "../definitions/ListOfCurrenciesByName";
+import { ListOfCurrenciesByNameResponse } from "../definitions/ListOfCurrenciesByNameResponse";
+import { ListOfCurrenciesByCode } from "../definitions/ListOfCurrenciesByCode";
+import { ListOfCurrenciesByCodeResponse } from "../definitions/ListOfCurrenciesByCodeResponse";
+import { CurrencyName } from "../definitions/CurrencyName";
+import { CurrencyNameResponse } from "../definitions/CurrencyNameResponse";
+import { ListOfCountryNamesByCode } from "../definitions/ListOfCountryNamesByCode";
+import { ListOfCountryNamesByCodeResponse } from "../definitions/ListOfCountryNamesByCodeResponse";
+import { ListOfCountryNamesByName } from "../definitions/ListOfCountryNamesByName";
+import { ListOfCountryNamesByNameResponse } from "../definitions/ListOfCountryNamesByNameResponse";
+import { ListOfCountryNamesGroupedByContinent } from "../definitions/ListOfCountryNamesGroupedByContinent";
+import { ListOfCountryNamesGroupedByContinentResponse } from "../definitions/ListOfCountryNamesGroupedByContinentResponse";
+import { CountryName } from "../definitions/CountryName";
+import { CountryNameResponse } from "../definitions/CountryNameResponse";
+import { CountryIsoCode1 } from "../definitions/CountryIsoCode1";
+import { CountryIsoCodeResponse1 } from "../definitions/CountryIsoCodeResponse1";
+import { CapitalCity } from "../definitions/CapitalCity";
+import { CapitalCityResponse } from "../definitions/CapitalCityResponse";
+import { CountryCurrency } from "../definitions/CountryCurrency";
+import { CountryCurrencyResponse } from "../definitions/CountryCurrencyResponse";
+import { CountryFlag } from "../definitions/CountryFlag";
+import { CountryFlagResponse } from "../definitions/CountryFlagResponse";
+import { CountryIntPhoneCode } from "../definitions/CountryIntPhoneCode";
+import { CountryIntPhoneCodeResponse } from "../definitions/CountryIntPhoneCodeResponse";
+import { FullCountryInfo } from "../definitions/FullCountryInfo";
+import { FullCountryInfoResponse } from "../definitions/FullCountryInfoResponse";
+import { FullCountryInfoAllCountries } from "../definitions/FullCountryInfoAllCountries";
+import { FullCountryInfoAllCountriesResponse } from "../definitions/FullCountryInfoAllCountriesResponse";
+import { CountriesUsingCurrency } from "../definitions/CountriesUsingCurrency";
+import { CountriesUsingCurrencyResponse } from "../definitions/CountriesUsingCurrencyResponse";
+import { ListOfLanguagesByName } from "../definitions/ListOfLanguagesByName";
+import { ListOfLanguagesByNameResponse } from "../definitions/ListOfLanguagesByNameResponse";
+import { ListOfLanguagesByCode } from "../definitions/ListOfLanguagesByCode";
+import { ListOfLanguagesByCodeResponse } from "../definitions/ListOfLanguagesByCodeResponse";
+import { LanguageName } from "../definitions/LanguageName";
+import { LanguageNameResponse } from "../definitions/LanguageNameResponse";
+import { LanguageIsoCode1 } from "../definitions/LanguageIsoCode1";
+import { LanguageIsoCodeResponse1 } from "../definitions/LanguageIsoCodeResponse1";
+
+export interface CountryInfoServiceSoap12 {
+  ListOfContinentsByName(
+    listOfContinentsByName: ListOfContinentsByName,
+    callback: (
+      err: any,
+      result: ListOfContinentsByNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  ListOfContinentsByCode(
+    listOfContinentsByCode: ListOfContinentsByCode,
+    callback: (
+      err: any,
+      result: ListOfContinentsByCodeResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  ListOfCurrenciesByName(
+    listOfCurrenciesByName: ListOfCurrenciesByName,
+    callback: (
+      err: any,
+      result: ListOfCurrenciesByNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  ListOfCurrenciesByCode(
+    listOfCurrenciesByCode: ListOfCurrenciesByCode,
+    callback: (
+      err: any,
+      result: ListOfCurrenciesByCodeResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  CurrencyName(
+    currencyName: CurrencyName,
+    callback: (
+      err: any,
+      result: CurrencyNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  ListOfCountryNamesByCode(
+    listOfCountryNamesByCode: ListOfCountryNamesByCode,
+    callback: (
+      err: any,
+      result: ListOfCountryNamesByCodeResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  ListOfCountryNamesByName(
+    listOfCountryNamesByName: ListOfCountryNamesByName,
+    callback: (
+      err: any,
+      result: ListOfCountryNamesByNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  ListOfCountryNamesGroupedByContinent(
+    listOfCountryNamesGroupedByContinent: ListOfCountryNamesGroupedByContinent,
+    callback: (
+      err: any,
+      result: ListOfCountryNamesGroupedByContinentResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  CountryName(
+    countryName: CountryName,
+    callback: (
+      err: any,
+      result: CountryNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  CountryISOCode(
+    countryIsoCode: CountryIsoCode1,
+    callback: (
+      err: any,
+      result: CountryIsoCodeResponse1,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  CapitalCity(
+    capitalCity: CapitalCity,
+    callback: (
+      err: any,
+      result: CapitalCityResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  CountryCurrency(
+    countryCurrency: CountryCurrency,
+    callback: (
+      err: any,
+      result: CountryCurrencyResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  CountryFlag(
+    countryFlag: CountryFlag,
+    callback: (
+      err: any,
+      result: CountryFlagResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  CountryIntPhoneCode(
+    countryIntPhoneCode: CountryIntPhoneCode,
+    callback: (
+      err: any,
+      result: CountryIntPhoneCodeResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  FullCountryInfo(
+    fullCountryInfo: FullCountryInfo,
+    callback: (
+      err: any,
+      result: FullCountryInfoResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  FullCountryInfoAllCountries(
+    fullCountryInfoAllCountries: FullCountryInfoAllCountries,
+    callback: (
+      err: any,
+      result: FullCountryInfoAllCountriesResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  CountriesUsingCurrency(
+    countriesUsingCurrency: CountriesUsingCurrency,
+    callback: (
+      err: any,
+      result: CountriesUsingCurrencyResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  ListOfLanguagesByName(
+    listOfLanguagesByName: ListOfLanguagesByName,
+    callback: (
+      err: any,
+      result: ListOfLanguagesByNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  ListOfLanguagesByCode(
+    listOfLanguagesByCode: ListOfLanguagesByCode,
+    callback: (
+      err: any,
+      result: ListOfLanguagesByCodeResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  LanguageName(
+    languageName: LanguageName,
+    callback: (
+      err: any,
+      result: LanguageNameResponse,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+  LanguageISOCode(
+    languageIsoCode: LanguageIsoCode1,
+    callback: (
+      err: any,
+      result: LanguageIsoCodeResponse1,
+      rawResponse: any,
+      soapHeader: any,
+      rawRequest: any,
+    ) => void,
+  ): void;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryinfoservice/services/CountryInfoService.ts 1`] = `
+"import { CountryInfoServiceSoap } from "../ports/CountryInfoServiceSoap";
+import { CountryInfoServiceSoap12 } from "../ports/CountryInfoServiceSoap12";
+
+export interface CountryInfoService {
+  readonly CountryInfoServiceSoap: CountryInfoServiceSoap;
+  readonly CountryInfoServiceSoap12: CountryInfoServiceSoap12;
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/package.json 1`] = `
+"{
+  "name": "countryinfoservice",
+  "version": "0.0.1",
+  "main": "index.js",
+  "private": true,
+  "scripts": {
+    "build": "webpack",
+    "publish": "npm run build && prism components:publish",
+    "test": "jest",
+    "lint": "eslint --ext .ts ."
+  },
+  "eslintConfig": {
+    "root": true,
+    "extends": ["@prismatic-io/eslint-config-spectral"]
+  },
+  "dependencies": {
+    "@prismatic-io/spectral": "8.0.6",
+    "soap": "0.40.0"
+  },
+  "devDependencies": {
+    "@prismatic-io/eslint-config-spectral": "2.0.1",
+    "@types/jest": "29.5.11",
+    "copy-webpack-plugin": "11.0.0",
+    "eslint": "8.57.0",
+    "jest": "29.7.0",
+    "ts-jest": "29.1.1",
+    "ts-loader": "9.2.3",
+    "typescript": "4.3.5",
+    "webpack": "5.76.3",
+    "webpack-cli": "5.0.1"
+  }
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/tsconfig.json 1`] = `
+"{
+  "compilerOptions": {
+    "target": "es6",
+    "lib": ["esnext"],
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node"
+  },
+  "include": ["src"]
+}
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/countryInfoService.wsdl 1`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soap12="http://schemas.xmlsoap.org/wsdl/soap12/" xmlns:tns="http://www.oorsprong.org/websamples.countryinfo" name="CountryInfoService" targetNamespace="http://www.oorsprong.org/websamples.countryinfo">
+  <types>
+    <xs:schema elementFormDefault="qualified" targetNamespace="http://www.oorsprong.org/websamples.countryinfo">
+      <xs:complexType name="tContinent">
+        <xs:sequence>
+          <xs:element name="sCode" type="xs:string"/>
+          <xs:element name="sName" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="tCurrency">
+        <xs:sequence>
+          <xs:element name="sISOCode" type="xs:string"/>
+          <xs:element name="sName" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="tCountryCodeAndName">
+        <xs:sequence>
+          <xs:element name="sISOCode" type="xs:string"/>
+          <xs:element name="sName" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="tCountryCodeAndNameGroupedByContinent">
+        <xs:sequence>
+          <xs:element name="Continent" type="tns:tContinent"/>
+          <xs:element name="CountryCodeAndNames" type="tns:ArrayOftCountryCodeAndName"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="tCountryInfo">
+        <xs:sequence>
+          <xs:element name="sISOCode" type="xs:string"/>
+          <xs:element name="sName" type="xs:string"/>
+          <xs:element name="sCapitalCity" type="xs:string"/>
+          <xs:element name="sPhoneCode" type="xs:string"/>
+          <xs:element name="sContinentCode" type="xs:string"/>
+          <xs:element name="sCurrencyISOCode" type="xs:string"/>
+          <xs:element name="sCountryFlag" type="xs:string"/>
+          <xs:element name="Languages" type="tns:ArrayOftLanguage"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="tLanguage">
+        <xs:sequence>
+          <xs:element name="sISOCode" type="xs:string"/>
+          <xs:element name="sName" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="ArrayOftCountryCodeAndName">
+        <xs:sequence>
+          <xs:element name="tCountryCodeAndName" type="tns:tCountryCodeAndName" minOccurs="0" maxOccurs="unbounded" nillable="true"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="ArrayOftLanguage">
+        <xs:sequence>
+          <xs:element name="tLanguage" type="tns:tLanguage" minOccurs="0" maxOccurs="unbounded" nillable="true"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="ArrayOftContinent">
+        <xs:sequence>
+          <xs:element name="tContinent" type="tns:tContinent" minOccurs="0" maxOccurs="unbounded" nillable="true"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="ArrayOftCurrency">
+        <xs:sequence>
+          <xs:element name="tCurrency" type="tns:tCurrency" minOccurs="0" maxOccurs="unbounded" nillable="true"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="ArrayOftCountryCodeAndNameGroupedByContinent">
+        <xs:sequence>
+          <xs:element name="tCountryCodeAndNameGroupedByContinent" type="tns:tCountryCodeAndNameGroupedByContinent" minOccurs="0" maxOccurs="unbounded" nillable="true"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="ArrayOftCountryInfo">
+        <xs:sequence>
+          <xs:element name="tCountryInfo" type="tns:tCountryInfo" minOccurs="0" maxOccurs="unbounded" nillable="true"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:element name="ListOfContinentsByName">
+        <xs:complexType>
+          <xs:sequence/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="ListOfContinentsByNameResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ListOfContinentsByNameResult" type="tns:ArrayOftContinent"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="ListOfContinentsByCode">
+        <xs:complexType>
+          <xs:sequence/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="ListOfContinentsByCodeResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ListOfContinentsByCodeResult" type="tns:ArrayOftContinent"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="ListOfCurrenciesByName">
+        <xs:complexType>
+          <xs:sequence/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="ListOfCurrenciesByNameResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ListOfCurrenciesByNameResult" type="tns:ArrayOftCurrency"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="ListOfCurrenciesByCode">
+        <xs:complexType>
+          <xs:sequence/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="ListOfCurrenciesByCodeResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ListOfCurrenciesByCodeResult" type="tns:ArrayOftCurrency"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="CurrencyName">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="sCurrencyISOCode" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="CurrencyNameResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="CurrencyNameResult" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="ListOfCountryNamesByCode">
+        <xs:complexType>
+          <xs:sequence/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="ListOfCountryNamesByCodeResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ListOfCountryNamesByCodeResult" type="tns:ArrayOftCountryCodeAndName"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="ListOfCountryNamesByName">
+        <xs:complexType>
+          <xs:sequence/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="ListOfCountryNamesByNameResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ListOfCountryNamesByNameResult" type="tns:ArrayOftCountryCodeAndName"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="ListOfCountryNamesGroupedByContinent">
+        <xs:complexType>
+          <xs:sequence/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="ListOfCountryNamesGroupedByContinentResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ListOfCountryNamesGroupedByContinentResult" type="tns:ArrayOftCountryCodeAndNameGroupedByContinent"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="CountryName">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="sCountryISOCode" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="CountryNameResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="CountryNameResult" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="CountryISOCode">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="sCountryName" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="CountryISOCodeResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="CountryISOCodeResult" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="CapitalCity">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="sCountryISOCode" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="CapitalCityResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="CapitalCityResult" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="CountryCurrency">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="sCountryISOCode" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="CountryCurrencyResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="CountryCurrencyResult" type="tns:tCurrency"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="CountryFlag">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="sCountryISOCode" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="CountryFlagResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="CountryFlagResult" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="CountryIntPhoneCode">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="sCountryISOCode" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="CountryIntPhoneCodeResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="CountryIntPhoneCodeResult" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="FullCountryInfo">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="sCountryISOCode" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="FullCountryInfoResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="FullCountryInfoResult" type="tns:tCountryInfo"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="FullCountryInfoAllCountries">
+        <xs:complexType>
+          <xs:sequence/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="FullCountryInfoAllCountriesResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="FullCountryInfoAllCountriesResult" type="tns:ArrayOftCountryInfo"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="CountriesUsingCurrency">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="sISOCurrencyCode" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="CountriesUsingCurrencyResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="CountriesUsingCurrencyResult" type="tns:ArrayOftCountryCodeAndName"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="ListOfLanguagesByName">
+        <xs:complexType>
+          <xs:sequence/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="ListOfLanguagesByNameResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ListOfLanguagesByNameResult" type="tns:ArrayOftLanguage"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="ListOfLanguagesByCode">
+        <xs:complexType>
+          <xs:sequence/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="ListOfLanguagesByCodeResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="ListOfLanguagesByCodeResult" type="tns:ArrayOftLanguage"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="LanguageName">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="sISOCode" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="LanguageNameResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="LanguageNameResult" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="LanguageISOCode">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="sLanguageName" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="LanguageISOCodeResponse">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element name="LanguageISOCodeResult" type="xs:string"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+  </types>
+  <message name="ListOfContinentsByNameSoapRequest">
+    <part name="parameters" element="tns:ListOfContinentsByName"/>
+  </message>
+  <message name="ListOfContinentsByNameSoapResponse">
+    <part name="parameters" element="tns:ListOfContinentsByNameResponse"/>
+  </message>
+  <message name="ListOfContinentsByCodeSoapRequest">
+    <part name="parameters" element="tns:ListOfContinentsByCode"/>
+  </message>
+  <message name="ListOfContinentsByCodeSoapResponse">
+    <part name="parameters" element="tns:ListOfContinentsByCodeResponse"/>
+  </message>
+  <message name="ListOfCurrenciesByNameSoapRequest">
+    <part name="parameters" element="tns:ListOfCurrenciesByName"/>
+  </message>
+  <message name="ListOfCurrenciesByNameSoapResponse">
+    <part name="parameters" element="tns:ListOfCurrenciesByNameResponse"/>
+  </message>
+  <message name="ListOfCurrenciesByCodeSoapRequest">
+    <part name="parameters" element="tns:ListOfCurrenciesByCode"/>
+  </message>
+  <message name="ListOfCurrenciesByCodeSoapResponse">
+    <part name="parameters" element="tns:ListOfCurrenciesByCodeResponse"/>
+  </message>
+  <message name="CurrencyNameSoapRequest">
+    <part name="parameters" element="tns:CurrencyName"/>
+  </message>
+  <message name="CurrencyNameSoapResponse">
+    <part name="parameters" element="tns:CurrencyNameResponse"/>
+  </message>
+  <message name="ListOfCountryNamesByCodeSoapRequest">
+    <part name="parameters" element="tns:ListOfCountryNamesByCode"/>
+  </message>
+  <message name="ListOfCountryNamesByCodeSoapResponse">
+    <part name="parameters" element="tns:ListOfCountryNamesByCodeResponse"/>
+  </message>
+  <message name="ListOfCountryNamesByNameSoapRequest">
+    <part name="parameters" element="tns:ListOfCountryNamesByName"/>
+  </message>
+  <message name="ListOfCountryNamesByNameSoapResponse">
+    <part name="parameters" element="tns:ListOfCountryNamesByNameResponse"/>
+  </message>
+  <message name="ListOfCountryNamesGroupedByContinentSoapRequest">
+    <part name="parameters" element="tns:ListOfCountryNamesGroupedByContinent"/>
+  </message>
+  <message name="ListOfCountryNamesGroupedByContinentSoapResponse">
+    <part name="parameters" element="tns:ListOfCountryNamesGroupedByContinentResponse"/>
+  </message>
+  <message name="CountryNameSoapRequest">
+    <part name="parameters" element="tns:CountryName"/>
+  </message>
+  <message name="CountryNameSoapResponse">
+    <part name="parameters" element="tns:CountryNameResponse"/>
+  </message>
+  <message name="CountryISOCodeSoapRequest">
+    <part name="parameters" element="tns:CountryISOCode"/>
+  </message>
+  <message name="CountryISOCodeSoapResponse">
+    <part name="parameters" element="tns:CountryISOCodeResponse"/>
+  </message>
+  <message name="CapitalCitySoapRequest">
+    <part name="parameters" element="tns:CapitalCity"/>
+  </message>
+  <message name="CapitalCitySoapResponse">
+    <part name="parameters" element="tns:CapitalCityResponse"/>
+  </message>
+  <message name="CountryCurrencySoapRequest">
+    <part name="parameters" element="tns:CountryCurrency"/>
+  </message>
+  <message name="CountryCurrencySoapResponse">
+    <part name="parameters" element="tns:CountryCurrencyResponse"/>
+  </message>
+  <message name="CountryFlagSoapRequest">
+    <part name="parameters" element="tns:CountryFlag"/>
+  </message>
+  <message name="CountryFlagSoapResponse">
+    <part name="parameters" element="tns:CountryFlagResponse"/>
+  </message>
+  <message name="CountryIntPhoneCodeSoapRequest">
+    <part name="parameters" element="tns:CountryIntPhoneCode"/>
+  </message>
+  <message name="CountryIntPhoneCodeSoapResponse">
+    <part name="parameters" element="tns:CountryIntPhoneCodeResponse"/>
+  </message>
+  <message name="FullCountryInfoSoapRequest">
+    <part name="parameters" element="tns:FullCountryInfo"/>
+  </message>
+  <message name="FullCountryInfoSoapResponse">
+    <part name="parameters" element="tns:FullCountryInfoResponse"/>
+  </message>
+  <message name="FullCountryInfoAllCountriesSoapRequest">
+    <part name="parameters" element="tns:FullCountryInfoAllCountries"/>
+  </message>
+  <message name="FullCountryInfoAllCountriesSoapResponse">
+    <part name="parameters" element="tns:FullCountryInfoAllCountriesResponse"/>
+  </message>
+  <message name="CountriesUsingCurrencySoapRequest">
+    <part name="parameters" element="tns:CountriesUsingCurrency"/>
+  </message>
+  <message name="CountriesUsingCurrencySoapResponse">
+    <part name="parameters" element="tns:CountriesUsingCurrencyResponse"/>
+  </message>
+  <message name="ListOfLanguagesByNameSoapRequest">
+    <part name="parameters" element="tns:ListOfLanguagesByName"/>
+  </message>
+  <message name="ListOfLanguagesByNameSoapResponse">
+    <part name="parameters" element="tns:ListOfLanguagesByNameResponse"/>
+  </message>
+  <message name="ListOfLanguagesByCodeSoapRequest">
+    <part name="parameters" element="tns:ListOfLanguagesByCode"/>
+  </message>
+  <message name="ListOfLanguagesByCodeSoapResponse">
+    <part name="parameters" element="tns:ListOfLanguagesByCodeResponse"/>
+  </message>
+  <message name="LanguageNameSoapRequest">
+    <part name="parameters" element="tns:LanguageName"/>
+  </message>
+  <message name="LanguageNameSoapResponse">
+    <part name="parameters" element="tns:LanguageNameResponse"/>
+  </message>
+  <message name="LanguageISOCodeSoapRequest">
+    <part name="parameters" element="tns:LanguageISOCode"/>
+  </message>
+  <message name="LanguageISOCodeSoapResponse">
+    <part name="parameters" element="tns:LanguageISOCodeResponse"/>
+  </message>
+  <portType name="CountryInfoServiceSoapType">
+    <operation name="ListOfContinentsByName">
+      <documentation>Returns a list of continents ordered by name.</documentation>
+      <input message="tns:ListOfContinentsByNameSoapRequest"/>
+      <output message="tns:ListOfContinentsByNameSoapResponse"/>
+    </operation>
+    <operation name="ListOfContinentsByCode">
+      <documentation>Returns a list of continents ordered by code.</documentation>
+      <input message="tns:ListOfContinentsByCodeSoapRequest"/>
+      <output message="tns:ListOfContinentsByCodeSoapResponse"/>
+    </operation>
+    <operation name="ListOfCurrenciesByName">
+      <documentation>Returns a list of currencies ordered by name.</documentation>
+      <input message="tns:ListOfCurrenciesByNameSoapRequest"/>
+      <output message="tns:ListOfCurrenciesByNameSoapResponse"/>
+    </operation>
+    <operation name="ListOfCurrenciesByCode">
+      <documentation>Returns a list of currencies ordered by code.</documentation>
+      <input message="tns:ListOfCurrenciesByCodeSoapRequest"/>
+      <output message="tns:ListOfCurrenciesByCodeSoapResponse"/>
+    </operation>
+    <operation name="CurrencyName">
+      <documentation>Returns the name of the currency (if found)</documentation>
+      <input message="tns:CurrencyNameSoapRequest"/>
+      <output message="tns:CurrencyNameSoapResponse"/>
+    </operation>
+    <operation name="ListOfCountryNamesByCode">
+      <documentation>Returns a list of all stored counties ordered by ISO code</documentation>
+      <input message="tns:ListOfCountryNamesByCodeSoapRequest"/>
+      <output message="tns:ListOfCountryNamesByCodeSoapResponse"/>
+    </operation>
+    <operation name="ListOfCountryNamesByName">
+      <documentation>Returns a list of all stored counties ordered by country name</documentation>
+      <input message="tns:ListOfCountryNamesByNameSoapRequest"/>
+      <output message="tns:ListOfCountryNamesByNameSoapResponse"/>
+    </operation>
+    <operation name="ListOfCountryNamesGroupedByContinent">
+      <documentation>Returns a list of all stored counties grouped per continent</documentation>
+      <input message="tns:ListOfCountryNamesGroupedByContinentSoapRequest"/>
+      <output message="tns:ListOfCountryNamesGroupedByContinentSoapResponse"/>
+    </operation>
+    <operation name="CountryName">
+      <documentation>Searches the database for a country by the passed ISO country code</documentation>
+      <input message="tns:CountryNameSoapRequest"/>
+      <output message="tns:CountryNameSoapResponse"/>
+    </operation>
+    <operation name="CountryISOCode">
+      <documentation>This function tries to found a country based on the passed country name.</documentation>
+      <input message="tns:CountryISOCodeSoapRequest"/>
+      <output message="tns:CountryISOCodeSoapResponse"/>
+    </operation>
+    <operation name="CapitalCity">
+      <documentation>Returns the  name of the captial city for the passed country code</documentation>
+      <input message="tns:CapitalCitySoapRequest"/>
+      <output message="tns:CapitalCitySoapResponse"/>
+    </operation>
+    <operation name="CountryCurrency">
+      <documentation>Returns the currency ISO code and name for the passed country ISO code</documentation>
+      <input message="tns:CountryCurrencySoapRequest"/>
+      <output message="tns:CountryCurrencySoapResponse"/>
+    </operation>
+    <operation name="CountryFlag">
+      <documentation>Returns a link to a picture of the country flag</documentation>
+      <input message="tns:CountryFlagSoapRequest"/>
+      <output message="tns:CountryFlagSoapResponse"/>
+    </operation>
+    <operation name="CountryIntPhoneCode">
+      <documentation>Returns the internation phone code for the passed ISO country code</documentation>
+      <input message="tns:CountryIntPhoneCodeSoapRequest"/>
+      <output message="tns:CountryIntPhoneCodeSoapResponse"/>
+    </operation>
+    <operation name="FullCountryInfo">
+      <documentation>Returns a struct with all the stored country information. Pass the ISO country code</documentation>
+      <input message="tns:FullCountryInfoSoapRequest"/>
+      <output message="tns:FullCountryInfoSoapResponse"/>
+    </operation>
+    <operation name="FullCountryInfoAllCountries">
+      <documentation>Returns an array with all countries and all the language information stored</documentation>
+      <input message="tns:FullCountryInfoAllCountriesSoapRequest"/>
+      <output message="tns:FullCountryInfoAllCountriesSoapResponse"/>
+    </operation>
+    <operation name="CountriesUsingCurrency">
+      <documentation>Returns a list of all countries that use the same currency code. Pass a ISO currency code</documentation>
+      <input message="tns:CountriesUsingCurrencySoapRequest"/>
+      <output message="tns:CountriesUsingCurrencySoapResponse"/>
+    </operation>
+    <operation name="ListOfLanguagesByName">
+      <documentation>Returns an array of languages ordered by name</documentation>
+      <input message="tns:ListOfLanguagesByNameSoapRequest"/>
+      <output message="tns:ListOfLanguagesByNameSoapResponse"/>
+    </operation>
+    <operation name="ListOfLanguagesByCode">
+      <documentation>Returns an array of languages ordered by code</documentation>
+      <input message="tns:ListOfLanguagesByCodeSoapRequest"/>
+      <output message="tns:ListOfLanguagesByCodeSoapResponse"/>
+    </operation>
+    <operation name="LanguageName">
+      <documentation>Find a language name based on the passed ISO language code</documentation>
+      <input message="tns:LanguageNameSoapRequest"/>
+      <output message="tns:LanguageNameSoapResponse"/>
+    </operation>
+    <operation name="LanguageISOCode">
+      <documentation>Find a language ISO code based on the passed language name</documentation>
+      <input message="tns:LanguageISOCodeSoapRequest"/>
+      <output message="tns:LanguageISOCodeSoapResponse"/>
+    </operation>
+  </portType>
+  <binding name="CountryInfoServiceSoapBinding" type="tns:CountryInfoServiceSoapType">
+    <soap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="ListOfContinentsByName">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="ListOfContinentsByCode">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="ListOfCurrenciesByName">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="ListOfCurrenciesByCode">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="CurrencyName">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="ListOfCountryNamesByCode">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="ListOfCountryNamesByName">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="ListOfCountryNamesGroupedByContinent">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="CountryName">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="CountryISOCode">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="CapitalCity">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="CountryCurrency">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="CountryFlag">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="CountryIntPhoneCode">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="FullCountryInfo">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="FullCountryInfoAllCountries">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="CountriesUsingCurrency">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="ListOfLanguagesByName">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="ListOfLanguagesByCode">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="LanguageName">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="LanguageISOCode">
+      <soap:operation soapAction="" style="document"/>
+      <input>
+        <soap:body use="literal"/>
+      </input>
+      <output>
+        <soap:body use="literal"/>
+      </output>
+    </operation>
+  </binding>
+  <binding name="CountryInfoServiceSoapBinding12" type="tns:CountryInfoServiceSoapType">
+    <soap12:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="ListOfContinentsByName">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="ListOfContinentsByCode">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="ListOfCurrenciesByName">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="ListOfCurrenciesByCode">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="CurrencyName">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="ListOfCountryNamesByCode">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="ListOfCountryNamesByName">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="ListOfCountryNamesGroupedByContinent">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="CountryName">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="CountryISOCode">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="CapitalCity">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="CountryCurrency">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="CountryFlag">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="CountryIntPhoneCode">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="FullCountryInfo">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="FullCountryInfoAllCountries">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="CountriesUsingCurrency">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="ListOfLanguagesByName">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="ListOfLanguagesByCode">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="LanguageName">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+    <operation name="LanguageISOCode">
+      <soap12:operation soapAction="" style="document"/>
+      <input>
+        <soap12:body use="literal"/>
+      </input>
+      <output>
+        <soap12:body use="literal"/>
+      </output>
+    </operation>
+  </binding>
+  <service name="CountryInfoService">
+    <documentation>This DataFlex Web Service opens up country information. 2 letter ISO codes are used for Country code. There are functions to retrieve the used Currency, Language, Capital City, Continent and Telephone code.</documentation>
+    <port name="CountryInfoServiceSoap" binding="tns:CountryInfoServiceSoapBinding">
+      <soap:address location="http://webservices.oorsprong.org/websamples.countryinfo/CountryInfoService.wso"/>
+    </port>
+    <port name="CountryInfoServiceSoap12" binding="tns:CountryInfoServiceSoapBinding12">
+      <soap12:address location="http://webservices.oorsprong.org/websamples.countryinfo/CountryInfoService.wso"/>
+    </port>
+  </service>
+</definitions>"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/src/inputs.ts 1`] = `
+"import { input } from "@prismatic-io/spectral";
 export const options = input({
   label: "Options",
   type: "data",
   required: true,
 });
-export const ubiNum = input({
-  label: "UbiNum",
+export const sCountryISOCode = input({
+  label: "SCountryIsoCode",
+  type: "data",
+  required: true,
+});
+export const sCountryName = input({
+  label: "SCountryName",
+  type: "data",
+  required: true,
+});
+export const sCurrencyISOCode = input({
+  label: "SCurrencyIsoCode",
+  type: "data",
+  required: true,
+});
+export const sISOCode = input({
+  label: "SIsoCode",
+  type: "data",
+  required: true,
+});
+export const sISOCurrencyCode = input({
+  label: "SIsoCurrencyCode",
+  type: "data",
+  required: true,
+});
+export const sLanguageName = input({
+  label: "SLanguageName",
   type: "data",
   required: true,
 });
 "
 `;
 
-exports[`component generation tests wsdl CountryInfoService.wsdl generation should match actions.ts snapshot: countryinfoservice-actions.ts 1`] = `
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/src/dataSources.ts 1`] = `
+"import { dataSource, input } from "@prismatic-io/spectral";
+import { createClient } from "./client";
+
+const myConnectionField = input({
+  label: "Connection",
+  type: "connection",
+  required: true,
+});
+
+const myInputField = input({
+  label: "My Input",
+  type: "string",
+  required: true,
+});
+
+export const myDataSource = dataSource({
+  display: {
+    label: "My Data Source",
+    description: "This is my data source",
+  },
+  perform: async (context, { connection, myInput }) => {
+    const client = createClient(connection);
+    return {
+      result: await client.call(myInput),
+    };
+  },
+  inputs: {
+    connection: myConnectionField,
+    myInput: myInputField,
+  },
+  dataSourceType: "string",
+});
+
+export default { myDataSource };
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/src/actions.ts 1`] = `
 "import { action } from "@prismatic-io/spectral";
 import * as path from "path";
 import { createClientAsync } from "../countryinfoservice/index";
@@ -742,30 +5171,50 @@ export default {
 "
 `;
 
-exports[`component generation tests wsdl CountryInfoService.wsdl generation should match triggers.ts snapshot: countryinfoservice-triggers.ts 1`] = `
-"import { trigger } from "@prismatic-io/spectral";
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/src/connections.ts 1`] = `
+"import { connection } from "@prismatic-io/spectral";
 
-export const myTrigger = trigger({
-  display: {
-    label: "My Trigger",
-    description: "This is my trigger",
+export const myConnection = connection({
+  key: "myConnection",
+  label: "My Connection",
+  comments: "This is my connection",
+  inputs: {
+    username: {
+      label: "Username",
+      placeholder: "Username",
+      type: "string",
+      required: true,
+      comments: "Username for my Connection",
+    },
+    password: {
+      label: "Password",
+      placeholder: "Password",
+      type: "password",
+      required: true,
+      comments: "Password for my Connection",
+    },
   },
-  perform: async (context, payload, params) => {
-    console.log("My Trigger params", params);
-    return Promise.resolve({
-      payload,
-    });
-  },
-  inputs: {},
-  synchronousResponseSupport: "valid",
-  scheduleSupport: "valid",
 });
 
-export default { myTrigger };
+export default [myConnection];
 "
 `;
 
-exports[`component generation tests wsdl CountryInfoService.wsdl generation should match index.ts snapshot: countryinfoservice-index.ts 1`] = `
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/src/client.ts 1`] = `
+"import { Connection } from "@prismatic-io/spectral";
+
+export const createClient = (connection: Connection) => {
+  // Create a client using the provided Connection for the
+  // service you're consuming from this Component.
+  return {
+    call: async (name: unknown) =>
+      Promise.resolve(\`Hello, ${name} using connection ${connection.key}\`),
+  };
+};
+"
+`;
+
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/src/index.ts 1`] = `
 "import { component } from "@prismatic-io/spectral";
 import actions from "./actions";
 import triggers from "./triggers";
@@ -788,42 +5237,25 @@ export default component({
 "
 `;
 
-exports[`component generation tests wsdl CountryInfoService.wsdl generation should match inputs.ts snapshot: countryinfoservice-inputs.ts 1`] = `
-"import { input } from "@prismatic-io/spectral";
-export const options = input({
-  label: "Options",
-  type: "data",
-  required: true,
+exports[`component generation tests wsdl - countryinfoservice should match scaffolding snapshots: countryinfoservice/src/triggers.ts 1`] = `
+"import { trigger } from "@prismatic-io/spectral";
+
+export const myTrigger = trigger({
+  display: {
+    label: "My Trigger",
+    description: "This is my trigger",
+  },
+  perform: async (context, payload, params) => {
+    console.log("My Trigger params", params);
+    return Promise.resolve({
+      payload,
+    });
+  },
+  inputs: {},
+  synchronousResponseSupport: "valid",
+  scheduleSupport: "valid",
 });
-export const sCountryISOCode = input({
-  label: "SCountryIsoCode",
-  type: "data",
-  required: true,
-});
-export const sCountryName = input({
-  label: "SCountryName",
-  type: "data",
-  required: true,
-});
-export const sCurrencyISOCode = input({
-  label: "SCurrencyIsoCode",
-  type: "data",
-  required: true,
-});
-export const sISOCode = input({
-  label: "SIsoCode",
-  type: "data",
-  required: true,
-});
-export const sISOCurrencyCode = input({
-  label: "SIsoCurrencyCode",
-  type: "data",
-  required: true,
-});
-export const sLanguageName = input({
-  label: "SLanguageName",
-  type: "data",
-  required: true,
-});
+
+export default { myTrigger };
 "
 `;

--- a/src/commands/components/init/fixtures/specs/petstore-expanded-uuid-paths.json
+++ b/src/commands/components/init/fixtures/specs/petstore-expanded-uuid-paths.json
@@ -1,0 +1,242 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team",
+      "email": "apiteam@swagger.io",
+      "url": "http://swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://petstore.swagger.io/v2"
+    }
+  ],
+  "paths": {
+    "/82dbb5d5-b5fb-47ea-b3dc-1748750470e2": {
+      "get": {
+        "description": "Returns all pets from the system that the user has access to\nNam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.\n\nSed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.\n",
+        "operationId": "findPets",
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "tags to filter by",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new pet in the store. Duplicates are allowed",
+        "operationId": "addPet",
+        "requestBody": {
+          "description": "Pet to add to the store",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewPet"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/82dbb5d5-b5fb-47ea-b3dc-1748750470e2/{id}": {
+      "get": {
+        "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId": "find pet by id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to fetch",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "deletes a single pet based on the ID supplied",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to delete",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pet deleted"
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NewPet"
+          },
+          {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          }
+        ]
+      },
+      "NewPet": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/commands/components/init/fixtures/specs/petstore-expanded.json
+++ b/src/commands/components/init/fixtures/specs/petstore-expanded.json
@@ -1,0 +1,242 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0.0",
+    "title": "Swagger Petstore",
+    "description": "A sample API that uses a petstore as an example to demonstrate features in the OpenAPI 3.0 specification",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "name": "Swagger API Team",
+      "email": "apiteam@swagger.io",
+      "url": "http://swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://petstore.swagger.io/v2"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "description": "Returns all pets from the system that the user has access to\nNam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.\n\nSed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.\n",
+        "operationId": "findPets",
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "tags to filter by",
+            "required": false,
+            "style": "form",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "maximum number of results to return",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "description": "Creates a new pet in the store. Duplicates are allowed",
+        "operationId": "addPet",
+        "requestBody": {
+          "description": "Pet to add to the store",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NewPet"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pets/{id}": {
+      "get": {
+        "description": "Returns a user based on a single ID, if the user does not have access to the pet",
+        "operationId": "find pet by id",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to fetch",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "pet response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "description": "deletes a single pet based on the ID supplied",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "ID of pet to delete",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "pet deleted"
+          },
+          "default": {
+            "description": "unexpected error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Pet": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/NewPet"
+          },
+          {
+            "type": "object",
+            "required": [
+              "id"
+            ],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "format": "int64"
+              }
+            }
+          }
+        ]
+      },
+      "NewPet": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "required": [
+          "code",
+          "message"
+        ],
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/commands/components/init/formats.ts
+++ b/src/commands/components/init/formats.ts
@@ -35,12 +35,13 @@ export default class GenerateFormatsCommand extends Command {
     } = await this.parse(GenerateFormatsCommand);
     const key = camelCase(name);
 
-    await Promise.all([
-      template("tsconfig.json.ejs"),
-      template("webpack.config.js.ejs"),
-      template("jest.config.js.ejs"),
-      template(path.join("assets", "icon.png.ejs")),
-    ]);
+    const templateFiles = [
+      "tsconfig.json",
+      "webpack.config.js",
+      "jest.config.js",
+      path.join("assets", "icon.png"),
+    ];
+    await Promise.all(templateFiles.map((f) => template(path.join("formats", `${f}.ejs`), f)));
 
     await updatePackageJson({
       path: "package.json",

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -1,13 +1,14 @@
 import { promises as fs } from "fs";
+import path from "path";
 
-export const exists = async (path: string) => {
+export const exists = async (path: string): Promise<boolean> => {
   return fs.access(path).then(
     () => true,
     () => false,
   );
 };
 
-export const readStdin = async () => {
+export const readStdin = async (): Promise<string> => {
   return new Promise((resolve, reject) => {
     process.stdin
       .on("readable", () => {
@@ -19,6 +20,15 @@ export const readStdin = async () => {
       })
       .on("error", reject);
   });
+};
+
+export const walkDir = async (dir: string, ignore: string[] = []): Promise<string[]> => {
+  const dirents = await fs.readdir(dir, { withFileTypes: true });
+  const promises = dirents.map((d) =>
+    d.isDirectory() ? walkDir(path.join(dir, d.name)) : path.join(dir, d.name),
+  );
+  const results = (await Promise.all(promises)).flat();
+  return results.filter((r) => !ignore.some((i) => r.endsWith(i)));
 };
 
 export { fs };

--- a/src/generate/formats/readers/openapi/actions.ts
+++ b/src/generate/formats/readers/openapi/actions.ts
@@ -61,7 +61,7 @@ const buildAction = (
   const operationName = cleanIdentifier(operation.operationId || `${verb} ${path}`);
 
   const { pathInputs, queryInputs, bodyInputs } = getInputs(operation, sharedParameters);
-  const groupTag = toGroupTag(path);
+  const groupTag = toGroupTag(operation.tags?.[0] ?? path);
 
   // Repackage inputs; need to ensure we camelCase to handle hyphenated identifiers.
   const inputs = [...pathInputs, ...queryInputs, ...bodyInputs].reduce(

--- a/src/generate/formats/readers/openapi/util.test.ts
+++ b/src/generate/formats/readers/openapi/util.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "bun:test";
+import { toGroupTag } from "./util";
+
+describe("toGroupTag", () => {
+  it.each([
+    {
+      input: "/",
+      expected: "root",
+    },
+    {
+      input: "/users/{id}",
+      expected: "users",
+    },
+    {
+      input: "External ID",
+      expected: "externalId",
+    },
+  ])("handles reasonable path or tag inputs", ({ input, expected }) => {
+    expect(toGroupTag(input)).toStrictEqual(expected);
+  });
+
+  it.each([
+    {
+      input: "/17",
+      expected: "a17",
+    },
+    {
+      input: "/82dbb5d5-b5fb-47ea-b3dc-1748750470e2/{id}",
+      expected: "a82Dbb5D5B5Fb47EaB3Dc1748750470E2",
+    },
+    {
+      input: "1. Users",
+      expected: "a1Users",
+    },
+  ])("handles inputs producing invalid import names", ({ input, expected }) => {
+    expect(toGroupTag(input)).toStrictEqual(expected);
+  });
+});

--- a/src/generate/formats/readers/openapi/util.ts
+++ b/src/generate/formats/readers/openapi/util.ts
@@ -1,8 +1,8 @@
 import { camelCase } from "lodash-es";
-import { toWords } from "number-to-words";
 
 /** Convert path to grouping tag. */
-export const toGroupTag = (path: string): string =>
-  camelCase(path === "/" ? "root" : path.split("/")[1]).replace(/^(\d+)/, (_, match) =>
-    toWords(match),
-  );
+export const toGroupTag = (input: string): string => {
+  const tag = input.startsWith("/") ? input.split("/")[1] || "root" : input;
+  const cleaned = tag.replace(/^(\d)/, "a$1");
+  return camelCase(cleaned);
+};

--- a/src/generate/util.ts
+++ b/src/generate/util.ts
@@ -5,6 +5,7 @@ import prettier from "prettier";
 import { startCase, camelCase, merge } from "lodash-es";
 import path from "path";
 import { fileURLToPath } from "url";
+import { exists } from "../fs.js";
 
 export const pascalCase = (str: string) => startCase(camelCase(str)).replace(/ /g, "");
 
@@ -25,7 +26,7 @@ export const toArgv = (args: Record<string, unknown>): string[] =>
 export const template = async (
   source: string,
   destination: string = source.replace(/\.ejs$/, ""),
-  data?: Record<string, unknown>,
+  data: Record<string, unknown> = {},
 ): Promise<void> => {
   const basePath =
     process.env.NODE_ENV === "test"
@@ -49,7 +50,8 @@ interface UpdatePackageJsonParams {
 }
 
 export const updatePackageJson = async ({ path, ...rest }: UpdatePackageJsonParams) => {
-  const contents = await readJson(path, { encoding: "utf-8" });
+  const existingPackageJson = await exists(path);
+  const contents = existingPackageJson ? await readJson(path, { encoding: "utf-8" }) : {};
   const result = merge({}, contents, rest);
   const formatted = await prettier.format(JSON.stringify(result, null, 2), {
     parser: "json",


### PR DESCRIPTION
Fixes an issue with scaffolding the initial files for OpenAPI component generation, improves test coverage of WSDL and adds missing coverage for OpenAPI, improves `cwd` handling during scaffolding, enables using the first tag for generating the "grouping tag" instead of only path, and fixes updating `package.json` if it doesn't already exist.