### PR TITLE
[Do not merge] Enable integration lookup by stableKey

### DIFF
--- a/src/utils/component/publish.ts
+++ b/src/utils/component/publish.ts
@@ -69,7 +69,14 @@ export const confirmPublish = async (
 };
 
 export const publishDefinition = async (
-  { actions, triggers, dataSources, connections, ...rest }: ComponentDefinition,
+  {
+    actions,
+    triggers,
+    dataSources,
+    connections,
+    codeNativeIntegrationStableKey,
+    ...rest
+  }: ComponentDefinition,
   {
     comment,
     customer,

--- a/src/utils/integration/import.ts
+++ b/src/utils/integration/import.ts
@@ -41,12 +41,13 @@ interface Integration {
 export const importDefinition = async (
   definition: string,
   integrationId?: string,
+  stableKey?: string,
 ): Promise<ImportDefinitionResult> => {
   const result = await gqlRequest({
     document: gql`
-      mutation importIntegration($definition: String!, $integrationId: ID) {
+      mutation importIntegration($definition: String!, $integrationId: ID, $stableKey: String) {
         importIntegration(
-          input: { definition: $definition, integrationId: $integrationId }
+          input: { definition: $definition, integrationId: $integrationId, stableKey: $stableKey }
         ) {
           integration {
             id
@@ -73,6 +74,7 @@ export const importDefinition = async (
     variables: {
       definition,
       integrationId,
+      stableKey,
     },
   });
 
@@ -168,9 +170,11 @@ export const importCodeNativeIntegration = async (integrationId?: string): Promi
   }
 
   ux.action.start("Importing definition for Code Native Integration into Prismatic");
+  const { codeNativeIntegrationStableKey } = componentDefinition;
   const { integrationId: integrationImportId } = await importDefinition(
     integrationDefinition,
     integrationId,
+    codeNativeIntegrationStableKey,
   );
 
   const {


### PR DESCRIPTION
This PR will fail checks until this spectral change is published: https://github.com/prismatic-io/spectral/pull/282

We also cannot merge this until the platform accepts `stableKey` as an optional parameter on the `importIntegration` mutation.