### PR TITLE
Add Prism Component Signature command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,8 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
-  "keywords": [
-    "prismatic",
-    "cli"
-  ],
+  "keywords": ["prismatic", "cli"],
   "homepage": "https://prismatic.io",
   "bugs": {
     "url": "https://github.com/prismatic-io/prism"
@@ -38,11 +35,7 @@
     "test": "bun run clean-test-temp && bun test src",
     "test:snapshots": "bun run clean-test-temp && bun test --update-snapshots"
   },
-  "files": [
-    "oclif.manifest.json",
-    "bin",
-    "lib"
-  ],
+  "files": ["oclif.manifest.json", "bin", "lib"],
   "dependencies": {
     "@apidevtools/swagger-parser": "10.1.0",
     "@msgpack/msgpack": "2.3.0",

--- a/src/commands/components/dev/test.ts
+++ b/src/commands/components/dev/test.ts
@@ -6,12 +6,9 @@ import inquirer, { DistinctQuestion } from "inquirer";
 import { snakeCase, upperCase, kebabCase } from "lodash-es";
 import { serverTypes } from "@prismatic-io/spectral"; // FIXME: Get rid of this and stop exporting it in Spectral.
 import {
-  loadEntrypoint,
-  createComponentPackage,
   publishDefinition,
   uploadConnectionIcons,
   uploadFile,
-  validateDefinition,
   checkPackageSignature,
 } from "../../../utils/component/publish.js";
 import { displayLogs } from "../../../utils/execution/logs.js";
@@ -32,6 +29,11 @@ import {
   writeFinalStepResults,
 } from "../../../utils/execution/stepResults.js";
 import { deleteComponentByKey } from "../../../utils/component/deleteByKey.js";
+import {
+  createComponentPackage,
+  loadEntrypoint,
+  validateDefinition,
+} from "../../../utils/component/index.js";
 
 const setTimeoutPromise = promisify(setTimeout);
 

--- a/src/commands/components/publish.ts
+++ b/src/commands/components/publish.ts
@@ -1,15 +1,18 @@
 import { Command, Flags, ux } from "@oclif/core";
+
+import { whoAmI } from "../../utils/user/query.js";
+import {
+  createComponentPackage,
+  loadEntrypoint,
+  validateDefinition,
+} from "../../utils/component/index.js";
 import {
   checkPackageSignature,
   confirmPublish,
-  createComponentPackage,
-  loadEntrypoint,
   publishDefinition,
   uploadConnectionIcons,
   uploadFile,
-  validateDefinition,
 } from "../../utils/component/publish.js";
-import { whoAmI } from "../../utils/user/query.js";
 
 export default class PublishCommand extends Command {
   static description = "Publish a Component to Prismatic";

--- a/src/commands/components/signature.ts
+++ b/src/commands/components/signature.ts
@@ -1,0 +1,55 @@
+import { Command, Flags } from "@oclif/core";
+import crypto from "crypto";
+
+import { getPackageSignatureFromApi } from "../../utils/component/signature.js";
+import { whoAmI } from "../../utils/user/query.js";
+import { fs } from "../../fs.js";
+import {
+  createComponentPackage,
+  loadEntrypoint,
+  validateDefinition,
+} from "../../utils/component/index.js";
+
+export default class ComponentsSignatureCommand extends Command {
+  static description = "Generate a Component signature";
+
+  static flags = {
+    customer: Flags.string({
+      description: "ID of customer with which to associate the component",
+    }),
+    "skip-signature-verify": Flags.boolean({
+      required: false,
+      description:
+        "This consistently returns a signature, regardless of whether the corresponding component signature is actually present in the API or not.",
+    }),
+  };
+
+  async run() {
+    const {
+      flags: { customer: flagCustomer, "skip-signature-verify": skipSignatureVerification },
+    } = await this.parse(ComponentsSignatureCommand);
+
+    const componentDefinition = await loadEntrypoint();
+    await validateDefinition(componentDefinition);
+    const packagePath = await createComponentPackage();
+    const me = await whoAmI();
+    const customer = flagCustomer ?? me.customer?.id;
+
+    const packageSignature = crypto
+      .createHash("sha1")
+      .update(await fs.readFile(packagePath))
+      .digest("hex");
+
+    if (skipSignatureVerification) {
+      return process.stdout.write(packageSignature);
+    }
+
+    const packageSignatureFromApi = await getPackageSignatureFromApi({
+      componentDefinition,
+      customer,
+      packageSignature,
+    });
+
+    return process.stdout.write(packageSignatureFromApi ?? "");
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ import ComponentsInitConnectionCommand from "./commands/components/init/connecti
 import ComponentsInitDataSourceCommand from "./commands/components/init/dataSource.js";
 import ComponentsInitCommand from "./commands/components/init/index.js";
 import ComponentsInitTriggerCommand from "./commands/components/init/trigger.js";
+import ComponentsSignatureCommand from "./commands/components/signature.js";
 import ComponentsTriggersListCommand from "./commands/components/triggers/list.js";
 import CustomersCredentialsCreateCommand from "./commands/customers/credentials/create.js";
 import CustomersCredentialsDeleteCommand from "./commands/customers/credentials/delete.js";
@@ -150,6 +151,7 @@ export const Commands = {
   "components:init:data-source": ComponentsInitDataSourceCommand,
   "components:init": ComponentsInitCommand,
   "components:init:trigger": ComponentsInitTriggerCommand,
+  "components:signature": ComponentsSignatureCommand,
   "components:triggers:list": ComponentsTriggersListCommand,
   "customers:credentials:create": CustomersCredentialsCreateCommand,
   "customers:credentials:delete": CustomersCredentialsDeleteCommand,

--- a/src/utils/component/index.ts
+++ b/src/utils/component/index.ts
@@ -1,0 +1,99 @@
+import { ComponentDefinition as ComponentDefinitionTemplate } from "@prismatic-io/spectral";
+import { ux } from "@oclif/core";
+import { resolve } from "path";
+import tempy from "tempy";
+import archiver from "archiver";
+import { extname } from "path";
+
+import { seekPackageDistDirectory } from "../import.js";
+import { exists } from "../../fs.js";
+
+/** Type defining leftover legacy backwards compat keys. */
+type LegacyDefinition = {
+  authorization?: {
+    required: boolean;
+    methods: string[];
+  };
+};
+
+/**
+ * Superset of component definitions built from our current latest Spectral
+ * definitions as well as legacy backwards compat for deprecated features.
+ * Prism must be capable of publishing all past component definitions and
+ * gracefully publish future component definitions.
+ */
+export type ComponentDefinition = Omit<ComponentDefinitionTemplate<false, any>, "hooks"> &
+  Pick<ComponentDefinitionTemplate<true, any>, "documentationUrl"> &
+  LegacyDefinition;
+
+interface ComponentEntrypoint {
+  default: ComponentDefinition;
+}
+
+export const loadEntrypoint = async (): Promise<ComponentDefinition> => {
+  // If we don't have an index.js in cwd seek directories to find package.json of component
+  if (!(await exists("index.js"))) {
+    await seekPackageDistDirectory("component");
+  }
+
+  // If we still didn't find index.js error out
+  if (!(await exists("index.js"))) {
+    ux.error("Failed to find 'index.js' entrypoint file. Is the current path a component?", {
+      exit: 1,
+    });
+  }
+
+  // Require index.js and access its root-most default export which should be the Component config
+  const cwd = process.cwd();
+  const entrypointPath = resolve(cwd, "./index.js");
+  const { default: definition }: ComponentEntrypoint = require(entrypointPath);
+
+  return definition;
+};
+
+export const createComponentPackage = async (): Promise<string> => {
+  const zip = archiver("zip", { zlib: { level: 9 } });
+  const pathPromise = tempy.write(zip, { extension: "zip" });
+
+  // Zip all files in the current directory (since we found the index.js entrypoint)
+  // Set all files' dates to the Unix epoch so that the zip hash is deterministic
+  zip.directory(process.cwd(), false, (entry) => ({
+    ...entry,
+    date: new Date(0),
+  }));
+  await zip.finalize();
+
+  return pathPromise;
+};
+
+export const validateDefinition = async (definition: ComponentDefinition): Promise<void> => {
+  // Output basic information to the user to confirm that this component is what they want to publish
+  const {
+    display: { label, description, iconPath },
+    connections,
+  } = definition;
+  if (!label || !description) {
+    ux.error("Missing required values `label` or `description`. Exiting.", {
+      exit: 1,
+    });
+  }
+
+  const componentIconValid = await validateIcon(iconPath);
+  if (!componentIconValid) {
+    ux.error("Component icon does not exist or is not a png. Exiting.", {
+      exit: 1,
+    });
+  }
+
+  const connectionIconsValid = await Promise.all(
+    (connections ?? []).map(({ iconPath }) => validateIcon(iconPath)),
+  );
+  if (connectionIconsValid.some((v) => !v)) {
+    ux.error("One or more connection icons do not exist or are not a png. Exiting.", {
+      exit: 1,
+    });
+  }
+};
+
+const validateIcon = async (iconPath?: string): Promise<boolean> =>
+  !iconPath || (extname(iconPath.trim().toLowerCase()) === ".png" && (await exists(iconPath)));

--- a/src/utils/component/publish.ts
+++ b/src/utils/component/publish.ts
@@ -1,31 +1,12 @@
-import { ux } from "@oclif/core";
-import { exists, fs } from "../../fs.js";
-import { resolve, extname } from "path";
-import { ComponentDefinition as ComponentDefinitionTemplate } from "@prismatic-io/spectral";
-import tempy from "tempy";
+import { extname } from "path";
 import crypto from "crypto";
-import archiver from "archiver";
-import { gqlRequest, gql } from "../../graphql.js";
-import { seekPackageDistDirectory } from "../import.js";
-import axios from "axios";
+import { ux } from "@oclif/core";
 import mimetypes from "mime-types";
+import axios from "axios";
 
-/** Type defining leftover legacy backwards compat keys. */
-type LegacyDefinition = {
-  authorization?: {
-    required: boolean;
-    methods: string[];
-  };
-};
-/**
- * Superset of component definitions built from our current latest Spectral
- * definitions as well as legacy backwards compat for deprecated features.
- * Prism must be capable of publishing all past component definitions and
- * gracefully publish future component definitions.
- */
-export type ComponentDefinition = Omit<ComponentDefinitionTemplate<false, any>, "hooks"> &
-  Pick<ComponentDefinitionTemplate<true, any>, "documentationUrl"> &
-  LegacyDefinition;
+import { ComponentDefinition } from "./index.js";
+import { fs } from "../../fs.js";
+import { gqlRequest, gql } from "../../graphql.js";
 
 const componentDefinitionShape: Record<keyof ComponentDefinition, true> = {
   actions: true,
@@ -37,78 +18,6 @@ const componentDefinitionShape: Record<keyof ComponentDefinition, true> = {
   key: true,
   public: true,
   triggers: true,
-};
-
-interface ComponentEntrypoint {
-  default: ComponentDefinition;
-}
-
-export const loadEntrypoint = async (): Promise<ComponentDefinition> => {
-  // If we don't have an index.js in cwd seek directories to find package.json of component
-  if (!(await exists("index.js"))) {
-    await seekPackageDistDirectory("component");
-  }
-
-  // If we still didn't find index.js error out
-  if (!(await exists("index.js"))) {
-    ux.error("Failed to find 'index.js' entrypoint file. Is the current path a component?", {
-      exit: 1,
-    });
-  }
-
-  // Require index.js and access its root-most default export which should be the Component config
-  const cwd = process.cwd();
-  const entrypointPath = resolve(cwd, "./index.js");
-  const { default: definition }: ComponentEntrypoint = require(entrypointPath);
-
-  return definition;
-};
-
-const validateIcon = async (iconPath?: string): Promise<boolean> =>
-  !iconPath || (extname(iconPath.trim().toLowerCase()) === ".png" && (await exists(iconPath)));
-
-export const validateDefinition = async (definition: ComponentDefinition): Promise<void> => {
-  // Output basic information to the user to confirm that this component is what they want to publish
-  const {
-    display: { label, description, iconPath },
-    connections,
-  } = definition;
-  if (!label || !description) {
-    ux.error("Missing required values `label` or `description`. Exiting.", {
-      exit: 1,
-    });
-  }
-
-  const componentIconValid = await validateIcon(iconPath);
-  if (!componentIconValid) {
-    ux.error("Component icon does not exist or is not a png. Exiting.", {
-      exit: 1,
-    });
-  }
-
-  const connectionIconsValid = await Promise.all(
-    (connections ?? []).map(({ iconPath }) => validateIcon(iconPath)),
-  );
-  if (connectionIconsValid.some((v) => !v)) {
-    ux.error("One or more connection icons do not exist or are not a png. Exiting.", {
-      exit: 1,
-    });
-  }
-};
-
-export const createComponentPackage = async (): Promise<string> => {
-  const zip = archiver("zip", { zlib: { level: 9 } });
-  const pathPromise = tempy.write(zip, { extension: "zip" });
-
-  // Zip all files in the current directory (since we found the index.js entrypoint)
-  // Set all files' dates to the Unix epoch so that the zip hash is deterministic
-  zip.directory(process.cwd(), false, (entry) => ({
-    ...entry,
-    date: new Date(0),
-  }));
-  await zip.finalize();
-
-  return pathPromise;
 };
 
 export const checkPackageSignature = async (

--- a/src/utils/component/signature.ts
+++ b/src/utils/component/signature.ts
@@ -1,0 +1,39 @@
+import { gqlRequest, gql } from "../../graphql.js";
+import { ComponentDefinition } from "./index.js";
+
+interface GetPackageSignatureFromApiProps {
+  componentDefinition: ComponentDefinition;
+  customer?: string;
+  packageSignature: string;
+}
+
+export const getPackageSignatureFromApi = async ({
+  componentDefinition,
+  customer,
+  packageSignature,
+}: GetPackageSignatureFromApiProps): Promise<string | null> => {
+  const results = await gqlRequest({
+    document: gql`
+      query component($key: String!, $public: Boolean!, $customer: ID) {
+        components(key: $key, public: $public, customer: $customer) {
+          nodes {
+            signature
+          }
+        }
+      }
+    `,
+    variables: {
+      key: componentDefinition.key,
+      public: componentDefinition.public ?? false,
+      customer,
+    },
+  });
+
+  const {
+    components: {
+      nodes: [{ signature: existingSignature } = { signature: null }],
+    },
+  } = results;
+
+  return existingSignature === packageSignature ? packageSignature : null;
+};

--- a/src/utils/integration/import.ts
+++ b/src/utils/integration/import.ts
@@ -6,13 +6,15 @@ import { exists, fs } from "../../fs.js";
 import { resolve } from "path";
 import { seekPackageDistDirectory } from "../import.js";
 import {
-  createComponentPackage,
   publishDefinition as publishComponentDefinition,
-  validateDefinition as validateComponentDefinition,
   uploadFile,
   uploadConnectionIcons,
-  ComponentDefinition,
 } from "../component/publish.js";
+import {
+  ComponentDefinition,
+  createComponentPackage,
+  validateDefinition,
+} from "../component/index.js";
 
 interface ImportDefinitionResult {
   integrationId: string;
@@ -142,7 +144,7 @@ export const importCodeNativeIntegration = async (integrationId?: string): Promi
     );
   }
 
-  await validateComponentDefinition(componentDefinition);
+  await validateDefinition(componentDefinition);
 
   const packagePath = await createComponentPackage();
 


### PR DESCRIPTION
```
prism components:signature
prism components:signature --skip-signature-verify
```

The `prism components:signature` command in Prism verifies the existence of the component in the Prismatic Platform before returning it. If you want the command to return a key regardless of whether the component exists or not in the API, you can run it with the `skip-signature-verify` option. This will allow the command to return a key even if the component is not found.

If you're using a Component Manifest with an unverified signature key in a Code Native Integration (CNI), it's fine to work with it locally. However, when you try to integrate the CNI with the Prismatic Platform, it will fail.


**Other changes**

Moved shared functions into the components index to indicate they are used in multiple component commands.