### PR TITLE
CNI - Add a Scoped Registry

### DIFF
--- a/src/commands/integrations/init/integration.ts
+++ b/src/commands/integrations/init/integration.ts
@@ -6,6 +6,7 @@ import { v4 as uuid4 } from "uuid";
 import path from "path";
 import { template, toArgv, updatePackageJson } from "../../../generate/util.js";
 import GenerateFlowCommand from "./flow.js";
+import { prismaticUrl } from "../../../auth.js";
 
 export default class GenerateIntegrationCommand extends Command {
   static description = "Initialize a new Code Native Integration";
@@ -27,6 +28,7 @@ export default class GenerateIntegrationCommand extends Command {
 
   async run() {
     const { flags } = await this.parse(GenerateIntegrationCommand);
+
     const { name, description, connectionType } = await inquirer.prompt<{
       name: string;
       description: string;
@@ -71,6 +73,10 @@ export default class GenerateIntegrationCommand extends Command {
         connectionType,
       },
       flow: { name: flowName },
+      registry: {
+        url: new URL("/packages/npm", prismaticUrl).toString(),
+        scope: "@component-manifests",
+      },
     };
 
     const templateFiles = [
@@ -80,6 +86,7 @@ export default class GenerateIntegrationCommand extends Command {
       path.join("src", "client.ts"),
       path.join("src", "componentRegistry.ts"),
       path.join(".spectral", "index.ts"),
+      ".npmrc",
       "jest.config.js",
       "package.json",
       "tsconfig.json",

--- a/src/generate/util.ts
+++ b/src/generate/util.ts
@@ -36,7 +36,8 @@ export const template = async (
 
   const templatePath = path.join(basePath, "templates", source);
 
-  const isTemplate = [".js", ".ts", ".json"].includes(path.extname(destination));
+  const isTemplate = [".js", ".ts", ".json", ""].includes(path.extname(destination));
+
   if (isTemplate) {
     const rendered = await renderFile(templatePath, data);
     await outputFile(destination, rendered, { encoding: "utf-8" });

--- a/templates/integration/.npmrc.ejs
+++ b/templates/integration/.npmrc.ejs
@@ -1,0 +1,1 @@
+<%= registry.scope %>:registry=<%= registry.url %>


### PR DESCRIPTION
Create an `.npmrc` file that includes the registry information for the component manifests scope.