### PR TITLE
Fix OpenAPI client writer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "6.0.6",
+  "version": "6.0.7",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": ["prismatic", "cli"],
   "homepage": "https://prismatic.io",

--- a/src/generate/formats/writer/index.ts
+++ b/src/generate/formats/writer/index.ts
@@ -110,7 +110,7 @@ const writeClient = (project: Project, baseUrl: string, connections: Connection[
           `import { HttpClient, createClient as createHttpClient } from "@prismatic-io/spectral/dist/clients/http";`,
         )
         .writeLine(
-          `import { ${connections.map(({ key }) => key).join(", ")} } from "./connections.js";`,
+          `import { ${connections.map(({ key }) => key).join(", ")} } from "./connections";`,
         )
         .blankLine()
         .writeLine(`export const baseUrl = "${baseUrl}";`)


### PR DESCRIPTION
Removes mistakenly added `.js` extension, likely from the ESM changeset.