### PR TITLE
Fix EEXIT 0 errors when successfully early terminating prism commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "7.3.1",
+  "version": "7.3.2",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": ["prismatic", "cli"],
   "homepage": "https://prismatic.io",

--- a/src/commands/components/publish.ts
+++ b/src/commands/components/publish.ts
@@ -101,12 +101,15 @@ export default class PublishCommand extends PrismaticBaseCommand {
         ) {
           // Signatures match and we've opted to skip on match, so bail.
           ux.log("Package signatures match, skipping publish.");
-          ux.exit(0);
+          return;
         }
       }
     }
 
-    await confirmPublish(definition, confirm);
+    const shouldPublish = await confirmPublish(definition, confirm);
+    if (!shouldPublish) {
+      return;
+    }
 
     const { iconUploadUrl, packageUploadUrl, connectionIconUploadUrls, versionNumber } =
       await publishDefinition(definition, {

--- a/src/commands/login.ts
+++ b/src/commands/login.ts
@@ -34,6 +34,5 @@ export default class LoginCommand extends Command {
     await login({ url });
 
     this.log("Login complete!");
-    process.exit(0);
   }
 }

--- a/src/utils/component/publish.ts
+++ b/src/utils/component/publish.ts
@@ -59,13 +59,12 @@ export const checkPackageSignature = async (
 export const confirmPublish = async (
   { display: { label, description } }: ComponentDefinition,
   confirm = true,
-) => {
-  if (!confirm) return;
+): Promise<boolean> => {
+  if (!confirm) return true;
 
   ux.log(label, "-", description);
 
-  const continuePublish = await ux.confirm(`Would you like to publish ${label}? (y/N)`);
-  if (!continuePublish) ux.exit(0);
+  return await ux.confirm(`Would you like to publish ${label}? (y/N)`);
 };
 
 export const publishDefinition = async (


### PR DESCRIPTION
This occurred primarily during component publishes as you able to avoid duplicate publishes by skipping publish if signatures match. This change makes that actually return "successfully" instead of producing the `EEXIT 0` error.