### PR TITLE
Add --print-requests flag to most commands

### DIFF
--- a/biome.jsonc
+++ b/biome.jsonc
@@ -28,7 +28,8 @@
         "useImportType": "off"
       },
       "complexity": {
-        "noForEach": "off"
+        "noForEach": "off",
+        "noStaticOnlyClass": "off"
       },
       "performance": {
         "noAccumulatingSpread": "off"

--- a/src/baseCommand.ts
+++ b/src/baseCommand.ts
@@ -1,0 +1,14 @@
+import { Command, Flags } from "@oclif/core";
+
+export abstract class PrismaticBaseCommand extends Command {
+  static baseFlags = {
+    "print-requests": Flags.boolean({
+      description: "Print all GraphQL requests that are issued",
+      helpGroup: "GLOBAL",
+      parse: async (input) => {
+        process.env.PRISMATIC_PRINT_REQUESTS = `${input}`;
+        return input;
+      },
+    }),
+  };
+}

--- a/src/commands/alerts/events/list.ts
+++ b/src/commands/alerts/events/list.ts
@@ -1,7 +1,8 @@
-import { Command, Args, ux } from "@oclif/core";
+import { Args, ux } from "@oclif/core";
 import { gqlRequest, gql } from "../../../graphql.js";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Alert Events for an Alert Monitor";
   static args = {
     alertMonitorId: Args.string({

--- a/src/commands/alerts/groups/create.ts
+++ b/src/commands/alerts/groups/create.ts
@@ -1,8 +1,9 @@
-import { Command, Flags } from "@oclif/core";
-import { gql, gqlRequest } from "../../../graphql.js";
+import { Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { parseJsonOrUndefined } from "../../../fields.js";
+import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class CreateCommand extends Command {
+export default class CreateCommand extends PrismaticBaseCommand {
   static description = "Create an Alert Group";
   static flags = {
     name: Flags.string({

--- a/src/commands/alerts/groups/delete.ts
+++ b/src/commands/alerts/groups/delete.ts
@@ -1,7 +1,8 @@
-import { Command, Args } from "@oclif/core";
+import { Args } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class DeleteCommand extends Command {
+export default class DeleteCommand extends PrismaticBaseCommand {
   static description = "Delete an Alert Group";
   static args = {
     group: Args.string({

--- a/src/commands/alerts/groups/list.ts
+++ b/src/commands/alerts/groups/list.ts
@@ -1,7 +1,8 @@
-import { Command, ux } from "@oclif/core";
-import { gqlRequest, gql } from "../../../graphql.js";
+import { ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
+import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Alert Groups in your Organization";
   static flags = { ...ux.table.flags() };
 

--- a/src/commands/alerts/monitors/clear.ts
+++ b/src/commands/alerts/monitors/clear.ts
@@ -1,7 +1,8 @@
-import { Command, Args } from "@oclif/core";
+import { Args } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest, gql } from "../../../graphql.js";
 
-export default class ClearCommand extends Command {
+export default class ClearCommand extends PrismaticBaseCommand {
   static description = "Clear an Alert Monitor";
   static args = {
     monitor: Args.string({

--- a/src/commands/alerts/monitors/create.ts
+++ b/src/commands/alerts/monitors/create.ts
@@ -1,8 +1,9 @@
-import { Command, Flags } from "@oclif/core";
-import { gqlRequest, gql } from "../../../graphql.js";
+import { Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { parseJsonOrUndefined } from "../../../fields.js";
+import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class CreateCommand extends Command {
+export default class CreateCommand extends PrismaticBaseCommand {
   static description =
     "Create an Alert Monitor by attaching an Alert Trigger and a set of users and webhooks to an Instance";
 

--- a/src/commands/alerts/monitors/delete.ts
+++ b/src/commands/alerts/monitors/delete.ts
@@ -1,7 +1,8 @@
-import { Command, Args } from "@oclif/core";
+import { Args } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest, gql } from "../../../graphql.js";
 
-export default class DeleteCommand extends Command {
+export default class DeleteCommand extends PrismaticBaseCommand {
   static description = "Delete an Alert Monitor";
   static args = {
     monitor: Args.string({

--- a/src/commands/alerts/monitors/list.ts
+++ b/src/commands/alerts/monitors/list.ts
@@ -1,7 +1,8 @@
-import { Command, ux } from "@oclif/core";
+import { ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest, gql } from "../../../graphql.js";
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Alert Monitors for Customer Instances";
   static flags = { ...ux.table.flags() };
 

--- a/src/commands/alerts/triggers/list.ts
+++ b/src/commands/alerts/triggers/list.ts
@@ -1,7 +1,8 @@
-import { Command, ux } from "@oclif/core";
+import { ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest, gql } from "../../../graphql.js";
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Alert Triggers";
   static flags = { ...ux.table.flags() };
 

--- a/src/commands/alerts/webhooks/create.ts
+++ b/src/commands/alerts/webhooks/create.ts
@@ -1,7 +1,8 @@
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class CreateCommand extends Command {
+export default class CreateCommand extends PrismaticBaseCommand {
   static description = "Create an Alert Webhook";
   static flags = {
     name: Flags.string({

--- a/src/commands/alerts/webhooks/delete.ts
+++ b/src/commands/alerts/webhooks/delete.ts
@@ -1,7 +1,8 @@
-import { Command, Args } from "@oclif/core";
+import { Args } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest, gql } from "../../../graphql.js";
 
-export default class DeleteCommand extends Command {
+export default class DeleteCommand extends PrismaticBaseCommand {
   static description = "Delete an Alert Webhook";
   static args = {
     webhook: Args.string({

--- a/src/commands/alerts/webhooks/list.ts
+++ b/src/commands/alerts/webhooks/list.ts
@@ -1,7 +1,8 @@
-import { Command, ux } from "@oclif/core";
+import { ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest, gql } from "../../../graphql.js";
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Alert Webhooks";
   static flags = { ...ux.table.flags() };
 

--- a/src/commands/components/actions/list.ts
+++ b/src/commands/components/actions/list.ts
@@ -1,4 +1,5 @@
-import { Command, ux, Args, Flags } from "@oclif/core";
+import { Args, Flags, ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
 interface ActionNode {
@@ -9,7 +10,7 @@ interface ActionNode {
   description: string;
 }
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Actions that Components implement";
   static flags = {
     ...ux.table.flags(),

--- a/src/commands/components/data-sources/list.ts
+++ b/src/commands/components/data-sources/list.ts
@@ -1,4 +1,5 @@
-import { Command, ux, Args, Flags } from "@oclif/core";
+import { Args, Flags, ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
 interface DataSourceNode {
@@ -11,7 +12,7 @@ interface DataSourceNode {
   detailDataSource?: string;
 }
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Data Sources that Components implement";
   static flags = {
     ...ux.table.flags(),

--- a/src/commands/components/delete.ts
+++ b/src/commands/components/delete.ts
@@ -1,7 +1,8 @@
-import { Command, Args } from "@oclif/core";
+import { Args } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { gqlRequest, gql } from "../../graphql.js";
 
-export default class DeleteCommand extends Command {
+export default class DeleteCommand extends PrismaticBaseCommand {
   static description = "Delete a Component";
   static args = {
     component: Args.string({

--- a/src/commands/components/dev/run.ts
+++ b/src/commands/components/dev/run.ts
@@ -1,9 +1,10 @@
-import { Command, Flags, ux } from "@oclif/core";
+import { Flags, ux } from "@oclif/core";
 import { isEmpty } from "lodash-es";
-import { gqlRequest, gql } from "../../../graphql.js";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
+import { gql, gqlRequest } from "../../../graphql.js";
 import { spawnProcess } from "../../../utils/process.js";
 
-export default class RunCommand extends Command {
+export default class RunCommand extends PrismaticBaseCommand {
   static description =
     `Fetch an integration's active connection and execute a CLI command with that connection's fields as an environment variable.`;
   static usage = "components:dev:run -i <value> -c <value> -- /command/to/run";

--- a/src/commands/components/dev/test.ts
+++ b/src/commands/components/dev/test.ts
@@ -1,39 +1,40 @@
-import { promisify } from "util";
-import dotenv from "dotenv";
-import { Command, Flags, ux } from "@oclif/core";
-import open from "open";
-import inquirer, { DistinctQuestion } from "inquirer";
-import { snakeCase, upperCase, kebabCase } from "lodash-es";
+import { Flags, ux } from "@oclif/core";
 import { serverTypes } from "@prismatic-io/spectral"; // FIXME: Get rid of this and stop exporting it in Spectral.
-import {
-  publishDefinition,
-  uploadConnectionIcons,
-  uploadFile,
-  checkPackageSignature,
-} from "../../../utils/component/publish.js";
-import { displayLogs } from "../../../utils/execution/logs.js";
-import {
-  buildComponentTestHarnessIntegration,
-  componentTestIntegrationName,
-  ComponentTestInfo,
-} from "../../../utils/integration/definition.js";
-import { importDefinition } from "../../../utils/integration/import.js";
-import { deleteIntegration, runIntegrationFlow } from "../../../utils/integration/invoke.js";
-import { pollForActiveConfigVarState } from "../../../utils/integration/query.js";
-import { Expression } from "../../../utils/integration/export.js";
+import dotenv from "dotenv";
+import inquirer, { DistinctQuestion } from "inquirer";
+import { kebabCase, snakeCase, upperCase } from "lodash-es";
+import open from "open";
+import { promisify } from "util";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { exists } from "../../../fs.js";
-import { whoAmI } from "../../../utils/user/query.js";
-import { spawnProcess } from "../../../utils/process.js";
-import {
-  printFinalStepResults,
-  writeFinalStepResults,
-} from "../../../utils/execution/stepResults.js";
 import { deleteComponentByKey } from "../../../utils/component/deleteByKey.js";
 import {
   createComponentPackage,
   loadEntrypoint,
   validateDefinition,
 } from "../../../utils/component/index.js";
+import {
+  checkPackageSignature,
+  publishDefinition,
+  uploadConnectionIcons,
+  uploadFile,
+} from "../../../utils/component/publish.js";
+import { displayLogs } from "../../../utils/execution/logs.js";
+import {
+  printFinalStepResults,
+  writeFinalStepResults,
+} from "../../../utils/execution/stepResults.js";
+import {
+  buildComponentTestHarnessIntegration,
+  ComponentTestInfo,
+  componentTestIntegrationName,
+} from "../../../utils/integration/definition.js";
+import { Expression } from "../../../utils/integration/export.js";
+import { importDefinition } from "../../../utils/integration/import.js";
+import { deleteIntegration, runIntegrationFlow } from "../../../utils/integration/invoke.js";
+import { pollForActiveConfigVarState } from "../../../utils/integration/query.js";
+import { spawnProcess } from "../../../utils/process.js";
+import { whoAmI } from "../../../utils/user/query.js";
 
 const setTimeoutPromise = promisify(setTimeout);
 
@@ -142,7 +143,7 @@ const valuesFromAnswers = ({
   };
 };
 
-export default class TestCommand extends Command {
+export default class TestCommand extends PrismaticBaseCommand {
   static description =
     "Run an action of a component within a test integration in the integration runner";
   static flags = {

--- a/src/commands/components/list.ts
+++ b/src/commands/components/list.ts
@@ -1,8 +1,9 @@
-import { Command, Flags, ux } from "@oclif/core";
+import { Flags, ux } from "@oclif/core";
 import dayjs from "dayjs";
-import { gqlRequest, gql } from "../../graphql.js";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
+import { gql, gqlRequest } from "../../graphql.js";
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List available Components";
   static flags = {
     ...ux.table.flags(),

--- a/src/commands/components/publish.ts
+++ b/src/commands/components/publish.ts
@@ -1,6 +1,6 @@
-import { Command, Flags, ux } from "@oclif/core";
+import { Flags, ux } from "@oclif/core";
 
-import { whoAmI } from "../../utils/user/query.js";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import {
   createComponentPackage,
   loadEntrypoint,
@@ -13,8 +13,9 @@ import {
   uploadConnectionIcons,
   uploadFile,
 } from "../../utils/component/publish.js";
+import { whoAmI } from "../../utils/user/query.js";
 
-export default class PublishCommand extends Command {
+export default class PublishCommand extends PrismaticBaseCommand {
   static description = "Publish a Component to Prismatic";
   static flags = {
     comment: Flags.string({

--- a/src/commands/components/signature.ts
+++ b/src/commands/components/signature.ts
@@ -1,15 +1,15 @@
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
 import crypto from "crypto";
-
-import { getPackageSignatureFromApi } from "../../utils/component/signature.js";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { fs } from "../../fs.js";
 import {
   createComponentPackage,
   loadEntrypoint,
   validateDefinition,
 } from "../../utils/component/index.js";
+import { getPackageSignatureFromApi } from "../../utils/component/signature.js";
 
-export default class ComponentsSignatureCommand extends Command {
+export default class ComponentsSignatureCommand extends PrismaticBaseCommand {
   static description = "Generate a Component signature";
 
   static flags = {

--- a/src/commands/components/triggers/list.ts
+++ b/src/commands/components/triggers/list.ts
@@ -1,4 +1,5 @@
-import { Command, ux, Args, Flags } from "@oclif/core";
+import { Args, Flags, ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
 interface TriggerNode {
@@ -9,7 +10,7 @@ interface TriggerNode {
   description: string;
 }
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Triggers that Components implement";
   static flags = {
     ...ux.table.flags(),

--- a/src/commands/customers/create.ts
+++ b/src/commands/customers/create.ts
@@ -1,7 +1,8 @@
-import { Command, Flags } from "@oclif/core";
-import { gqlRequest, gql } from "../../graphql.js";
+import { Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
+import { gql, gqlRequest } from "../../graphql.js";
 
-export default class CreateCommand extends Command {
+export default class CreateCommand extends PrismaticBaseCommand {
   static description = "Create a new Customer";
   static flags = {
     name: Flags.string({

--- a/src/commands/customers/credentials/create.ts
+++ b/src/commands/customers/credentials/create.ts
@@ -1,8 +1,9 @@
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { toValues } from "../../../fields.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class CreateCommand extends Command {
+export default class CreateCommand extends PrismaticBaseCommand {
   static description = "Create a set of Customer-specific Credentials for use by Instance Actions";
 
   static flags = {

--- a/src/commands/customers/credentials/delete.ts
+++ b/src/commands/customers/credentials/delete.ts
@@ -1,7 +1,8 @@
-import { Command, Args } from "@oclif/core";
+import { Args } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class DeleteCommand extends Command {
+export default class DeleteCommand extends PrismaticBaseCommand {
   static description = "Delete a Customer Credential";
   static args = {
     credential: Args.string({

--- a/src/commands/customers/credentials/list.ts
+++ b/src/commands/customers/credentials/list.ts
@@ -1,7 +1,8 @@
-import { Command, Flags, ux } from "@oclif/core";
-import { gqlRequest, gql } from "../../../graphql.js";
+import { Flags, ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
+import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Credentials for a Customer";
   static flags = {
     customer: Flags.string({

--- a/src/commands/customers/credentials/update.ts
+++ b/src/commands/customers/credentials/update.ts
@@ -1,8 +1,9 @@
-import { Command, Args, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { toValues } from "../../../fields.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class UpdateCommand extends Command {
+export default class UpdateCommand extends PrismaticBaseCommand {
   static description = "Update a Customer-specific Credential for use by Instance Actions";
   static args = {
     credential: Args.string({

--- a/src/commands/customers/delete.ts
+++ b/src/commands/customers/delete.ts
@@ -1,7 +1,8 @@
-import { Command, Args } from "@oclif/core";
+import { Args } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { gql, gqlRequest } from "../../graphql.js";
 
-export default class DeleteCommand extends Command {
+export default class DeleteCommand extends PrismaticBaseCommand {
   static description = "Delete a Customer";
   static args = {
     customer: Args.string({

--- a/src/commands/customers/list.ts
+++ b/src/commands/customers/list.ts
@@ -1,7 +1,8 @@
-import { Command, ux } from "@oclif/core";
-import { gqlRequest, gql } from "../../graphql.js";
+import { ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
+import { gql, gqlRequest } from "../../graphql.js";
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List your Customers";
   static flags = { ...ux.table.flags() };
 

--- a/src/commands/customers/update.ts
+++ b/src/commands/customers/update.ts
@@ -1,7 +1,8 @@
-import { Command, Args, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { gql, gqlRequest } from "../../graphql.js";
 
-export default class UpdateCommand extends Command {
+export default class UpdateCommand extends PrismaticBaseCommand {
   // TODO: Add more flags once optional updates are implemented
   static description = "Update a Customer";
   static args = {

--- a/src/commands/customers/users/create.ts
+++ b/src/commands/customers/users/create.ts
@@ -1,7 +1,8 @@
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest, gql } from "../../../graphql.js";
 
-export default class CreateCommand extends Command {
+export default class CreateCommand extends PrismaticBaseCommand {
   static description = "Create a User for the specified Customer";
   static flags = {
     email: Flags.string({

--- a/src/commands/customers/users/delete.ts
+++ b/src/commands/customers/users/delete.ts
@@ -1,7 +1,8 @@
-import { Command, Args } from "@oclif/core";
+import { Args } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class DeleteCommand extends Command {
+export default class DeleteCommand extends PrismaticBaseCommand {
   static description = "Delete a Customer User";
   static args = {
     user: Args.string({

--- a/src/commands/customers/users/list.ts
+++ b/src/commands/customers/users/list.ts
@@ -1,7 +1,8 @@
-import { Command, ux, Args } from "@oclif/core";
+import { Args, ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Customer Users";
   static args = {
     customer: Args.string({

--- a/src/commands/customers/users/roles.ts
+++ b/src/commands/customers/users/roles.ts
@@ -1,7 +1,8 @@
-import { Command, ux } from "@oclif/core";
+import { ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Roles you can grant to Customer Users";
 
   static flags = {

--- a/src/commands/customers/users/update.ts
+++ b/src/commands/customers/users/update.ts
@@ -1,7 +1,8 @@
-import { Command, Args, Flags } from "@oclif/core";
-import { gqlRequest, gql } from "../../../graphql.js";
+import { Args, Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
+import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class UpdateCommand extends Command {
+export default class UpdateCommand extends PrismaticBaseCommand {
   static description = "Update a User";
   static args = {
     user: Args.string({

--- a/src/commands/executions/step-result/get.ts
+++ b/src/commands/executions/step-result/get.ts
@@ -1,10 +1,11 @@
 import { fs } from "../../../fs.js";
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 import axios from "axios";
 import { deserialize, DeserializeResult, parseData } from "../../../utils/execution/stepResults.js";
 
-export default class GetCommand extends Command {
+export default class GetCommand extends PrismaticBaseCommand {
   static description = "Gets the Result of a specified Step in an Instance Execution";
   static flags = {
     executionId: Flags.string({

--- a/src/commands/instances/config-vars/list.ts
+++ b/src/commands/instances/config-vars/list.ts
@@ -1,7 +1,8 @@
-import { Command, ux, Args } from "@oclif/core";
+import { Args, ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Config Variables used on an Instance";
   static args = {
     instance: Args.string({ description: "ID of an instance", required: true }),

--- a/src/commands/instances/create.ts
+++ b/src/commands/instances/create.ts
@@ -1,8 +1,9 @@
-import { Command, Flags } from "@oclif/core";
-import { gqlRequest, gql } from "../../graphql.js";
+import { Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { parseJsonOrUndefined } from "../../fields.js";
+import { gql, gqlRequest } from "../../graphql.js";
 
-export default class CreateCommand extends Command {
+export default class CreateCommand extends PrismaticBaseCommand {
   static description = "Create an Instance";
   static flags = {
     name: Flags.string({

--- a/src/commands/instances/delete.ts
+++ b/src/commands/instances/delete.ts
@@ -1,7 +1,8 @@
-import { Command, Args } from "@oclif/core";
-import { gqlRequest, gql } from "../../graphql.js";
+import { Args } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
+import { gql, gqlRequest } from "../../graphql.js";
 
-export default class DeleteCommand extends Command {
+export default class DeleteCommand extends PrismaticBaseCommand {
   static description = "Delete an Instance";
   static args = {
     instance: Args.string({

--- a/src/commands/instances/deploy.ts
+++ b/src/commands/instances/deploy.ts
@@ -1,7 +1,8 @@
-import { Command, Args, Flags } from "@oclif/core";
-import { gqlRequest, gql } from "../../graphql.js";
+import { Args, Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
+import { gql, gqlRequest } from "../../graphql.js";
 
-export default class DeployCommand extends Command {
+export default class DeployCommand extends PrismaticBaseCommand {
   static description = "Deploy an Instance";
   static args = {
     instance: Args.string({

--- a/src/commands/instances/disable.ts
+++ b/src/commands/instances/disable.ts
@@ -1,7 +1,8 @@
-import { Command, Args } from "@oclif/core";
+import { Args } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { gql, gqlRequest } from "../../graphql.js";
 
-export default class DisableCommand extends Command {
+export default class DisableCommand extends PrismaticBaseCommand {
   static description = "Disable an Instance";
   static args = {
     instance: Args.string({

--- a/src/commands/instances/enable.ts
+++ b/src/commands/instances/enable.ts
@@ -1,7 +1,8 @@
-import { Command, Args } from "@oclif/core";
+import { Args } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { gql, gqlRequest } from "../../graphql.js";
 
-export default class EnableCommand extends Command {
+export default class EnableCommand extends PrismaticBaseCommand {
   static description = "Enable an Instance";
   static args = {
     instance: Args.string({

--- a/src/commands/instances/flow-configs/list.ts
+++ b/src/commands/instances/flow-configs/list.ts
@@ -1,7 +1,8 @@
-import { Command, ux, Args } from "@oclif/core";
+import { Args, ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Instance Flow Configs";
   static args = {
     instance: Args.string({ description: "ID of an Instance", required: true }),

--- a/src/commands/instances/flow-configs/test.ts
+++ b/src/commands/instances/flow-configs/test.ts
@@ -1,5 +1,6 @@
-import { Command, Flags, Args, ux } from "@oclif/core";
-import { gqlRequest, gql } from "../../../graphql.js";
+import { Args, Flags, ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
+import { gql, gqlRequest } from "../../../graphql.js";
 
 interface LogNode {
   [index: string]: unknown;
@@ -14,7 +15,7 @@ interface FetchLogsResult {
   executionComplete: boolean | undefined;
 }
 
-export default class TestCommand extends Command {
+export default class TestCommand extends PrismaticBaseCommand {
   static description = "Test a Flow Config of an Instance";
   static args = {
     flowConfig: Args.string({

--- a/src/commands/instances/list.ts
+++ b/src/commands/instances/list.ts
@@ -1,7 +1,8 @@
-import { Command, Flags, ux } from "@oclif/core";
+import { Flags, ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { gql, gqlRequest } from "../../graphql.js";
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Instances";
   static flags = {
     customer: Flags.string({

--- a/src/commands/instances/update.ts
+++ b/src/commands/instances/update.ts
@@ -1,7 +1,8 @@
-import { Command, Args, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { gql, gqlRequest } from "../../graphql.js";
 
-export default class UpdateCommand extends Command {
+export default class UpdateCommand extends PrismaticBaseCommand {
   // TODO: Add more flags once optional updates are implemented
   static description = "Update an Instance";
   static args = {

--- a/src/commands/integrations/available.ts
+++ b/src/commands/integrations/available.ts
@@ -1,7 +1,8 @@
-import { Command, Args, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { gql, gqlRequest } from "../../graphql.js";
 
-export default class AvailableCommand extends Command {
+export default class AvailableCommand extends PrismaticBaseCommand {
   static description = "Mark an Integration version as available or unavailable";
   static args = {
     integration: Args.string({

--- a/src/commands/integrations/create.ts
+++ b/src/commands/integrations/create.ts
@@ -1,7 +1,8 @@
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { gqlRequest, gql } from "../../graphql.js";
 
-export default class CreateCommand extends Command {
+export default class CreateCommand extends PrismaticBaseCommand {
   static description = "Create an Integration";
   static flags = {
     name: Flags.string({

--- a/src/commands/integrations/delete.ts
+++ b/src/commands/integrations/delete.ts
@@ -1,7 +1,8 @@
-import { Command, Args } from "@oclif/core";
+import { Args } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { gql, gqlRequest } from "../../graphql.js";
 
-export default class DeleteCommand extends Command {
+export default class DeleteCommand extends PrismaticBaseCommand {
   static description = "Delete an Integration";
   static args = {
     integration: Args.string({

--- a/src/commands/integrations/export.ts
+++ b/src/commands/integrations/export.ts
@@ -1,8 +1,9 @@
-import { Command, Args, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { exportDefinition } from "../../utils/integration/export.js";
 import { dumpYaml } from "../../utils/serialize.js";
 
-export default class ExportCommand extends Command {
+export default class ExportCommand extends PrismaticBaseCommand {
   static description = "Export an integration to YAML definition";
 
   static args = {

--- a/src/commands/integrations/flows/list.ts
+++ b/src/commands/integrations/flows/list.ts
@@ -1,7 +1,8 @@
-import { Command, Args, ux } from "@oclif/core";
-import { gqlRequest, gql } from "../../../graphql.js";
+import { Args, ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
+import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Integration Flows";
   static args = {
     integration: Args.string({

--- a/src/commands/integrations/flows/test.ts
+++ b/src/commands/integrations/flows/test.ts
@@ -1,4 +1,5 @@
-import { Command, Flags, Args, ux } from "@oclif/core";
+import { Args, Flags, ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
 interface LogNode {
@@ -14,7 +15,7 @@ interface FetchLogsResult {
   executionComplete: boolean;
 }
 
-export default class TestCommand extends Command {
+export default class TestCommand extends PrismaticBaseCommand {
   static description = "Run a test of an Integration Flow";
   static args = {
     flow: Args.string({ description: "ID of a flow to test", required: true }),

--- a/src/commands/integrations/fork.ts
+++ b/src/commands/integrations/fork.ts
@@ -1,7 +1,8 @@
-import { Command, Args, Flags } from "@oclif/core";
-import { gqlRequest, gql } from "../../graphql.js";
+import { Args, Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
+import { gql, gqlRequest } from "../../graphql.js";
 
-export default class ForkCommand extends Command {
+export default class ForkCommand extends PrismaticBaseCommand {
   static description = "Fork an Integration";
 
   static flags = {

--- a/src/commands/integrations/import.ts
+++ b/src/commands/integrations/import.ts
@@ -1,4 +1,5 @@
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { exists } from "../../fs.js";
 import {
   importYamlIntegration,
@@ -6,7 +7,7 @@ import {
 } from "../../utils/integration/import.js";
 import { openIntegration } from "../../utils/integration/open.js";
 
-export default class ImportCommand extends Command {
+export default class ImportCommand extends PrismaticBaseCommand {
   static description =
     "Import an Integration using a YAML definition file or a Code Native Integration";
   static flags = {

--- a/src/commands/integrations/list.ts
+++ b/src/commands/integrations/list.ts
@@ -1,7 +1,8 @@
-import { Command, Flags, ux } from "@oclif/core";
+import { Flags, ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { gql, gqlRequest } from "../../graphql.js";
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Integrations";
   static flags = {
     ...ux.table.flags(),

--- a/src/commands/integrations/marketplace.ts
+++ b/src/commands/integrations/marketplace.ts
@@ -1,7 +1,8 @@
-import { Command, Args, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { gql, gqlRequest } from "../../graphql.js";
 
-export default class MarketplaceCommand extends Command {
+export default class MarketplaceCommand extends PrismaticBaseCommand {
   static description = "Make a version of an Integration available in the Marketplace";
 
   static args = {

--- a/src/commands/integrations/publish.ts
+++ b/src/commands/integrations/publish.ts
@@ -1,7 +1,8 @@
-import { Command, Args, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { gql, gqlRequest } from "../../graphql.js";
 
-export default class PublishCommand extends Command {
+export default class PublishCommand extends PrismaticBaseCommand {
   static description = "Publish a version of an Integration for use in Instances";
 
   static args = {

--- a/src/commands/integrations/update.ts
+++ b/src/commands/integrations/update.ts
@@ -1,8 +1,9 @@
-import { Command, Args, Flags } from "@oclif/core";
-import { gqlRequest, gql } from "../../graphql.js";
+import { Args, Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { parseJsonOrUndefined } from "../../fields.js";
+import { gql, gqlRequest } from "../../graphql.js";
 
-export default class UpdateCommand extends Command {
+export default class UpdateCommand extends PrismaticBaseCommand {
   static description = "Update an Integration's name or description";
   static args = {
     integration: Args.string({

--- a/src/commands/integrations/versions/index.ts
+++ b/src/commands/integrations/versions/index.ts
@@ -1,7 +1,8 @@
-import { Command, ux, Args, Flags } from "@oclif/core";
+import { Args, Flags, ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Integration versions";
 
   static flags = {

--- a/src/commands/logs/severities/list.ts
+++ b/src/commands/logs/severities/list.ts
@@ -1,7 +1,8 @@
-import { Command, ux } from "@oclif/core";
+import { ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Log Severities for use by Alert Triggers";
   static flags = { ...ux.table.flags() };
 

--- a/src/commands/on-prem-resources/delete.ts
+++ b/src/commands/on-prem-resources/delete.ts
@@ -1,7 +1,8 @@
-import { Command, Args } from "@oclif/core";
+import { Args } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { gqlRequest, gql } from "../../graphql.js";
 
-export default class DeleteCommand extends Command {
+export default class DeleteCommand extends PrismaticBaseCommand {
   static description = "Delete an On-Premise Resource";
   static args = {
     resource: Args.string({

--- a/src/commands/on-prem-resources/list.ts
+++ b/src/commands/on-prem-resources/list.ts
@@ -1,7 +1,8 @@
-import { Command, Flags, ux } from "@oclif/core";
+import { Flags, ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { gql, gqlRequest } from "../../graphql.js";
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List On-Premise Resources";
   static flags = {
     ...ux.table.flags(),

--- a/src/commands/on-prem-resources/registration-jwt.ts
+++ b/src/commands/on-prem-resources/registration-jwt.ts
@@ -1,9 +1,10 @@
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { gqlRequest, gql } from "../../graphql.js";
 
 const onlyWhenOrgUser = "Only valid for Organization users.";
 
-export default class CreateCommand extends Command {
+export default class CreateCommand extends PrismaticBaseCommand {
   static description = "Create a JWT that may be used to register an On-Premise Resource.";
   static flags = {
     customerId: Flags.string({

--- a/src/commands/organization/credentials/create.ts
+++ b/src/commands/organization/credentials/create.ts
@@ -1,8 +1,9 @@
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { toValues } from "../../../fields.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class CreateCommand extends Command {
+export default class CreateCommand extends PrismaticBaseCommand {
   static description = "Create a set of Organization-level Credentials for use by Instance Actions";
 
   static flags = {

--- a/src/commands/organization/credentials/delete.ts
+++ b/src/commands/organization/credentials/delete.ts
@@ -1,7 +1,8 @@
-import { Command, Args } from "@oclif/core";
+import { Args } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class DeleteCommand extends Command {
+export default class DeleteCommand extends PrismaticBaseCommand {
   static description = "Delete an Organization Credential";
   static args = {
     credential: Args.string({

--- a/src/commands/organization/credentials/list.ts
+++ b/src/commands/organization/credentials/list.ts
@@ -1,7 +1,8 @@
-import { Command, ux } from "@oclif/core";
+import { ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Credentials available to the entire Organization";
   static flags = { ...ux.table.flags() };
 

--- a/src/commands/organization/credentials/update.ts
+++ b/src/commands/organization/credentials/update.ts
@@ -1,8 +1,9 @@
-import { Command, Args, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { toValues } from "../../../fields.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class UpdateCommand extends Command {
+export default class UpdateCommand extends PrismaticBaseCommand {
   static description = "Update a Customer-specific Credential for use by Instance Actions";
   static args = {
     credential: Args.string({

--- a/src/commands/organization/signingKeys/delete.ts
+++ b/src/commands/organization/signingKeys/delete.ts
@@ -1,7 +1,8 @@
-import { Command, Args } from "@oclif/core";
+import { Args } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class DeleteCommand extends Command {
+export default class DeleteCommand extends PrismaticBaseCommand {
   static description = "Delete an embedded marketplace signing key";
   static args = {
     signingKeyId: Args.string({

--- a/src/commands/organization/signingKeys/generate.ts
+++ b/src/commands/organization/signingKeys/generate.ts
@@ -1,7 +1,7 @@
-import { Command } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class GenerateCommand extends Command {
+export default class GenerateCommand extends PrismaticBaseCommand {
   static description = "Generate an embedded marketplace signing key";
 
   async run() {

--- a/src/commands/organization/signingKeys/import.ts
+++ b/src/commands/organization/signingKeys/import.ts
@@ -1,8 +1,9 @@
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { readFileSync } from "fs";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class ImportCommand extends Command {
+export default class ImportCommand extends PrismaticBaseCommand {
   static description = "Import a RSA public key for use with embedded marketplace";
 
   static flags = {

--- a/src/commands/organization/signingKeys/list.ts
+++ b/src/commands/organization/signingKeys/list.ts
@@ -1,7 +1,8 @@
-import { Command, ux } from "@oclif/core";
+import { ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List embedded signing keys for embedded marketplace";
   static flags = { ...ux.table.flags() };
 

--- a/src/commands/organization/update.ts
+++ b/src/commands/organization/update.ts
@@ -1,7 +1,8 @@
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { gql, gqlRequest } from "../../graphql.js";
 
-export default class UpdateCommand extends Command {
+export default class UpdateCommand extends PrismaticBaseCommand {
   // TODO: Add more flags once optional updates are implemented
   static description = "Update your Organization";
   static flags = {

--- a/src/commands/organization/updateAvatarUrl.ts
+++ b/src/commands/organization/updateAvatarUrl.ts
@@ -1,7 +1,8 @@
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { gqlRequest, gql } from "../../graphql.js";
 
-export default class UpdateAvatarUrlCommand extends Command {
+export default class UpdateAvatarUrlCommand extends PrismaticBaseCommand {
   // TODO: Add more flags once optional updates are implemented
   static description = "Update your Organization Avatar URL";
 

--- a/src/commands/organization/users/create.ts
+++ b/src/commands/organization/users/create.ts
@@ -1,7 +1,8 @@
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class CreateCommand extends Command {
+export default class CreateCommand extends PrismaticBaseCommand {
   static description = "Create a User for your Organization";
   static flags = {
     name: Flags.string({ char: "n", description: "name of the user" }),

--- a/src/commands/organization/users/delete.ts
+++ b/src/commands/organization/users/delete.ts
@@ -1,7 +1,8 @@
-import { Command, Args } from "@oclif/core";
+import { Args } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class DeleteCommand extends Command {
+export default class DeleteCommand extends PrismaticBaseCommand {
   static description = "Delete an Organization User";
   static args = {
     user: Args.string({

--- a/src/commands/organization/users/list.ts
+++ b/src/commands/organization/users/list.ts
@@ -1,7 +1,8 @@
-import { Command, ux } from "@oclif/core";
+import { ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Users of your Organization";
   static flags = { ...ux.table.flags() };
 

--- a/src/commands/organization/users/roles.ts
+++ b/src/commands/organization/users/roles.ts
@@ -1,7 +1,8 @@
-import { Command, ux } from "@oclif/core";
+import { ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class ListCommand extends Command {
+export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Roles you can grant to other users in your Organization";
 
   static flags = {

--- a/src/commands/organization/users/update.ts
+++ b/src/commands/organization/users/update.ts
@@ -1,7 +1,8 @@
-import { Command, Args, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
 
-export default class UpdateCommand extends Command {
+export default class UpdateCommand extends PrismaticBaseCommand {
   static description = "Update a User";
   static args = {
     user: Args.string({

--- a/src/commands/translations/list.ts
+++ b/src/commands/translations/list.ts
@@ -1,4 +1,5 @@
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 
 import { gqlRequest } from "../../graphql.js";
 import { MarketplaceTranslations } from "../../types.js";
@@ -6,7 +7,7 @@ import { processIntegrationsForTranslations } from "../../utils/translations/pro
 import { GET_MARKETPLACE_INTEGRATIONS_TRANSLATIONS } from "../../queries.graphql.js";
 import { fs } from "../../fs.js";
 
-export default class TranslationsCommand extends Command {
+export default class TranslationsCommand extends PrismaticBaseCommand {
   static description = "Generate Dynamic Phrases for Embedded Marketplace";
   static flags = {
     "output-file": Flags.string({

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -36,6 +36,13 @@ export const gqlRequest = async <T = any>({ document, variables }: GQLRequest): 
   const accessToken = await getAccessToken();
   const url = new URL("/api", prismaticUrl).toString();
 
+  if (process.env.PRISMATIC_PRINT_REQUESTS) {
+    console.log("=================================");
+    console.log(`GraphQL Request: ${document}`);
+    console.log(`Variables: ${JSON.stringify(variables)}`);
+    console.log("=================================");
+  }
+
   const result = await request<T>(url, document, variables, {
     Authorization: `Bearer ${accessToken}`,
     "Prismatic-Client": "prism",


### PR DESCRIPTION
Sometimes, it's handy to see what GraphQL queries and mutations `prism` issues. This adds a new flag, `--print-requests`, to any command that runs a GraphQL query or mutation. When the flag is present, the GraphQL query/mutation along with its variables are logged out.

For example,

```
> prism instances:list --print-requests --customer Q3VzdG9tZXI6YjBmZDAyZTItYmE1OC00NzE0LWJhYzgtMDMwNWM5N2JiY2Vj
=================================
GraphQL Request: 
          query listInstances($customer: ID, $integration: ID, $after: String) {
            instances(
              customer: $customer
              integration: $integration
              isSystem: false
              after: $after
            ) {
              nodes {
                id
                name
                description
                enabled
                customer {
                  id
                  name
                  externalId
                }
              }
              pageInfo {
                hasNextPage
                endCursor
              }
            }
          }
        
Variables: {"customer":"Q3VzdG9tZXI6YjBmZDAyZTItYmE1OC00NzE0LWJhYzgtMDMwNWM5N2JiY2Vj","after":""}
=================================
 Name                     Customer  Description                                                               
 ──────────────────────── ───────── ───────────────────────────────────────────────────────────────────────── 
 PSQL On-Prem             Acme Corp                                                                           
 Salesforce               Acme Corp                                                                           
 My First Integration     Acme Corp Send a Slack message indicating how many to-do items are marked complete. 
 HMAC Test                Acme Corp              
```