### PR TITLE
Allow users to tail logs & step results of a CNI flow's test execution

### DIFF
--- a/src/commands/cni/test/flow.ts
+++ b/src/commands/cni/test/flow.ts
@@ -1,41 +1,62 @@
 import { Flags, ux } from "@oclif/core";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import inquirer from "inquirer";
-import { listIntegrationFlows } from "../../../utils/integration/flows.js";
+import {
+  cniExecutionIsComplete,
+  FetchLogsResult,
+  listExecutionLogs,
+  listExecutionStepResults,
+  listIntegrationFlows,
+  LogNode,
+  StepResultNode,
+} from "../../../utils/integration/flows.js";
 import axios from "axios";
 import { getPrismMetadata } from "../../../utils/integration/metadata.js";
 import { exists, fs } from "../../../fs.js";
+import { decode } from "@msgpack/msgpack";
 
-const MISSING_PARAM_MESSAGE = "You must provide either a flow-url or an integration-id parameter.";
+type FormattedStepResult = {
+  type: string;
+  endedAt: string;
+  result: Record<string, unknown>;
+};
 
+const MISSING_ID_ERROR = "You must provide either a flow-url or an integration-id parameter.";
+const TIMEOUT_MS = 1000 * 60 * 20; // 20 minutes
 export default class CniTestFlowCommand extends PrismaticBaseCommand {
-  static description = "Run a test execution of a CNI flow";
+  private startTime = 0;
 
+  static description = "Run a test execution of a CNI flow";
   static flags = {
     "flow-url": Flags.string({
       char: "u",
-      description: "Invocation URL of the flow to run",
-      required: false,
+      description: "Invocation URL of the flow to run.",
     }),
     "integration-id": Flags.string({
       char: "i",
-      description: "ID of the integration that the flow belongs to",
-      required: false,
-    }),
-    sync: Flags.boolean({
-      char: "s",
-      description: "Forces the flow to run synchronously",
-      required: false,
-    }),
-    "include-execution-id": Flags.boolean({
-      char: "e",
-      description: "Include the execution ID in the response of a synchronous flow execution",
-      required: false,
+      description: "ID of the integration containing the flow to test.",
     }),
     "trigger-payload-file": Flags.string({
       char: "p",
-      description: "A file containing a custom trigger payload to run the flow with",
-      required: false,
+      description: "A file containing a custom trigger payload to run the flow with.",
+    }),
+    sync: Flags.boolean({
+      description: "Forces the flow to run synchronously.",
+    }),
+    "tail-results": Flags.boolean({
+      description: "Tail step results from the test execution until user interrupt or timeout.",
+    }),
+    "tail-logs": Flags.boolean({
+      description: "Tail logs from the test execution until user interrupt or timeout.",
+    }),
+    "auto-end": Flags.boolean({
+      description:
+        "Automatically stop polling activity once an execution completes. Some logs & results may not be returned this way.",
+    }),
+    "result-file": Flags.string({
+      char: "r",
+      description:
+        "A file to append execution result data to. Results are saved as comma-separated values.",
     }),
   };
 
@@ -45,13 +66,16 @@ export default class CniTestFlowCommand extends PrismaticBaseCommand {
         sync,
         "flow-url": flowUrl,
         "integration-id": integrationIdFlag,
-        "include-execution-id": includeExecutionId,
         "trigger-payload-file": triggerPayloadFilePath,
+        "tail-logs": tailLogs,
+        "tail-results": tailStepResults,
+        "auto-end": autoEndPoll,
+        "result-file": resultFilePath,
       },
     } = await this.parse(CniTestFlowCommand);
 
+    // Load custom trigger payload if provided.
     let triggerPayload: Record<string, string> = {};
