### PR TITLE
Bugfix: integrations:flows:test throws error if sync flow responds with no data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "7.5.5",
+  "version": "7.5.6",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": ["prismatic", "cli"],
   "homepage": "https://prismatic.io",

--- a/src/commands/integrations/flows/test.ts
+++ b/src/commands/integrations/flows/test.ts
@@ -266,7 +266,7 @@ prism integrations:flows:test -u=${invokeUrl} ${flagString}
 
     const executionId = response.headers["prismatic-executionid"];
 
-    if (!response.data.executionId) {
+    if (!response.data || !response.data.executionId) {
       // Log execution ID's separately for synchronously-run flows.
       this.log(`Execution ID: ${executionId}\n`);
     }

--- a/src/commands/integrations/flows/test.ts
+++ b/src/commands/integrations/flows/test.ts
@@ -266,7 +266,7 @@ prism integrations:flows:test -u=${invokeUrl} ${flagString}
 
     const executionId = response.headers["prismatic-executionid"];
 
-    if (!response.data || !response.data.executionId) {
+    if (!response?.data?.executionId) {
       // Log execution ID's separately for synchronously-run flows.
       this.log(`Execution ID: ${executionId}\n`);
     }


### PR DESCRIPTION
If a sync flow doesn't return any data, then this line throws an unhandled error trying to access `response.data.executionId`.