### PR TITLE
Format only component-related files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "7.1.4",
+  "version": "7.1.5",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": ["prismatic", "cli"],
   "homepage": "https://prismatic.io",

--- a/src/commands/components/init/index.ts
+++ b/src/commands/components/init/index.ts
@@ -119,6 +119,7 @@ For documentation on writing custom components, visit https://prismatic.io/docs/
     `);
       }
 
+      process.chdir(path.join(cwd, name));
       const filesToFormat = await getFilesToFormat(name);
       await formatSourceFiles(name, filesToFormat);
     } finally {


### PR DESCRIPTION
Depending on if you initialize a component from scratch, from a WSDL, or from an OpenAPI spec, you may be in different directories prior to the file format step. This ensures that you are in your component's base directory prior to formatting typescript files.