-
     if (triggerPayloadFilePath) {
       if (await exists(triggerPayloadFilePath)) {
         triggerPayload = JSON.parse(
@@ -65,17 +89,16 @@ export default class CniTestFlowCommand extends PrismaticBaseCommand {
     let integrationId = integrationIdFlag;
     let invokeUrl = flowUrl ?? "";
 
-    // Try to find an integrationId if we were not provided with an ID or
-    // direct invocation URL.
+    // Try to find an integrationId if we were not provided with an ID or invocation URL.
     if (!invokeUrl && !integrationId) {
       try {
         const metadata = await getPrismMetadata();
         integrationId = metadata.integrationId;
       } catch (e) {
-        throw MISSING_PARAM_MESSAGE;
+        throw MISSING_ID_ERROR;
       }
 
-      if (!integrationId) throw MISSING_PARAM_MESSAGE;
+      if (!integrationId) throw MISSING_ID_ERROR;
     }
 
     // Once we have an integrationId, prompt the user to select a flow.
@@ -116,20 +139,217 @@ export default class CniTestFlowCommand extends PrismaticBaseCommand {
     });
     ux.action.stop();
 
+    this.startTime = Date.now();
+
+    const flagString = `${triggerPayloadFilePath ? `-p=${triggerPayloadFilePath} ` : ""}${
+      tailLogs ? "--tail-logs " : ""
+    }${tailStepResults ? "--tail-results " : ""}${sync ? "--sync " : ""}${
+      autoEndPoll ? "--auto-end " : ""
+    }${resultFilePath ? `-r=${resultFilePath} ` : ""}`;
+
     this.log(`
-To re-run this flow, use the command:
-prism cni:test:flow -u=${invokeUrl}
+To re-run this flow directly:
+prism cni:test:flow -u=${invokeUrl} ${flagString}
 `);
 
-    if (includeExecutionId) {
-      this.log(
-        JSON.stringify({
-          data: response.data,
-          executionId: response.headers["prismatic-executionid"],
-        }),
+    const executionId = response.headers["prismatic-executionid"];
+
+    if (!response.data.executionId) {
+      // Log execution ID's separately for synchronously-run flows.
+      this.log(`Execution ID: ${executionId}\n`);
+    }
+
+    // Log the results.
+    this.log(`${JSON.stringify(response.data)}\n`);
+
+    if (!(tailLogs || tailStepResults)) return;
+
+    // If tailing logs or step results, show relevant messaging & setup polling promises.
+    this.warn(
+      "While the timestamps are accurate, logs & step results may not arrive in chronological order.",
+    );
+    this.log(
+      `\nPress CMD+C/CTRL+C to stop polling. ${
+        autoEndPoll ? "" : "This process will timeout after 20 minutes."
+      }\n`,
+    );
+
+    if (resultFilePath) {
+      fs.appendFile(resultFilePath, "timestamp,type,data\n");
+    }
+
+    const tailPromises = [];
+    const startTime = Date.now();
+
+    if (tailLogs) tailPromises.push(this.tailLogs(executionId, startTime));
+    if (tailStepResults) tailPromises.push(this.tailStepResults(executionId, startTime));
+
+    await Promise.all(tailPromises);
+  }
+
+  private async tailLogs(executionId: string, startTime: number) {
+    const {
+      flags: { "auto-end": autoEndPoll, "result-file": resultFilePath },
+    } = await this.parse(CniTestFlowCommand);
+
+    let nextCursor: string | undefined = undefined;
+
+    while (true) {
+      await ux.wait(this.getPollIntervalMs());
+
+      const result: any = await this.fetchLogs(executionId, nextCursor);
+      if (result === undefined) continue;
+
+      const { logs, cursor } = result;
+      nextCursor = cursor;
+
+      ux.table(
+        logs,
+        {
+          timestamp: {},
+          severity: {
+            minWidth: 15,
+          },
+          message: {},
+        },
+        {
+          "no-header": true,
+        },
       );
+
+      if (resultFilePath) {
+        for (const log of logs) {
+          fs.appendFile(resultFilePath, `${log.timestamp},${log.severity},${log.message}\n`);
+        }
+      }
+
+      if (await this.shouldEnd(executionId, autoEndPoll)) {
+        return;
+      }
+    }
+  }
+
+  private async tailStepResults(executionId: string, startTime: number) {
+    const {
+      flags: { "auto-end": autoEndPoll, "result-file": resultFilePath },
+    } = await this.parse(CniTestFlowCommand);
+
+    let nextCursor: string | undefined = undefined;
+
+    while (true) {
+      await ux.wait(this.getPollIntervalMs());
+
+      const result: any = await this.fetchStepResults(executionId, nextCursor);
+      if (result === undefined) {
+        continue;
+      }
+
+      const { stepResults, cursor } = result;
+      nextCursor = cursor;
+
+      ux.table(
+        stepResults,
+        {
+          endedAt: {},
+          type: {
+            minWidth: 15,
+          },
+          result: {},
+        },
+        {
+          "no-header": true,
+        },
+      );
+
+      if (resultFilePath) {
+        for (const result of stepResults) {
+          fs.appendFile(
+            resultFilePath,
+            `${result.endedAt},${result.type},${JSON.stringify(result.result)}\n`,
+          );
+        }
+      }
+
+      if (await this.shouldEnd(executionId, autoEndPoll)) {
+        return;
+      }
+    }
+  }
+
+  private async fetchLogs(
+    executionId: string,
+    nextCursor?: string,
+  ): Promise<FetchLogsResult | undefined> {
+    const results = await listExecutionLogs(executionId, nextCursor);
+
+    const { edges }: { edges: { node: LogNode; cursor?: string }[] } = results.logs;
+    if (!edges || edges.length === 0) {
+      return undefined;
+    }
+
+    const logs = edges.map(({ node }) => node);
+
+    const { cursor } = edges[edges.length - 1];
+    return { logs, cursor };
+  }
+
+  private async fetchStepResults(executionId: string, nextCursor?: string) {
+    const results = await listExecutionStepResults(executionId, nextCursor);
+
+    const { edges }: { edges: { node: StepResultNode; cursor?: string }[] } =
+      results.executionResult.stepResults;
+
+    if (!edges || edges.length === 0) {
+      return undefined;
+    }
+
+    const stepResults: Array<FormattedStepResult> = [];
+
+    for (const edge of edges) {
+      const { endedAt, resultsUrl, stepName } = edge.node;
+
+      const response = await axios.get(resultsUrl, {
+        responseType: "arraybuffer",
+      });
+      const resultsBuffer = Buffer.from(await response.data);
+      const result = decode(resultsBuffer) as Record<string, unknown>;
+
+      stepResults.push({
+        type: stepName === "onTrigger" ? "RESULT_TRIGGER" : "RESULT_FLOW",
+        endedAt,
+        result,
+      });
+    }
+
+    const { cursor } = edges[edges.length - 1];
+    return { stepResults, cursor };
+  }
+
+  private async executionIsComplete(executionId: string) {
+    return await cniExecutionIsComplete(executionId);
+  }
+
+  private async shouldEnd(executionId: string, autoEndPoll: boolean) {
+    return (
+      Date.now() - this.startTime > TIMEOUT_MS ||
+      (autoEndPoll && (await this.executionIsComplete(executionId)))
+    );
+  }
+
+  private getPollIntervalMs() {
+    const timeElapsed = this.startTime - Date.now();
+    if (timeElapsed < 30000) {
+      // every 1s for first 30s
+      return 1000;
+    } else if (timeElapsed < 60000) {
+      // every 5s for 30s-1min
+      return 5000;
+    } else if (timeElapsed < 300000) {
+      // every 30s for 1min-5min
+      return 30000;
     } else {
-      this.log(JSON.stringify(response.data));
+      // every 1min for 5min+
+      return 60000;
     }
   }
 }

--- a/src/commands/integrations/flows/test.ts
+++ b/src/commands/integrations/flows/test.ts
@@ -1,19 +1,7 @@
 import { Args, Flags, ux } from "@oclif/core";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gql, gqlRequest } from "../../../graphql.js";
-
-interface LogNode {
-  [index: string]: unknown;
-  timestamp: string;
-  severity: string;
-  message: string;
-}
-
-interface FetchLogsResult {
-  logs: LogNode[];
-  cursor: string | undefined;
-  executionComplete: boolean;
-}
+import { FetchLogsResult, LogNode } from "../../../utils/integration/flows.js";
 
 export default class TestCommand extends PrismaticBaseCommand {
   static description = "Run a test of an Integration Flow";

--- a/src/utils/integration/flows.ts
+++ b/src/utils/integration/flows.ts
@@ -50,3 +50,95 @@ export async function listIntegrationFlows(integrationId: string) {
 
   return flows;
 }
+
+export interface LogNode {
+  [index: string]: unknown;
+  timestamp: string;
+  severity: string;
+  message: string;
+}
+
+export interface FetchLogsResult {
+  logs: LogNode[];
+  cursor: string | undefined;
+  executionComplete?: boolean;
+}
+
+export async function listExecutionLogs(executionId: string, nextCursor?: string) {
+  return await gqlRequest({
+    document: gql`
+      query listExecutionLogs($executionId: ID!, $nextCursor: String) {
+        logs(
+          executionResult: $executionId
+          after: $nextCursor
+          orderBy: { field: TIMESTAMP, direction: ASC }
+        ) {
+          edges {
+            node {
+              timestamp
+              severity
+              message
+            }
+            cursor
+          }
+        }
+      }
+    `,
+    variables: {
+      executionId,
+      nextCursor,
+    },
+  });
+}
+
+export interface StepResultNode {
+  [index: string]: unknown;
+  stepName: string;
+  endedAt: string;
+  resultsUrl: string;
+}
+
+export async function listExecutionStepResults(executionId: string, nextCursor?: string) {
+  return await gqlRequest({
+    document: gql`
+      query listExecutionStepResults($executionId: ID!, $nextCursor: String) {
+        executionResult(id: $executionId) {
+          stepResults(after: $nextCursor, orderBy: { field: ENDED_AT, direction: ASC }) {
+            edges {
+              node {
+                stepName
+                endedAt
+                resultsUrl
+              }
+              cursor
+            }
+            totalCount
+          }
+        }
+      }
+    `,
+    variables: {
+      executionId,
+      nextCursor,
+    },
+  });
+}
+
+export async function cniExecutionIsComplete(executionId: string) {
+  const result = await gqlRequest({
+    document: gql`
+      query cniExecutionIsComplete($executionId: ID!) {
+        executionResult(id: $executionId) {
+          stepResults {
+            totalCount
+          }
+        }
+      }
+    `,
+    variables: {
+      executionId,
+    },
+  });
+
+  return result.executionResult.stepResults.totalCount === 2;
+}


### PR DESCRIPTION
# Additions
* `--tail-logs` and `--tail-results`, which can be used with `--result-file` to save the results to a file
* The tail options will run until user interrupt or a 20min timeout, whichever comes first. `--auto-end` will force the process to stop after detecting the execution is complete, even if logs/results may be dropped as a result
* Polling interval drop-offs after 30s, 1min, and 5min break points

# Demo
![cni_tail_demo](https://github.com/user-attachments/assets/95bdbb30-99d1-41c1-8d82-b1fea4d3de8f)