### PR TITLE
Correct docs links

### DIFF
--- a/src/commands/components/publish.mdx
+++ b/src/commands/components/publish.mdx
@@ -1,5 +1,5 @@
 :::note Building Components
-See [writing custom components](custom-components/writing-custom-components.mdx) for information on building components with `webpack`.
+See [writing custom connectors](../custom-connectors/overview.mdx) for information on building components with `webpack`.
 :::
 
 ```bash

--- a/src/commands/customers/users/roles.mdx
+++ b/src/commands/customers/users/roles.mdx
@@ -1,3 +1,3 @@
 :::note Customer User Roles
-Click [here](users.mdx#customer-user-roles) for descriptions of roles that can be assigned to customer users
+Click [here](../customers/customer-users.mdx#customer-user-roles) for descriptions of roles that can be assigned to customer users
 :::

--- a/src/commands/organization/users/create.mdx
+++ b/src/commands/organization/users/create.mdx
@@ -1,5 +1,5 @@
 :::note Organization Roles
-See the [users](users.mdx#organization-users) page for information on roles that users can assume
+See the [users](../configure-prismatic/organization-users.mdx) page for information on roles that users can assume
 :::
 
 ```bash


### PR DESCRIPTION
We're moving some documentation files around to improve discoverability. This updates a few inter-page links. Do not merge until updated docs are published.