### PR TITLE
Bugfix - OpenAPI component init not generating header params properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "7.0.4",
+  "version": "7.1.0",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": ["prismatic", "cli"],
   "homepage": "https://prismatic.io",

--- a/src/generate/formats/readers/openapi/inputs.ts
+++ b/src/generate/formats/readers/openapi/inputs.ts
@@ -152,6 +152,7 @@ export const getInputs = (
   operation: OpenAPIV3.OperationObject | OpenAPIV3_1.OperationObject,
   sharedParameters: ParameterObject[] = [],
 ): {
+  headerInputs: Input[];
   pathInputs: Input[];
   queryInputs: Input[];
   bodyInputs: Input[];
@@ -176,6 +177,10 @@ export const getInputs = (
     }, {}),
   );
 
+  const headerInputs = (parameters ?? [])
+    .filter((p) => p.in === "header")
+    .map((p) => buildInput(p, seenKeys));
+
   const pathInputs = (parameters ?? [])
     .filter((p) => p.in === "path")
     .map((p) => buildInput(p, seenKeys));
@@ -192,6 +197,7 @@ export const getInputs = (
     requestBodySchema === undefined ? [] : buildBodyInputs(requestBodySchema, seenKeys);
 
   return {
+    headerInputs,
     pathInputs,
     queryInputs,
     bodyInputs,


### PR DESCRIPTION
This PR addresses an issue where when initializing a component with an Open API spec JSON file, `header` parameters were not getting carried over into the resulting component code. For example:

```js
{
  // ...
  "/todos/{todoListId}": {
      "get": {
        "operationId": "Get a list of to-do items",
        "parameters": [
          {
            "name": "X-EnvironmentId",
            "in": "header",
            "description": "Allowed values: dev, test or prod",
            "required": true,
            "schema": {
              "type": "string"
            }
          },
          {
            "name": "todoListId",
            "in": "path",
            "description": "List ID",
            "required": true,
            "schema": {
              "type": "string"
            }
          },
          {
            "name": "$filter",
            "in": "query",
            "description": "Filter terms",
            "schema": {
              "type": "string"
            }
          },
  // ...
}
```

Previously in this situation, `todoListId` and `search` would be correctly processed in the resulting component's `perform` methods and `inputs`, but `X-EnvironmentId` would get dropped.

This change makes it so that headers are included in both cases. For example:

```js
  action({
    display: {
      label: "Get a list of to-do items",
      description: "TODO: Description",
    },
    perform: async (
      context,
      { connection, xEnvironmentId, todoListId, filter },
    ) => {
      const client = createClient(connection);
      const { data } = await client.get(
        `/todos/{todoListId}`,
        {
          params: {
            search,
            $filter: filter,
          },
          headers: {
            "X-EnvironmentId": xEnvironmentId,
          }
        },
      );
      return { data };
    },
    inputs: {
      // other inputs...
      xEnvironmentId: input({
        label: "X Environment Id",
        type: "string",
        required: true,
        clean: (value): string => util.types.toString(value),
        comments: "Allowed values: dev, test or prod",
      }),
      // other inputs...
   },
});
```