### PR TITLE
CNI - Components generated manifests script updates

### DIFF
--- a/src/commands/components/init/component.ts
+++ b/src/commands/components/init/component.ts
@@ -116,9 +116,9 @@ export default class GenerateComponentCommand extends Command {
       scripts: {
         build: "webpack",
         publish: "npm run build && prism components:publish",
-        "generate:manifest":
-          "npm run build && npx @prismatic-io/spectral component-manifest --include-signature",
-        "generate:manifest:dev": "npm run build && npx @prismatic-io/spectral component-manifest",
+        "generate:manifest": "npm run build && npx @prismatic-io/spectral component-manifest",
+        "generate:manifest:dev":
+          "npm run build && npx @prismatic-io/spectral component-manifest --skip-signature-verify",
         test: "jest",
         lint: "eslint --ext .ts .",
       },

--- a/src/commands/components/init/formats.ts
+++ b/src/commands/components/init/formats.ts
@@ -50,9 +50,9 @@ export default class GenerateFormatsCommand extends Command {
       version: "0.0.1",
       scripts: {
         build: "webpack",
-        "generate:manifest":
-          "npm run build && npx @prismatic-io/spectral component-manifest --include-signature",
-        "generate:manifest:dev": "npm run build && npx @prismatic-io/spectral component-manifest",
+        "generate:manifest": "npm run build && npx @prismatic-io/spectral component-manifest",
+        "generate:manifest:dev":
+          "npm run build && npx @prismatic-io/spectral component-manifest --skip-signature-verify",
         test: "jest --runInBand",
         lint: "eslint --quiet --ext .ts .",
         "lint-fix": "eslint --quiet --ext .ts --fix .",

--- a/src/commands/components/signature.ts
+++ b/src/commands/components/signature.ts
@@ -16,13 +16,13 @@ export default class ComponentsSignatureCommand extends Command {
     "skip-signature-verify": Flags.boolean({
       required: false,
       description:
-        "This consistently returns a signature, regardless of whether the corresponding component signature is actually present in the API or not.",
+        "This consistently returns a signature, regardless of whether the corresponding component has been published to the platform or not.",
     }),
   };
 
   async run() {
     const {
-      flags: { "skip-signature-verify": skipSignatureVerification },
+      flags: { "skip-signature-verify": skipSignatureVerify },
     } = await this.parse(ComponentsSignatureCommand);
 
     const componentDefinition = await loadEntrypoint();
@@ -34,7 +34,7 @@ export default class ComponentsSignatureCommand extends Command {
       .update(await fs.readFile(packagePath))
       .digest("hex");
 
-    if (skipSignatureVerification) {
+    if (skipSignatureVerify) {
       return this.log(packageSignature);
     }
 


### PR DESCRIPTION
Update the component generated templates. Removing the `--include-signature` and adding the `--validate-signature` for the `generate:manifest` script.