### PR TITLE
Fix: Ensure helpful log line are not consumed by stdout to ensure scripting compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "7.4.2",
+  "version": "7.4.3",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": ["prismatic", "cli"],
   "homepage": "https://prismatic.io",

--- a/src/baseCommand.ts
+++ b/src/baseCommand.ts
@@ -10,5 +10,15 @@ export abstract class PrismaticBaseCommand extends Command {
         return input;
       },
     }),
+    quiet: Flags.boolean({
+      description: "Reduce helpful notes and text",
+      helpGroup: "GLOBAL",
+      required: false,
+      default: false,
+      parse: async (input) => {
+        process.env.PRISM_QUIET = `${input}`;
+        return input;
+      },
+    }),
   };
 }

--- a/src/utils/integration/metadata.ts
+++ b/src/utils/integration/metadata.ts
@@ -38,7 +38,7 @@ export async function writePrismMetadata(
   const file = await fs.writeFile(metadataPath, JSON.stringify(metadata));
 
   if (!alreadyExists) {
-    console.log(`
+    console.warn(`
 [NOTE] A metadata file has been added at .spectral/prism.json to improve local developer experience.
 If you are managing your integration via git, feel free to add this to your .gitignore.
 `);

--- a/src/utils/integration/metadata.ts
+++ b/src/utils/integration/metadata.ts
@@ -37,7 +37,7 @@ export async function writePrismMetadata(
   const alreadyExists = await exists(metadataPath);
   const file = await fs.writeFile(metadataPath, JSON.stringify(metadata));
 
-  if (!alreadyExists) {
+  if (!alreadyExists && !process.env.PRISM_QUIET) {
     console.warn(`
 [NOTE] A metadata file has been added at .spectral/prism.json to improve local developer experience.
 If you are managing your integration via git, feel free to add this to your .gitignore.


### PR DESCRIPTION
Suppose you build a bash or PowerShell script that takes the output of one command and passes it to another command as a parameter. For example,

```
export INTEGRATION_ID=$(prism integrations:import)
prism integrations:publish $INTEGRATION_ID
```

If you run this script, and the first command outputs an additional log line like `[NOTE] A metadata file has been added at .spectral/prism.json to improve local developer experience. If you are managing your integration via git, feel free to add this to your .gitignore.`, then your second command will attempt to run a command like 

```
prism integrations:publish [NOTE] A metadata file has been added at .spectral/prism.json to improve local developer experience. If you are managing your integration via git, feel free to add this to your .gitignore. SW5EXAMPLE
```

That's obviously not desirable.

What you really want is for extra notes from your first command to appear, but be written to `stderr` rather than `stdout`, so the note isn't consumed by your variable assignment.

This updates a log line in our integrations:import command so that it outputs to `stderr` rather than `stdout`.