### PR TITLE
Component signature pretty output using Oclif

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "6.2.0",
+  "version": "6.2.1",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": ["prismatic", "cli"],
   "homepage": "https://prismatic.io",

--- a/src/commands/components/signature.ts
+++ b/src/commands/components/signature.ts
@@ -41,7 +41,7 @@ export default class ComponentsSignatureCommand extends Command {
       .digest("hex");
 
     if (skipSignatureVerification) {
-      return process.stdout.write(packageSignature);
+      return this.log(packageSignature);
     }
 
     const packageSignatureFromApi = await getPackageSignatureFromApi({
@@ -50,6 +50,6 @@ export default class ComponentsSignatureCommand extends Command {
       packageSignature,
     });
 
-    return process.stdout.write(packageSignatureFromApi ?? "");
+    return this.log(packageSignatureFromApi ?? "");
   }
 }


### PR DESCRIPTION
**Issue:**
When using `process.stdout.write` this includes `%` at the end of the output indicating the end of program. However, this could be confusing to the user if they need to manually generate a component signature. 

```
# dummy example
process.stdout.write("Hello World"); // Hello World%
```

```
# live example
❯ prism components:signature
34593f3f1921a1ce32b2ece60f5b1bea1333acf9%  
```

**Solution:**
Use oclifs way of logging output, however we'll need to account for the automatic line break it adds  in spectral when generating the component manifest. 