### PR TITLE
Low-code converter: Do not wrap connection boolean values in quotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "7.5.0",
+  "version": "7.5.1",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": ["prismatic", "cli"],
   "homepage": "https://prismatic.io",

--- a/src/commands/integrations/convert/__snapshots__/convert.test.ts.snap
+++ b/src/commands/integrations/convert/__snapshots__/convert.test.ts.snap
@@ -114,7 +114,7 @@ export const configPages = {
               visibleToOrgDeployer: false,
             },
             isUser: {
-              value: "false",
+              value: false,
               permissionAndVisibilityType: "organization",
               visibleToOrgDeployer: false,
             },

--- a/src/generate/formats/writer/yaml/index.ts
+++ b/src/generate/formats/writer/yaml/index.ts
@@ -392,7 +392,10 @@ function writeConfigPages(project: Project, integration: IntegrationObjectFromYA
                       )
                       .conditionalWriteLine(
                         input.type !== "configVar",
-                        `value: ${formatInputValue(input.value, true)},`,
+                        `value: ${formatInputValue(input.value, {
+                          boolean: false,
+                          number: true,
+                        })},`,
                       )
                       .conditionalWriteLine(
                         Boolean(input.meta.permissionAndVisibilityType),

--- a/src/generate/formats/writer/yaml/utils.ts
+++ b/src/generate/formats/writer/yaml/utils.ts
@@ -33,15 +33,15 @@ export function valueIsBoolean(value: unknown) {
  * or nothing depending on the case. */
 export function formatInputValue(
   value: ValidYAMLValue | ValidComplexYAMLValue | undefined,
-  forceWrap?: boolean,
+  forceWrap: { boolean?: boolean; number?: boolean } = { boolean: false, number: false },
 ) {
-  if (valueIsBoolean(value) && !forceWrap) {
+  if (valueIsBoolean(value) && !forceWrap.boolean) {
     const formattedValue = typeof value === "string" ? value.toLowerCase() : value;
     // Boolean-like values shouldn't be wrapped
     return formattedValue;
   } else if (value === "" || (!value && value !== false && value !== 0)) {
     return `""`;
-  } else if (valueIsNumber(value) && !forceWrap) {
+  } else if (valueIsNumber(value) && !forceWrap.number) {
     // Number-like values shouldn't be wrapped
     return value;
   } else if (typeof value === "string" && value.indexOf("\n") >= 0) {
@@ -237,10 +237,10 @@ export function createFlowInputsString(
     } else if (input.type === "template") {
       currentInputString += `${convertTemplateInput(input.value as string, trigger, loop)},`;
     } else {
-      const forceWrap =
-        (typeof input.value === "string" || valueIsNumber(input.value)) &&
-        !valueIsBoolean(input.value);
-      currentInputString += `${formatInputValue(input.value as ValidYAMLValue, forceWrap)},`;
+      currentInputString += `${formatInputValue(input.value as ValidYAMLValue, {
+        boolean: false,
+        number: true,
+      })},`;
     }
 
     if (action.isTrigger) {


### PR DESCRIPTION
Taylor discovered an issue where connection values that are booleans should not be stringified, otherwise they fail typechecking.

This PR makes that fix, as well as updates the params for `formatInputValues` slightly so we are able to be more specific about when we want numbers and booleans to be wrapped as strings.