### PR TITLE
Support --replace flag on integration:import

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "7.5.2",
+  "version": "7.5.3",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": ["prismatic", "cli"],
   "homepage": "https://prismatic.io",

--- a/src/utils/integration/import.test.ts
+++ b/src/utils/integration/import.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "bun:test";
+import { compareConfigVars } from "./import.js";
+
+describe("compareConfigVars", () => {
+  it("should correctly identify missing config vars", async () => {
+    const originalYAML = `
+      configPages:
+        - elements:
+            - value: "configVar1"
+            - value: "missingVar"
+    `;
+
+    const newYAML = `
+      configPages:
+        - elements:
+            - value: "configVar1"
+    `;
+
+    const missingVars = await compareConfigVars(originalYAML, newYAML);
+    expect(missingVars).toEqual(["missingVar"]);
+  });
+});


### PR DESCRIPTION
This PR makes it so that users can replace existing integrations with a CNI or YAML file, regardless of the original integration's code native state.

For example, if a user ran the converter tool, they may want to replace their existing low-code integration with their new low code version. To do so, they can navigate to their CNI project & then run:

```bash
prism integrations:import -i=<SOME_ID> -r
```

They will be prompted at the following points:
* If the incoming integration is missing any config vars that the original integration defined, they will be warned & shown a list of the missing config var keys (config page parentage does not matter)
* Before import, they will be reminded that the existing draft version will be blown away by the incoming import.

This command also works with YAML files, e.g.:

```bash
prism integrations:import -i=<SOME_ID> -r --path=./some_yaml_file.yaml
```