### PR TITLE
Include connection template field values in components:dev:run output

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "7.1.1",
+  "version": "7.1.2",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": ["prismatic", "cli"],
   "homepage": "https://prismatic.io",


### PR DESCRIPTION
The `prism components:dev:run` command pulls down a test instance connection's values, so you can use them locally. This is handy if you have a basic auth, API key, or OAuth 2.0 connection in a test instance, and you want to use that connection's API key, etc., to test actions locally or to make requests to the third-party app from your machine.

Currently, if you run `prism components:dev:run` and the connection you're fetching leverages a [connection template](https://prismatic.io/docs/connections/#connection-templates), the connection template's fields are omitted from the values you receive back.

![image](https://github.com/user-attachments/assets/a14160d1-41a9-4e7a-b3a0-a50f68505156)

This changes the query the command makes, so that connections' templated values are fetched. Then, templated connection values are merged with other input field values, so the user receives all connection-relevant information.

<img width="957" alt="image" src="https://github.com/user-attachments/assets/339f3362-96f1-4a61-9046-1478f1ec6369">
