### PR TITLE
Remove customer flag from signature commands

### DIFF
--- a/src/commands/components/publish.ts
+++ b/src/commands/components/publish.ts
@@ -90,7 +90,7 @@ export default class PublishCommand extends Command {
     const packagePath = await createComponentPackage();
 
     if (checkSignature) {
-      const signatureMatches = await checkPackageSignature(definition, packagePath, customer);
+      const signatureMatches = await checkPackageSignature(definition, packagePath);
       if (signatureMatches) {
         if (
           skipOnSignatureMatch ||

--- a/src/commands/components/signature.ts
+++ b/src/commands/components/signature.ts
@@ -2,7 +2,6 @@ import { Command, Flags } from "@oclif/core";
 import crypto from "crypto";
 
 import { getPackageSignatureFromApi } from "../../utils/component/signature.js";
-import { whoAmI } from "../../utils/user/query.js";
 import { fs } from "../../fs.js";
 import {
   createComponentPackage,
@@ -14,9 +13,6 @@ export default class ComponentsSignatureCommand extends Command {
   static description = "Generate a Component signature";
 
   static flags = {
-    customer: Flags.string({
-      description: "ID of customer with which to associate the component",
-    }),
     "skip-signature-verify": Flags.boolean({
       required: false,
       description:
@@ -26,14 +22,12 @@ export default class ComponentsSignatureCommand extends Command {
 
   async run() {
     const {
-      flags: { customer: flagCustomer, "skip-signature-verify": skipSignatureVerification },
+      flags: { "skip-signature-verify": skipSignatureVerification },
     } = await this.parse(ComponentsSignatureCommand);
 
     const componentDefinition = await loadEntrypoint();
     await validateDefinition(componentDefinition);
     const packagePath = await createComponentPackage();
-    const me = await whoAmI();
-    const customer = flagCustomer ?? me.customer?.id;
 
     const packageSignature = crypto
       .createHash("sha1")
@@ -46,7 +40,6 @@ export default class ComponentsSignatureCommand extends Command {
 
     const packageSignatureFromApi = await getPackageSignatureFromApi({
       componentDefinition,
-      customer,
       packageSignature,
     });
 

--- a/src/utils/component/publish.ts
+++ b/src/utils/component/publish.ts
@@ -23,13 +23,12 @@ const componentDefinitionShape: Record<keyof ComponentDefinition, true> = {
 export const checkPackageSignature = async (
   { key, public: isPublic }: ComponentDefinition,
   packagePath: string,
-  customer?: string,
 ): Promise<boolean> => {
   // Retrieve the existing signature of the component if it exists.
   const results = await gqlRequest({
     document: gql`
-      query component($key: String!, $public: Boolean!, $customer: ID) {
-        components(key: $key, public: $public, customer: $customer) {
+      query component($key: String!, $public: Boolean!) {
+        components(key: $key, public: $public) {
           nodes {
             signature
           }
@@ -39,7 +38,6 @@ export const checkPackageSignature = async (
     variables: {
       key,
       public: isPublic ?? false,
-      customer,
     },
   });
 

--- a/src/utils/component/signature.ts
+++ b/src/utils/component/signature.ts
@@ -3,19 +3,17 @@ import { ComponentDefinition } from "./index.js";
 
 interface GetPackageSignatureFromApiProps {
   componentDefinition: ComponentDefinition;
-  customer?: string;
   packageSignature: string;
 }
 
 export const getPackageSignatureFromApi = async ({
   componentDefinition,
-  customer,
   packageSignature,
 }: GetPackageSignatureFromApiProps): Promise<string | null> => {
   const results = await gqlRequest({
     document: gql`
-      query component($key: String!, $public: Boolean!, $customer: ID) {
-        components(key: $key, public: $public, customer: $customer) {
+      query component($key: String!, $public: Boolean!) {
+        components(key: $key, public: $public) {
           nodes {
             signature
           }
@@ -25,7 +23,6 @@ export const getPackageSignatureFromApi = async ({
     variables: {
       key: componentDefinition.key,
       public: componentDefinition.public ?? false,
-      customer,
     },
   });
 


### PR DESCRIPTION
The uniquness constraint for components does not include the customer so we shouldn't be filtering components by customer. This would prevent a customer user logged into prism from validating a component signature.