### PR TITLE
Converter Tool: Pull from configVars in extractComponentList; remove unnecessary query

### DIFF
--- a/src/commands/components/init/index.test.ts
+++ b/src/commands/components/init/index.test.ts
@@ -15,7 +15,7 @@ interface SpecMeta {
 }
 
 describe("component generation tests", () => {
-  const basePath = process.cwd();
+  const basePath = process.env.PWD ?? process.cwd();
   const componentsPath = path.resolve("src/commands/components");
   const tempPath = path.resolve(`${componentsPath}/init/temp`);
 

--- a/src/commands/experimental/yaml/__snapshots__/yaml.test.ts.snap
+++ b/src/commands/experimental/yaml/__snapshots__/yaml.test.ts.snap
@@ -148,6 +148,41 @@ export const configPages = {
           },
         },
       }),
+      "Salesforce Connection": connectionConfigVar({
+        stableKey: "Salesforce Connection",
+        dataType: "connection",
+        connection: {
+          component: "salesforce",
+          key: "oauth2",
+          values: {
+            authorizeUrl: {
+              value: "https://login.salesforce.com/services/oauth2/authorize",
+              permissionAndVisibilityType: "embedded",
+              visibleToOrgDeployer: false,
+            },
+            clientId: {
+              value: "123",
+              permissionAndVisibilityType: "embedded",
+              visibleToOrgDeployer: false,
+            },
+            clientSecret: {
+              value: "456",
+              permissionAndVisibilityType: "embedded",
+              visibleToOrgDeployer: false,
+            },
+            revokeUrl: {
+              value: "https://login.salesforce.com/services/oauth2/revoke",
+              permissionAndVisibilityType: "embedded",
+              visibleToOrgDeployer: false,
+            },
+            tokenUrl: {
+              value: "https://login.salesforce.com/services/oauth2/token",
+              permissionAndVisibilityType: "embedded",
+              visibleToOrgDeployer: false,
+            },
+          },
+        },
+      }),
     },
   }),
   "Config Vars Page": configPage({
@@ -381,6 +416,10 @@ export const loopBranchTests = flow({
 
     const loopNTimes: { data: unknown[] } = { data: [] };
     for (let loopNTimesIdx = 0; loopNTimesIdx < 100; loopNTimesIdx++) {
+      const sleep = await context.components.sleep.sleep({
+        ms: 1000,
+      });
+
       const writeLogMessage2 = await context.components.log.writeLog({
         level: "info",
         message: loopOverItems.data[0],

--- a/src/commands/experimental/yaml/fixtures/specs/test-integration.yaml
+++ b/src/commands/experimental/yaml/fixtures/specs/test-integration.yaml
@@ -3,6 +3,8 @@ configPages:
   - elements:
       - type: configVar
         value: Slack Connection
+      - type: configVar
+        value: Salesforce Connection
     name: Connections Page
     tagline: ''
   - elements:
@@ -347,6 +349,18 @@ flows:
           - action:
               component:
                 isPublic: true
+                key: sleep
+                version: LATEST
+              key: sleep
+            description: ''
+            inputs:
+              ms:
+                type: value
+                value: '1000'
+            name: Sleep
+          - action:
+              component:
+                isPublic: true
                 key: log
                 version: LATEST
               key: writeLog
@@ -552,4 +566,53 @@ requiredConfigVars:
         type: value
         value: 'false'
     key: Slack Channels Data Source
+    orgOnly: false
+  - connection:
+      component:
+        isPublic: true
+        key: salesforce
+        version: LATEST
+      key: oauth2
+    dataType: connection
+    inputs:
+      authorizeUrl:
+        meta:
+          orgOnly: true
+          visibleToCustomerDeployer: false
+          visibleToOrgDeployer: false
+        type: value
+        value: 'https://login.salesforce.com/services/oauth2/authorize'
+      clientId:
+        meta:
+          orgOnly: true
+          visibleToCustomerDeployer: false
+          visibleToOrgDeployer: false
+        type: value
+        value: '123'
+      clientSecret:
+        meta:
+          orgOnly: true
+          visibleToCustomerDeployer: false
+          visibleToOrgDeployer: false
+        type: value
+        value: '456'
+      revokeUrl:
+        meta:
+          orgOnly: true
+          visibleToCustomerDeployer: false
+          visibleToOrgDeployer: false
+        type: value
+        value: 'https://login.salesforce.com/services/oauth2/revoke'
+      tokenUrl:
+        meta:
+          orgOnly: true
+          visibleToCustomerDeployer: false
+          visibleToOrgDeployer: false
+        type: value
+        value: 'https://login.salesforce.com/services/oauth2/token'
+    key: Salesforce Connection
+    meta:
+      visibleToCustomerDeployer: true
+      visibleToOrgDeployer: true
+    onPremiseConnectionConfig: disallowed
     orgOnly: false

--- a/src/commands/experimental/yaml/index.ts
+++ b/src/commands/experimental/yaml/index.ts
@@ -101,7 +101,7 @@ Use "prism integrations:version:download $INTEGRATION_ID" to download a compatib
             context,
           ),
         ),
-        writePackageJson(result.name, usedComponents, registryPrefix),
+        writePackageJson(result.name, usedComponents),
       ]);
 
       const filesToFormat = await getFilesToFormat(folderName);

--- a/src/commands/experimental/yaml/yaml.test.ts
+++ b/src/commands/experimental/yaml/yaml.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, spyOn } from "bun:test";
+import { describe, it, expect } from "bun:test";
 import GenerateIntegrationFromYAMLCommand from "./index.js";
 import fs from "fs";
 import path from "path";
@@ -6,13 +6,9 @@ import { readFile } from "fs-extra";
 import { walkDir } from "../../../fs.js";
 
 const CONVERT_GENERATION_TIMEOUT = 5 * 60 * 5; // 5 minutes
-interface SpecMeta {
-  fileName: string;
-  name: string;
-}
 
 describe("YAML CNI generation tests", () => {
-  const basePath = process.cwd();
+  const basePath = process.env.PWD ?? process.cwd();
   const commandPath = path.resolve("src/commands/experimental/yaml");
   const tempPath = path.resolve(`${commandPath}/temp`);
 

--- a/src/generate/formats/writer/yaml/index.ts
+++ b/src/generate/formats/writer/yaml/index.ts
@@ -32,8 +32,6 @@ type ImportDeclaration = {
   namedImports?: string[];
 };
 
-const EXCLUDED_PUBLIC_COMPONENTS = ["webhook-triggers", "loop"];
-
 export async function writeIntegration(
   integration: IntegrationObjectFromYAML,
   registryPrefix?: string,
@@ -67,12 +65,10 @@ export async function writePackageJson(
   const manifests: Record<string, string> = {};
 
   for (const [key, value] of Object.entries(usedComponents)) {
-    if (!EXCLUDED_PUBLIC_COMPONENTS.includes(key)) {
-      const packageName = `${value.registryPrefix}/${key}`;
-      // @TODO: We have access to the version here, we can eventually
-      // attempt to resolve the package version for them here.
-      manifests[packageName] = "*";
-    }
+    const packageName = `${value.registryPrefix}/${key}`;
+    // @TODO: If we can get access to the signature in the YAML export, we can
+    // eventually support resolving the package version for them here.
+    manifests[packageName] = "*";
   }
 
   await updatePackageJson({
@@ -316,13 +312,11 @@ function writeComponentRegistry(
           writer.writeLine("componentManifests({");
 
           for (const [key, value] of Object.entries(components)) {
-            if (!EXCLUDED_PUBLIC_COMPONENTS.includes(key)) {
-              componentImports.push({
-                moduleSpecifier: `${value.registryPrefix}/${key}`,
-                defaultImport: camelCase(key),
-              });
-              writer.writeLine(`${camelCase(key)},`);
-            }
+            componentImports.push({
+              moduleSpecifier: `${value.registryPrefix}/${key}`,
+              defaultImport: camelCase(key),
+            });
+            writer.writeLine(`${camelCase(key)},`);
           }
 
           writer.writeLine("})");

--- a/src/generate/formats/writer/yaml/utils.test.ts
+++ b/src/generate/formats/writer/yaml/utils.test.ts
@@ -5,8 +5,12 @@ import {
   createFlowInputsString,
   writeLoopString,
   wrapValue,
+  extractComponentList,
 } from "./utils";
 import { SourceFile } from "ts-morph";
+import { load } from "js-yaml";
+import { promises as fs } from "fs";
+import { IntegrationObjectFromYAML } from "./types";
 
 describe("wrapValue", () => {
   it.each([
@@ -406,4 +410,65 @@ describe("writeLoopString", () => {
       expect(writeLoopString(step, file, trigger, loop)).toStrictEqual(expected);
     },
   );
+});
+
+const TEST_YAML_PATH = "src/commands/experimental/yaml/fixtures/specs/test-integration.yaml";
+
+describe("extractComponentList", () => {
+  it("extracts the right list of components", async () => {
+    const basePath = process.env.PWD ?? process.cwd();
+    process.chdir(basePath);
+    console.log("BASE PATH", basePath);
+    const integration = load(
+      await fs.readFile(TEST_YAML_PATH, "utf-8"),
+    ) as IntegrationObjectFromYAML;
+    const result = await extractComponentList(integration);
+    expect(result).toMatchObject({
+      branch: {
+        isPublic: true,
+        registryPrefix: "@component-manifests",
+        version: "LATEST",
+      },
+      code: {
+        isPublic: true,
+        registryPrefix: "@component-manifests",
+        version: "LATEST",
+      },
+      log: {
+        isPublic: true,
+        registryPrefix: "@component-manifests",
+        version: "LATEST",
+      },
+      loop: {
+        isPublic: true,
+        registryPrefix: "@component-manifests",
+        version: "LATEST",
+      },
+      salesforce: {
+        isPublic: true,
+        registryPrefix: "@component-manifests",
+        version: "LATEST",
+      },
+      "schedule-triggers": {
+        isPublic: true,
+        registryPrefix: "@component-manifests",
+        version: "LATEST",
+      },
+      slack: {
+        isPublic: true,
+        registryPrefix: "@component-manifests",
+        version: "LATEST",
+      },
+      sleep: {
+        isPublic: true,
+        registryPrefix: "@component-manifests",
+        version: "LATEST",
+      },
+      "webhook-triggers": {
+        isPublic: true,
+        registryPrefix: "@component-manifests",
+        version: "LATEST",
+      },
+    });
+  });
 });

--- a/src/generate/formats/writer/yaml/utils.test.ts
+++ b/src/generate/formats/writer/yaml/utils.test.ts
@@ -418,7 +418,6 @@ describe("extractComponentList", () => {
   it("extracts the right list of components", async () => {
     const basePath = process.env.PWD ?? process.cwd();
     process.chdir(basePath);
-    console.log("BASE PATH", basePath);
     const integration = load(
       await fs.readFile(TEST_YAML_PATH, "utf-8"),
     ) as IntegrationObjectFromYAML;
@@ -439,11 +438,6 @@ describe("extractComponentList", () => {
         registryPrefix: "@component-manifests",
         version: "LATEST",
       },
-      loop: {
-        isPublic: true,
-        registryPrefix: "@component-manifests",
-        version: "LATEST",
-      },
       salesforce: {
         isPublic: true,
         registryPrefix: "@component-manifests",
@@ -460,11 +454,6 @@ describe("extractComponentList", () => {
         version: "LATEST",
       },
       sleep: {
-        isPublic: true,
-        registryPrefix: "@component-manifests",
-        version: "LATEST",
-      },
-      "webhook-triggers": {
         isPublic: true,
         registryPrefix: "@component-manifests",
         version: "LATEST",

--- a/src/generate/formats/writer/yaml/utils.ts
+++ b/src/generate/formats/writer/yaml/utils.ts
@@ -6,7 +6,6 @@ import {
   ValidComplexYAMLValue,
   ValidYAMLValue,
 } from "./types.js";
-import { gql, gqlRequest } from "../../../../graphql.js";
 import { camelCase, xor } from "lodash-es";
 import { writeBranchString, getBranchKind } from "./branching.js";
 import { SourceFile } from "ts-morph";
@@ -332,6 +331,7 @@ export type UsedComponent = {
 };
 
 const PUBLIC_REGISTRY = "@component-manifests";
+const EXCLUDED_PUBLIC_COMPONENTS = ["webhook-triggers", "loop"];
 
 function _extractComponentData(component: ComponentObjectFromYAML, customRegistry: string) {
   const { key, isPublic, version } = component;
@@ -355,7 +355,7 @@ export async function extractComponentList(
   flows.forEach((flow) => {
     flow.steps.forEach((step) => {
       const { component } = step.action;
-      if (!componentMap[component.key]) {
+      if (!EXCLUDED_PUBLIC_COMPONENTS.includes(component.key)) {
         componentMap[component.key] = _extractComponentData(component, customRegistry);
       }
 
@@ -371,7 +371,7 @@ export async function extractComponentList(
 
     (current ?? []).forEach((step) => {
       const { component } = step.action;
-      if (!componentMap[component.key]) {
+      if (!EXCLUDED_PUBLIC_COMPONENTS.includes(component.key)) {
         componentMap[component.key] = _extractComponentData(component, customRegistry);
       }
 
@@ -385,12 +385,16 @@ export async function extractComponentList(
   requiredConfigVars.forEach((configVar) => {
     if (configVar.dataSource) {
       const { component } = configVar.dataSource;
-      componentMap[component.key] = _extractComponentData(component, customRegistry);
+      if (!EXCLUDED_PUBLIC_COMPONENTS.includes(component.key)) {
+        componentMap[component.key] = _extractComponentData(component, customRegistry);
+      }
     }
 
     if (configVar.connection) {
       const { component } = configVar.connection;
-      componentMap[component.key] = _extractComponentData(component, customRegistry);
+      if (!EXCLUDED_PUBLIC_COMPONENTS.includes(component.key)) {
+        componentMap[component.key] = _extractComponentData(component, customRegistry);
+      }
     }
   });
 


### PR DESCRIPTION
This PR makes some improvements to the `extractComponentList` util that's used by the low-code > CNI converter tool to generate the list of component manifests to install. Previously we only grabbed from flows, now we correctly look through config vars as well (both data sources and connections).

This PR also removes the unnecessary query to check for whether components are public, and generally makes some improvements to the returned data structure to make it more useful than just a list of strings. I also added a test.