### PR TITLE
Template new component connections with new display object

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": ["prismatic", "cli"],
   "homepage": "https://prismatic.io",

--- a/src/commands/components/init/__snapshots__/index.test.ts.snap
+++ b/src/commands/components/init/__snapshots__/index.test.ts.snap
@@ -982,8 +982,10 @@ exports[`component generation tests wsdl - numberconversion should match scaffol
 
 export const myConnection = connection({
   key: "myConnection",
-  label: "My Connection",
-  comments: "This is my connection",
+  display: {
+    label: "My Connection",
+    description: "This is my connection",
+  },
   inputs: {
     username: {
       label: "Username",
@@ -5029,8 +5031,10 @@ exports[`component generation tests wsdl - countryinfoservice should match scaff
 
 export const myConnection = connection({
   key: "myConnection",
-  label: "My Connection",
-  comments: "This is my connection",
+  display: {
+    label: "My Connection",
+    description: "This is my connection",
+  },
   inputs: {
     username: {
       label: "Username",

--- a/templates/connection/basic.ts.ejs
+++ b/templates/connection/basic.ts.ejs
@@ -2,8 +2,10 @@ import { connection } from "@prismatic-io/spectral";
 
 export const <%= connection.key %> = connection({
   key: "<%= connection.key %>",
-  label: "<%= connection.label %>",
-  comments: "<%= connection.comments %>",
+  display: {
+    label: "<%= connection.label %>",
+    description: "<%= connection.comments %>",
+  },
   inputs: {
     username: {
       label: "Username",

--- a/templates/connection/oauth.ts.ejs
+++ b/templates/connection/oauth.ts.ejs
@@ -6,8 +6,10 @@ import {
 
 export const <%= connection.key %> = oauth2Connection({
   key: "<%= connection.key %>",
-  label: "<%= connection.label %>",
-  comments: "<%= connection.comments %>",
+  display: {
+    label: "<%= connection.label %>",
+    description: "<%= connection.comments %>",
+  },
   oauth2Type: OAuth2Type.AuthorizationCode,
   inputs: {
     authorizeUrl: {


### PR DESCRIPTION
Spectral 10.x introduces extended customization for the look-and-feel of a connection defined in a custom component or code-native integration. This adjusts the default connection boilerplate code so that rather than `label` and `comments` properties, the new `display.label` and `display.description` syntax is used in adherence with Spectral 10.x syntax.