### PR TITLE
Wrap example columns flag in double-quotes

### DIFF
--- a/src/commands/alerts/groups/list.mdx
+++ b/src/commands/alerts/groups/list.mdx
@@ -1,4 +1,4 @@
 ```bash
 # Fetch the ID and Name of all alert groups in JSON format, sorted descending by name
-prism alerts:groups:list --columns id,name --output json --sort name
+prism alerts:groups:list --columns "id,name" --output json --sort name
 ```


### PR DESCRIPTION
Trivial PR. It turns out `,` in Windows Powershell is interpreted differently than in a Unix shell. In Windows you need to wrap comma-delimited paramaters in double-quotes.