### PR TITLE
Add `organization:connections:list`; make --json flag global

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "7.6.1",
+  "version": "7.7.0",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": ["prismatic", "cli"],
   "homepage": "https://prismatic.io",

--- a/src/baseCommand.ts
+++ b/src/baseCommand.ts
@@ -20,5 +20,14 @@ export abstract class PrismaticBaseCommand extends Command {
         return input;
       },
     }),
+    json: Flags.boolean({
+      description: "Output in JSON format",
+      helpGroup: "GLOBAL",
+      default: false,
+    }),
   };
+
+  protected logJsonOutput(data: any): void {
+    this.log(JSON.stringify(data, null, 2));
+  }
 }

--- a/src/commands/alerts/events/list.ts
+++ b/src/commands/alerts/events/list.ts
@@ -11,6 +11,7 @@ export default class ListCommand extends PrismaticBaseCommand {
     }),
   };
   static flags = {
+    ...PrismaticBaseCommand.baseFlags,
     ...ux.table.flags(),
   };
 
@@ -43,23 +44,27 @@ export default class ListCommand extends PrismaticBaseCommand {
       },
     });
 
-    ux.table(
-      result.alertEvents.nodes,
-      {
-        id: {
-          minWidth: 8,
-          extended: true,
+    if (flags.json) {
+      this.logJsonOutput(result.alertEvents.nodes);
+    } else {
+      ux.table(
+        result.alertEvents.nodes,
+        {
+          id: {
+            minWidth: 8,
+            extended: true,
+          },
+          name: {
+            get: (row: any) => row.monitor.name,
+            header: "Name",
+          },
+          createdAt: {
+            header: "Timestamp",
+          },
+          details: {},
         },
-        name: {
-          get: (row: any) => row.monitor.name,
-          header: "Name",
-        },
-        createdAt: {
-          header: "Timestamp",
-        },
-        details: {},
-      },
-      { ...flags },
-    );
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/alerts/groups/list.ts
+++ b/src/commands/alerts/groups/list.ts
@@ -4,7 +4,7 @@ import { gql, gqlRequest } from "../../../graphql.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Alert Groups in your Organization";
-  static flags = { ...ux.table.flags() };
+  static flags = { ...PrismaticBaseCommand.baseFlags, ...ux.table.flags() };
 
   async run() {
     const { flags } = await this.parse(ListCommand);
@@ -38,16 +38,20 @@ export default class ListCommand extends PrismaticBaseCommand {
       hasNextPage = pageInfo.hasNextPage;
     }
 
-    ux.table(
-      alertGroups,
-      {
-        id: {
-          minWidth: 8,
-          extended: true,
+    if (flags.json) {
+      this.logJsonOutput(alertGroups);
+    } else {
+      ux.table(
+        alertGroups,
+        {
+          id: {
+            minWidth: 8,
+            extended: true,
+          },
+          name: {},
         },
-        name: {},
-      },
-      { ...flags },
-    );
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/alerts/monitors/list.ts
+++ b/src/commands/alerts/monitors/list.ts
@@ -4,7 +4,7 @@ import { gqlRequest, gql } from "../../../graphql.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Alert Monitors for Customer Instances";
-  static flags = { ...ux.table.flags() };
+  static flags = { ...PrismaticBaseCommand.baseFlags, ...ux.table.flags() };
 
   async run() {
     const { flags } = await this.parse(ListCommand);
@@ -47,26 +47,30 @@ export default class ListCommand extends PrismaticBaseCommand {
       hasNextPage = pageInfo.hasNextPage;
     }
 
-    ux.table(
-      alertMonitors,
-      {
-        id: {
-          minWidth: 8,
-          extended: true,
+    if (flags.json) {
+      this.logJsonOutput(alertMonitors);
+    } else {
+      ux.table(
+        alertMonitors,
+        {
+          id: {
+            minWidth: 8,
+            extended: true,
+          },
+          name: {},
+          triggered: {},
+          customer: {
+            get: ({ instance: { customer } }) => customer.name,
+          },
+          customerId: {
+            extended: true,
+            get: ({ instance: { customer } }) => customer.id,
+          },
+          instance: { get: ({ instance }) => instance.name },
+          instanceId: { extended: true, get: ({ instance }) => instance.id },
         },
-        name: {},
-        triggered: {},
-        customer: {
-          get: ({ instance: { customer } }) => customer.name,
-        },
-        customerId: {
-          extended: true,
-          get: ({ instance: { customer } }) => customer.id,
-        },
-        instance: { get: ({ instance }) => instance.name },
-        instanceId: { extended: true, get: ({ instance }) => instance.id },
-      },
-      { ...flags },
-    );
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/alerts/triggers/list.ts
+++ b/src/commands/alerts/triggers/list.ts
@@ -4,7 +4,7 @@ import { gqlRequest, gql } from "../../../graphql.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Alert Triggers";
-  static flags = { ...ux.table.flags() };
+  static flags = { ...PrismaticBaseCommand.baseFlags, ...ux.table.flags() };
 
   async run() {
     const { flags } = await this.parse(ListCommand);
@@ -22,16 +22,20 @@ export default class ListCommand extends PrismaticBaseCommand {
       `,
     });
 
-    ux.table(
-      result.alertTriggers.nodes,
-      {
-        id: {
-          minWidth: 8,
-          extended: true,
+    if (flags.json) {
+      this.logJsonOutput(result.alertTriggers.nodes);
+    } else {
+      ux.table(
+        result.alertTriggers.nodes,
+        {
+          id: {
+            minWidth: 8,
+            extended: true,
+          },
+          name: {},
         },
-        name: {},
-      },
-      { ...flags },
-    );
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/alerts/webhooks/list.ts
+++ b/src/commands/alerts/webhooks/list.ts
@@ -4,7 +4,7 @@ import { gqlRequest, gql } from "../../../graphql.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Alert Webhooks";
-  static flags = { ...ux.table.flags() };
+  static flags = { ...PrismaticBaseCommand.baseFlags, ...ux.table.flags() };
 
   async run() {
     const { flags } = await this.parse(ListCommand);
@@ -41,26 +41,30 @@ export default class ListCommand extends PrismaticBaseCommand {
       hasNextPage = pageInfo.hasNextPage;
     }
 
-    ux.table(
-      alertWebhooks,
-      {
-        id: {
-          minWidth: 8,
-          extended: true,
+    if (flags.json) {
+      this.logJsonOutput(alertWebhooks);
+    } else {
+      ux.table(
+        alertWebhooks,
+        {
+          id: {
+            minWidth: 8,
+            extended: true,
+          },
+          name: {},
+          url: {
+            extended: true,
+          },
+          headers: {
+            extended: true,
+          },
+          payloadTemplate: {
+            header: "Payload Template",
+            extended: true,
+          },
         },
-        name: {},
-        url: {
-          extended: true,
-        },
-        headers: {
-          extended: true,
-        },
-        payloadTemplate: {
-          header: "Payload Template",
-          extended: true,
-        },
-      },
-      { ...flags },
-    );
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/components/actions/list.ts
+++ b/src/commands/components/actions/list.ts
@@ -13,6 +13,7 @@ interface ActionNode {
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Actions that Components implement";
   static flags = {
+    ...PrismaticBaseCommand.baseFlags,
     ...ux.table.flags(),
     public: Flags.boolean({
       required: false,
@@ -94,29 +95,33 @@ export default class ListCommand extends PrismaticBaseCommand {
       hasNextPage = component.actions.pageInfo.hasNextPage;
     }
 
-    ux.table(
-      actions,
-      {
-        id: {
-          minWidth: 8,
-          extended: true,
+    if (flags.json) {
+      this.logJsonOutput(actions);
+    } else {
+      ux.table(
+        actions,
+        {
+          id: {
+            minWidth: 8,
+            extended: true,
+          },
+          key: {
+            minWidth: 10,
+            extended: true,
+          },
+          label: {},
+          description: {},
+          componentid: {
+            get: () => componentId,
+            extended: true,
+          },
+          componentkey: {
+            get: () => componentKey,
+            extended: true,
+          },
         },
-        key: {
-          minWidth: 10,
-          extended: true,
-        },
-        label: {},
-        description: {},
-        componentid: {
-          get: () => componentId,
-          extended: true,
-        },
-        componentkey: {
-          get: () => componentKey,
-          extended: true,
-        },
-      },
-      { ...flags },
-    );
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/components/data-sources/list.ts
+++ b/src/commands/components/data-sources/list.ts
@@ -15,6 +15,7 @@ interface DataSourceNode {
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Data Sources that Components implement";
   static flags = {
+    ...PrismaticBaseCommand.baseFlags,
     ...ux.table.flags(),
     public: Flags.boolean({
       required: false,
@@ -106,34 +107,38 @@ export default class ListCommand extends PrismaticBaseCommand {
       hasNextPage = component.actions.pageInfo.hasNextPage;
     }
 
-    ux.table(
-      dataSources,
-      {
-        id: {
-          minWidth: 8,
-          extended: true,
+    if (flags.json) {
+      this.logJsonOutput(dataSources);
+    } else {
+      ux.table(
+        dataSources,
+        {
+          id: {
+            minWidth: 8,
+            extended: true,
+          },
+          key: {
+            minWidth: 10,
+            extended: true,
+          },
+          label: {},
+          description: {},
+          dataSourceType: { header: "Type" },
+          detailDataSource: {
+            header: "Detail Data Source",
+            extended: true,
+          },
+          componentid: {
+            get: () => componentId,
+            extended: true,
+          },
+          componentkey: {
+            get: () => componentKey,
+            extended: true,
+          },
         },
-        key: {
-          minWidth: 10,
-          extended: true,
-        },
-        label: {},
-        description: {},
-        dataSourceType: { header: "Type" },
-        detailDataSource: {
-          header: "Detail Data Source",
-          extended: true,
-        },
-        componentid: {
-          get: () => componentId,
-          extended: true,
-        },
-        componentkey: {
-          get: () => componentKey,
-          extended: true,
-        },
-      },
-      { ...flags },
-    );
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/components/list.ts
+++ b/src/commands/components/list.ts
@@ -6,6 +6,7 @@ import { gql, gqlRequest } from "../../graphql.js";
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List available Components";
   static flags = {
+    ...PrismaticBaseCommand.baseFlags,
     ...ux.table.flags(),
     showAllVersions: Flags.boolean({
       char: "a",
@@ -62,41 +63,45 @@ export default class ListCommand extends PrismaticBaseCommand {
       hasNextPage = pageInfo.hasNextPage;
     }
 
-    ux.table(
-      components,
-      {
-        id: {
-          minWidth: 8,
-          extended: true,
+    if (flags.json) {
+      this.logJsonOutput(components);
+    } else {
+      ux.table(
+        components,
+        {
+          id: {
+            minWidth: 8,
+            extended: true,
+          },
+          key: {
+            minWidth: 10,
+            extended: true,
+          },
+          label: {},
+          public: {},
+          description: {},
+          versionNumber: { header: "Version" },
+          versionCreatedAt: {
+            header: "Last Published",
+            extended: true,
+            get: ({ versionCreatedAt }) => dayjs(versionCreatedAt).format(),
+          },
+          category: { get: ({ category }) => category || "" },
+          customerId: {
+            extended: true,
+            get: ({ customer }) => customer?.id ?? "",
+          },
+          customerName: {
+            extended: true,
+            get: ({ customer }) => customer?.name ?? "",
+          },
+          customerExternalId: {
+            extended: true,
+            get: ({ customer }) => customer?.externalId ?? "",
+          },
         },
-        key: {
-          minWidth: 10,
-          extended: true,
-        },
-        label: {},
-        public: {},
-        description: {},
-        versionNumber: { header: "Version" },
-        versionCreatedAt: {
-          header: "Last Published",
-          extended: true,
-          get: ({ versionCreatedAt }) => dayjs(versionCreatedAt).format(),
-        },
-        category: { get: ({ category }) => category || "" },
-        customerId: {
-          extended: true,
-          get: ({ customer }) => customer?.id ?? "",
-        },
-        customerName: {
-          extended: true,
-          get: ({ customer }) => customer?.name ?? "",
-        },
-        customerExternalId: {
-          extended: true,
-          get: ({ customer }) => customer?.externalId ?? "",
-        },
-      },
-      { ...flags },
-    );
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/components/triggers/list.ts
+++ b/src/commands/components/triggers/list.ts
@@ -13,6 +13,7 @@ interface TriggerNode {
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Triggers that Components implement";
   static flags = {
+    ...PrismaticBaseCommand.baseFlags,
     ...ux.table.flags(),
     public: Flags.boolean({
       required: false,
@@ -94,29 +95,33 @@ export default class ListCommand extends PrismaticBaseCommand {
       hasNextPage = component.actions.pageInfo.hasNextPage;
     }
 
-    ux.table(
-      triggers,
-      {
-        id: {
-          minWidth: 8,
-          extended: true,
+    if (flags.json) {
+      this.logJsonOutput(triggers);
+    } else {
+      ux.table(
+        triggers,
+        {
+          id: {
+            minWidth: 8,
+            extended: true,
+          },
+          key: {
+            minWidth: 10,
+            extended: true,
+          },
+          label: {},
+          description: {},
+          componentid: {
+            get: () => componentId,
+            extended: true,
+          },
+          componentkey: {
+            get: () => componentKey,
+            extended: true,
+          },
         },
-        key: {
-          minWidth: 10,
-          extended: true,
-        },
-        label: {},
-        description: {},
-        componentid: {
-          get: () => componentId,
-          extended: true,
-        },
-        componentkey: {
-          get: () => componentKey,
-          extended: true,
-        },
-      },
-      { ...flags },
-    );
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/customers/credentials/list.ts
+++ b/src/commands/customers/credentials/list.ts
@@ -10,6 +10,7 @@ export default class ListCommand extends PrismaticBaseCommand {
       required: true,
       description: "ID of a customer",
     }),
+    ...PrismaticBaseCommand.baseFlags,
     ...ux.table.flags(),
   };
 
@@ -40,23 +41,27 @@ export default class ListCommand extends PrismaticBaseCommand {
       },
     });
 
-    ux.table(
-      result.customer.credentials.nodes,
-      {
-        id: {
-          minWidth: 8,
-          extended: true,
+    if (flags.json) {
+      this.logJsonOutput(result.customer.credentials.nodes);
+    } else {
+      ux.table(
+        result.customer.credentials.nodes,
+        {
+          id: {
+            minWidth: 8,
+            extended: true,
+          },
+          label: {},
+          authorizationMethod: {
+            header: "Authorization Method",
+            get: (row: any) => row.authorizationMethod.label,
+          },
+          readyForUse: {
+            header: "Ready for Use",
+          },
         },
-        label: {},
-        authorizationMethod: {
-          header: "Authorization Method",
-          get: (row: any) => row.authorizationMethod.label,
-        },
-        readyForUse: {
-          header: "Ready for Use",
-        },
-      },
-      { ...flags },
-    );
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/customers/list.ts
+++ b/src/commands/customers/list.ts
@@ -4,7 +4,7 @@ import { gql, gqlRequest } from "../../graphql.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List your Customers";
-  static flags = { ...ux.table.flags() };
+  static flags = { ...PrismaticBaseCommand.baseFlags, ...ux.table.flags() };
 
   async run() {
     const { flags } = await this.parse(ListCommand);
@@ -40,21 +40,25 @@ export default class ListCommand extends PrismaticBaseCommand {
       hasNextPage = pageInfo.hasNextPage;
     }
 
-    ux.table(
-      customers,
-      {
-        id: {
-          minWidth: 8,
-          extended: true,
+    if (flags.json) {
+      this.logJsonOutput(customers);
+    } else {
+      ux.table(
+        customers,
+        {
+          id: {
+            minWidth: 8,
+            extended: true,
+          },
+          externalId: {
+            extended: true,
+            get: ({ externalId }) => externalId || "",
+          },
+          name: {},
+          description: {},
         },
-        externalId: {
-          extended: true,
-          get: ({ externalId }) => externalId || "",
-        },
-        name: {},
-        description: {},
-      },
-      { ...flags },
-    );
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/customers/users/list.ts
+++ b/src/commands/customers/users/list.ts
@@ -12,6 +12,7 @@ export default class ListCommand extends PrismaticBaseCommand {
   };
 
   static flags = {
+    ...PrismaticBaseCommand.baseFlags,
     ...ux.table.flags(),
   };
 
@@ -59,22 +60,26 @@ export default class ListCommand extends PrismaticBaseCommand {
       hasNextPage = pageInfo.hasNextPage;
     }
 
-    ux.table(
-      customerUsers,
-      {
-        id: {
-          minWidth: 8,
-          extended: true,
+    if (flags.json) {
+      this.logJsonOutput(customerUsers);
+    } else {
+      ux.table(
+        customerUsers,
+        {
+          id: {
+            minWidth: 8,
+            extended: true,
+          },
+          name: {},
+          email: {},
+          role: { get: ({ role: { name } }) => name },
+          externalId: {
+            extended: true,
+            get: ({ externalId }) => externalId || "",
+          },
         },
-        name: {},
-        email: {},
-        role: { get: ({ role: { name } }) => name },
-        externalId: {
-          extended: true,
-          get: ({ externalId }) => externalId || "",
-        },
-      },
-      { ...flags },
-    );
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/customers/users/roles.ts
+++ b/src/commands/customers/users/roles.ts
@@ -6,6 +6,7 @@ export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Roles you can grant to Customer Users";
 
   static flags = {
+    ...PrismaticBaseCommand.baseFlags,
     ...ux.table.flags(),
   };
 
@@ -24,17 +25,21 @@ export default class ListCommand extends PrismaticBaseCommand {
       `,
     });
 
-    ux.table(
-      result.customerRoles,
-      {
-        id: {
-          minWidth: 8,
-          extended: true,
+    if (flags.json) {
+      this.log(JSON.stringify(result.customerRoles, null, 2));
+    } else {
+      ux.table(
+        result.customerRoles,
+        {
+          id: {
+            minWidth: 8,
+            extended: true,
+          },
+          name: {},
+          description: {},
         },
-        name: {},
-        description: {},
-      },
-      { ...flags },
-    );
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/instances/config-vars/list.ts
+++ b/src/commands/instances/config-vars/list.ts
@@ -9,6 +9,7 @@ export default class ListCommand extends PrismaticBaseCommand {
   };
 
   static flags = {
+    ...PrismaticBaseCommand.baseFlags,
     ...ux.table.flags(),
   };
 
@@ -67,32 +68,36 @@ export default class ListCommand extends PrismaticBaseCommand {
       hasNextPage = pageInfo.hasNextPage;
     }
 
-    ux.table(
-      configVariables,
-      {
-        id: {
-          minWidth: 8,
-          extended: true,
+    if (flags.json) {
+      this.logJsonOutput(configVariables);
+    } else {
+      ux.table(
+        configVariables,
+        {
+          id: {
+            minWidth: 8,
+            extended: true,
+          },
+          requiredVariableId: {
+            get: (row: any) => row.requiredConfigVariable.id,
+            extended: true,
+          },
+          key: {
+            get: (row: any) => row.requiredConfigVariable.key,
+          },
+          value: {
+            get: (row: any) =>
+              row.requiredConfigVariable.dataType === "CONNECTION" ? row.inputs : row.value,
+          },
+          defaultValue: {
+            get: (row: any) =>
+              row.requiredConfigVariable.dataType === "CONNECTION"
+                ? ""
+                : row.requiredConfigVariable.defaultValue,
+          },
         },
-        requiredVariableId: {
-          get: (row: any) => row.requiredConfigVariable.id,
-          extended: true,
-        },
-        key: {
-          get: (row: any) => row.requiredConfigVariable.key,
-        },
-        value: {
-          get: (row: any) =>
-            row.requiredConfigVariable.dataType === "CONNECTION" ? row.inputs : row.value,
-        },
-        defaultValue: {
-          get: (row: any) =>
-            row.requiredConfigVariable.dataType === "CONNECTION"
-              ? ""
-              : row.requiredConfigVariable.defaultValue,
-        },
-      },
-      { ...flags },
-    );
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/instances/flow-configs/list.ts
+++ b/src/commands/instances/flow-configs/list.ts
@@ -8,6 +8,7 @@ export default class ListCommand extends PrismaticBaseCommand {
     instance: Args.string({ description: "ID of an Instance", required: true }),
   };
   static flags = {
+    ...PrismaticBaseCommand.baseFlags,
     ...ux.table.flags(),
   };
 
@@ -56,21 +57,25 @@ export default class ListCommand extends PrismaticBaseCommand {
       hasNextPage = pageInfo.hasNextPage;
     }
 
-    ux.table(
-      flowConfigs,
-      {
-        id: {
-          minWidth: 8,
-          extended: true,
+    if (flags.json) {
+      this.logJsonOutput(flowConfigs);
+    } else {
+      ux.table(
+        flowConfigs,
+        {
+          id: {
+            minWidth: 8,
+            extended: true,
+          },
+          name: {
+            get: (row: any) => row.flow.name,
+          },
+          webhookUrl: {
+            extended: true,
+          },
         },
-        name: {
-          get: (row: any) => row.flow.name,
-        },
-        webhookUrl: {
-          extended: true,
-        },
-      },
-      { ...flags },
-    );
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/instances/list.ts
+++ b/src/commands/instances/list.ts
@@ -5,6 +5,8 @@ import { gql, gqlRequest } from "../../graphql.js";
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Instances";
   static flags = {
+    ...PrismaticBaseCommand.baseFlags,
+    ...ux.table.flags(),
     customer: Flags.string({
       char: "c",
       required: false,
@@ -15,7 +17,6 @@ export default class ListCommand extends PrismaticBaseCommand {
       required: false,
       description: "ID of an integration",
     }),
-    ...ux.table.flags(),
   };
 
   async run() {
@@ -67,29 +68,33 @@ export default class ListCommand extends PrismaticBaseCommand {
       hasNextPage = pageInfo.hasNextPage;
     }
 
-    ux.table(
-      instances,
-      {
-        id: {
-          minWidth: 8,
-          extended: true,
+    if (flags.json) {
+      this.logJsonOutput(instances);
+    } else {
+      ux.table(
+        instances,
+        {
+          id: {
+            minWidth: 8,
+            extended: true,
+          },
+          name: {},
+          customer: {
+            get: ({ customer }) => customer.name,
+          },
+          customerid: {
+            get: ({ customer }) => customer.id,
+            extended: true,
+          },
+          customerExternalId: {
+            get: ({ customer }) => customer.externalId || "",
+            extended: true,
+          },
+          description: {},
+          enabled: { extended: true },
         },
-        name: {},
-        customer: {
-          get: ({ customer }) => customer.name,
-        },
-        customerid: {
-          get: ({ customer }) => customer.id,
-          extended: true,
-        },
-        customerExternalId: {
-          get: ({ customer }) => customer.externalId || "",
-          extended: true,
-        },
-        description: {},
-        enabled: { extended: true },
-      },
-      { ...flags },
-    );
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/integrations/flows/list.ts
+++ b/src/commands/integrations/flows/list.ts
@@ -11,6 +11,7 @@ export default class ListCommand extends PrismaticBaseCommand {
     }),
   };
   static flags = {
+    ...PrismaticBaseCommand.baseFlags,
     ...ux.table.flags(),
   };
 
@@ -22,18 +23,22 @@ export default class ListCommand extends PrismaticBaseCommand {
 
     const flows = await getIntegrationFlows(integration);
 
-    ux.table(
-      flows,
-      {
-        id: {
-          minWidth: 8,
-          extended: true,
+    if (flags.json) {
+      this.logJsonOutput(flows);
+    } else {
+      ux.table(
+        flows,
+        {
+          id: {
+            minWidth: 8,
+            extended: true,
+          },
+          name: {},
+          description: {},
+          testUrl: { header: "Test URL", extended: true },
         },
-        name: {},
-        description: {},
-        testUrl: { header: "Test URL", extended: true },
-      },
-      { ...flags },
-    );
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/integrations/flows/test.ts
+++ b/src/commands/integrations/flows/test.ts
@@ -48,6 +48,7 @@ export default class TestFlowCommand extends PrismaticBaseCommand {
 
   static description = "Run a test execution of a flow";
   static flags = {
+    ...PrismaticBaseCommand.baseFlags,
     "flow-url": Flags.string({
       char: "u",
       description: "Invocation URL of the flow to run.",
@@ -86,9 +87,6 @@ export default class TestFlowCommand extends PrismaticBaseCommand {
       char: "r",
       description:
         "Optional file to append tailed execution result data to. Results are saved into JSON Lines.",
-    }),
-    jsonl: Flags.boolean({
-      description: "Optionally format the step and tail results output into JSON Lines.",
     }),
     debug: Flags.boolean({
       description: "Enables debug mode on the test execution.",
@@ -311,7 +309,7 @@ prism integrations:flows:test -u=${invokeUrl} ${flagString}
 
   private async tailLogs(executionId: string) {
     const {
-      flags: { "cni-auto-end": autoEndPoll, "result-file": resultFilePath, timeout, jsonl },
+      flags: { "cni-auto-end": autoEndPoll, "result-file": resultFilePath, timeout, json },
     } = await this.parse(TestFlowCommand);
 
     let nextCursor: string | undefined = undefined;
@@ -325,7 +323,7 @@ prism integrations:flows:test -u=${invokeUrl} ${flagString}
       const { logs, cursor } = result;
       nextCursor = cursor;
 
-      if (jsonl) {
+      if (json) {
         logs.forEach((result) => {
           this.log(JSON.stringify(result));
         });
@@ -360,7 +358,7 @@ prism integrations:flows:test -u=${invokeUrl} ${flagString}
 
   private async tailStepResults(executionId: string) {
     const {
-      flags: { "cni-auto-end": autoEndPoll, "result-file": resultFilePath, timeout, jsonl },
+      flags: { "cni-auto-end": autoEndPoll, "result-file": resultFilePath, timeout, json },
     } = await this.parse(TestFlowCommand);
 
     let nextCursor: string | undefined = undefined;
@@ -376,7 +374,7 @@ prism integrations:flows:test -u=${invokeUrl} ${flagString}
       const { stepResults, cursor } = result;
       nextCursor = cursor;
 
-      if (jsonl) {
+      if (json) {
         stepResults.forEach((result) => {
           this.log(JSON.stringify(result));
         });

--- a/src/commands/integrations/list.ts
+++ b/src/commands/integrations/list.ts
@@ -5,6 +5,7 @@ import { gql, gqlRequest } from "../../graphql.js";
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Integrations";
   static flags = {
+    ...PrismaticBaseCommand.baseFlags,
     ...ux.table.flags(),
     showAllVersions: Flags.boolean({
       char: "a",
@@ -79,29 +80,33 @@ export default class ListCommand extends PrismaticBaseCommand {
       hasNextPage = pageInfo.hasNextPage;
     }
 
-    ux.table(
-      integrations,
-      {
-        id: {
-          minWidth: 8,
-          extended: true,
+    if (flags.json) {
+      this.logJsonOutput(integrations);
+    } else {
+      ux.table(
+        integrations,
+        {
+          id: {
+            minWidth: 8,
+            extended: true,
+          },
+          name: {},
+          description: {},
+          versionNumber: { header: "Version" },
+          labels: { extended: true },
+          category: { extended: true },
+          customerId: { extended: true, get: (row) => row.customer?.id ?? "" },
+          customerName: {
+            extended: true,
+            get: (row) => row.customer?.name ?? "",
+          },
+          customerExternalId: {
+            extended: true,
+            get: (row) => row.customer?.externalId ?? "",
+          },
         },
-        name: {},
-        description: {},
-        versionNumber: { header: "Version" },
-        labels: { extended: true },
-        category: { extended: true },
-        customerId: { extended: true, get: (row) => row.customer?.id ?? "" },
-        customerName: {
-          extended: true,
-          get: (row) => row.customer?.name ?? "",
-        },
-        customerExternalId: {
-          extended: true,
-          get: (row) => row.customer?.externalId ?? "",
-        },
-      },
-      { ...flags },
-    );
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/integrations/versions/index.ts
+++ b/src/commands/integrations/versions/index.ts
@@ -6,6 +6,7 @@ export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Integration versions";
 
   static flags = {
+    ...PrismaticBaseCommand.baseFlags,
     ...ux.table.flags(),
     "latest-available": Flags.boolean({
       char: "l",
@@ -60,35 +61,39 @@ export default class ListCommand extends PrismaticBaseCommand {
       },
     });
 
-    ux.table(
-      result.integration.versionSequence.nodes,
-      {
-        versionNumber: {
-          header: "Version",
+    if (flags.json) {
+      this.log(JSON.stringify(result.integration.versionSequence.nodes, null, 2));
+    } else {
+      ux.table(
+        result.integration.versionSequence.nodes,
+        {
+          versionNumber: {
+            header: "Version",
+          },
+          id: {
+            header: "ID",
+            get: (row: any) => row.id,
+            extended: true,
+          },
+          versionCreatedAt: {
+            header: "Created At",
+            get: (row: any) => new Date(row.versionCreatedAt).toISOString(),
+          },
+          versionCreatedBy: {
+            header: "Created By",
+            get: (row: any) => row.versionCreatedBy?.email ?? "",
+          },
+          versionComment: {
+            header: "Comment",
+            get: (row: any) => row.versionComment ?? "",
+          },
+          available: {
+            header: "Available",
+            get: (row: any) => row.versionIsAvailable,
+          },
         },
-        id: {
-          header: "ID",
-          get: (row: any) => row.id,
-          extended: true,
-        },
-        versionCreatedAt: {
-          header: "Created At",
-          get: (row: any) => new Date(row.versionCreatedAt).toISOString(),
-        },
-        versionCreatedBy: {
-          header: "Created By",
-          get: (row: any) => row.versionCreatedBy?.email ?? "",
-        },
-        versionComment: {
-          header: "Comment",
-          get: (row: any) => row.versionComment ?? "",
-        },
-        available: {
-          header: "Available",
-          get: (row: any) => row.versionIsAvailable,
-        },
-      },
-      { ...flags },
-    );
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/logs/severities/list.ts
+++ b/src/commands/logs/severities/list.ts
@@ -4,7 +4,10 @@ import { gql, gqlRequest } from "../../../graphql.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Log Severities for use by Alert Triggers";
-  static flags = { ...ux.table.flags() };
+  static flags = {
+    ...PrismaticBaseCommand.baseFlags,
+    ...ux.table.flags(),
+  };
 
   async run() {
     const { flags } = await this.parse(ListCommand);
@@ -20,16 +23,20 @@ export default class ListCommand extends PrismaticBaseCommand {
       `,
     });
 
-    ux.table(
-      result.logSeverityLevels,
-      {
-        id: {
-          minWidth: 8,
-          extended: true,
+    if (flags.json) {
+      this.logJsonOutput(result.logSeverityLevels);
+    } else {
+      ux.table(
+        result.logSeverityLevels,
+        {
+          id: {
+            minWidth: 8,
+            extended: true,
+          },
+          name: {},
         },
-        name: {},
-      },
-      { ...flags },
-    );
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/on-prem-resources/list.ts
+++ b/src/commands/on-prem-resources/list.ts
@@ -5,6 +5,7 @@ import { gql, gqlRequest } from "../../graphql.js";
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List On-Premise Resources";
   static flags = {
+    ...PrismaticBaseCommand.baseFlags,
     ...ux.table.flags(),
     customer: Flags.string({
       char: "c",
@@ -55,24 +56,32 @@ export default class ListCommand extends PrismaticBaseCommand {
       hasNextPage = pageInfo.hasNextPage;
     }
 
-    ux.table(
-      onPremiseResources,
-      {
-        id: {
-          minWidth: 8,
-          extended: true,
+    if (flags.json) {
+      this.logJsonOutput(onPremiseResources);
+    } else {
+      ux.table(
+        onPremiseResources,
+        {
+          id: {
+            minWidth: 8,
+            extended: true,
+          },
+          name: {},
+          customerId: {
+            header: "Customer ID",
+            extended: true,
+            get: (row) => row.customer?.id ?? "",
+          },
+          status: { get: (row) => row.status ?? "" },
+          customer: { get: (row) => row.customer?.name ?? "" },
+          customerExternalId: {
+            header: "Customer External ID",
+            extended: true,
+            get: (row) => row.customer?.externalId ?? "",
+          },
         },
-        name: {},
-        customerId: { header: "Customer ID", extended: true, get: (row) => row.customer?.id ?? "" },
-        status: { get: (row) => row.status ?? "" },
-        customer: { get: (row) => row.customer?.name ?? "" },
-        customerExternalId: {
-          header: "Customer External ID",
-          extended: true,
-          get: (row) => row.customer?.externalId ?? "",
-        },
-      },
-      { ...flags },
-    );
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/organization/connections/list.ts
+++ b/src/commands/organization/connections/list.ts
@@ -1,0 +1,81 @@
+import { Flags, ux } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
+import { gql, gqlRequest } from "../../../graphql.js";
+
+export default class ListCommand extends PrismaticBaseCommand {
+  static description = "List all integration-agnostic connections available to the organization";
+  static flags = {
+    ...PrismaticBaseCommand.baseFlags,
+    ...ux.table.flags(),
+    "managed-by": Flags.string({
+      description: "Filter connections by management type",
+      options: ["org", "customer"],
+    }),
+  };
+
+  async run() {
+    const { flags } = await this.parse(ListCommand);
+
+    const result = await gqlRequest({
+      document: gql`
+        query availableConnections($managedBy: String) {
+          scopedConfigVariables(managedBy: $managedBy) {
+            nodes {
+              stableKey
+              description
+              managedBy
+              customer {
+                externalId
+                name
+              }
+              connection {
+                component {
+                  key
+                }
+              }
+            }
+          }
+        }
+      `,
+      variables: {
+        managedBy: flags["managed-by"] || null,
+      },
+    });
+
+    const connections = result.scopedConfigVariables.nodes;
+
+    if (flags.json) {
+      this.logJsonOutput(connections);
+    } else {
+      ux.table(
+        connections,
+        {
+          stableKey: {
+            header: "Stable Key",
+            minWidth: 20,
+          },
+          description: {
+            header: "Description",
+            minWidth: 30,
+          },
+          managedBy: {
+            header: "Managed By",
+            minWidth: 12,
+          },
+          customer: {
+            header: "Customer",
+            get: (row: any) =>
+              row.customer ? `${row.customer.name} (${row.customer.externalId})` : "N/A",
+            minWidth: 25,
+          },
+          component: {
+            header: "Component",
+            get: (row: any) => row.connection?.component?.key || "N/A",
+            minWidth: 20,
+          },
+        },
+        { ...flags },
+      );
+    }
+  }
+}

--- a/src/commands/organization/credentials/list.ts
+++ b/src/commands/organization/credentials/list.ts
@@ -4,7 +4,10 @@ import { gql, gqlRequest } from "../../../graphql.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Credentials available to the entire Organization";
-  static flags = { ...ux.table.flags() };
+  static flags = {
+    ...PrismaticBaseCommand.baseFlags,
+    ...ux.table.flags(),
+  };
 
   async run() {
     const { flags } = await this.parse(ListCommand);
@@ -29,23 +32,27 @@ export default class ListCommand extends PrismaticBaseCommand {
       `,
     });
 
-    ux.table(
-      result.organization.credentials.nodes,
-      {
-        id: {
-          minWidth: 8,
-          extended: true,
+    if (flags.json) {
+      this.logJsonOutput(result.organization.credentials.nodes);
+    } else {
+      ux.table(
+        result.organization.credentials.nodes,
+        {
+          id: {
+            minWidth: 8,
+            extended: true,
+          },
+          label: {},
+          authorizationMethod: {
+            header: "Authorization Method",
+            get: (row: any) => row.authorizationMethod.label,
+          },
+          readyForUse: {
+            header: "Ready for Use",
+          },
         },
-        label: {},
-        authorizationMethod: {
-          header: "Authorization Method",
-          get: (row: any) => row.authorizationMethod.label,
-        },
-        readyForUse: {
-          header: "Ready for Use",
-        },
-      },
-      { ...flags },
-    );
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/organization/signingKeys/list.ts
+++ b/src/commands/organization/signingKeys/list.ts
@@ -4,7 +4,10 @@ import { gql, gqlRequest } from "../../../graphql.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List embedded signing keys for embedded marketplace";
-  static flags = { ...ux.table.flags() };
+  static flags = {
+    ...PrismaticBaseCommand.baseFlags,
+    ...ux.table.flags(),
+  };
 
   async run() {
     const { flags } = await this.parse(ListCommand);
@@ -27,16 +30,20 @@ export default class ListCommand extends PrismaticBaseCommand {
       `,
     });
 
-    ux.table(
-      result.organization.signingKeys.nodes,
-      {
-        id: { minWidth: 8, extended: true },
-        privateKeyPreview: { header: "Private Key Preview" },
-        publicKey: { header: "Public Key", extended: true },
-        issuedAt: { header: "Timestamp" },
-        imported: { header: "Imported?" },
-      },
-      { ...flags },
-    );
+    if (flags.json) {
+      this.logJsonOutput(result.organization.signingKeys.nodes);
+    } else {
+      ux.table(
+        result.organization.signingKeys.nodes,
+        {
+          id: { minWidth: 8, extended: true },
+          privateKeyPreview: { header: "Private Key Preview" },
+          publicKey: { header: "Public Key", extended: true },
+          issuedAt: { header: "Timestamp" },
+          imported: { header: "Imported?" },
+        },
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/organization/users/list.ts
+++ b/src/commands/organization/users/list.ts
@@ -4,7 +4,10 @@ import { gql, gqlRequest } from "../../../graphql.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Users of your Organization";
-  static flags = { ...ux.table.flags() };
+  static flags = {
+    ...PrismaticBaseCommand.baseFlags,
+    ...ux.table.flags(),
+  };
 
   async run() {
     const { flags } = await this.parse(ListCommand);
@@ -48,24 +51,28 @@ export default class ListCommand extends PrismaticBaseCommand {
       hasNextPage = pageInfo.hasNextPage;
     }
 
-    ux.table(
-      customerUsers,
-      {
-        id: {
-          minWidth: 8,
-          extended: true,
+    if (flags.json) {
+      this.logJsonOutput(customerUsers);
+    } else {
+      ux.table(
+        customerUsers,
+        {
+          id: {
+            minWidth: 8,
+            extended: true,
+          },
+          name: {},
+          email: {},
+          phone: {},
+          role: {
+            get: ({ role }) => role.name,
+          },
+          externalId: {
+            get: ({ externalId }) => externalId || "",
+          },
         },
-        name: {},
-        email: {},
-        phone: {},
-        role: {
-          get: ({ role }) => role.name,
-        },
-        externalId: {
-          get: ({ externalId }) => externalId || "",
-        },
-      },
-      { ...flags },
-    );
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/organization/users/roles.ts
+++ b/src/commands/organization/users/roles.ts
@@ -6,6 +6,7 @@ export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Roles you can grant to other users in your Organization";
 
   static flags = {
+    ...PrismaticBaseCommand.baseFlags,
     ...ux.table.flags(),
   };
 
@@ -24,17 +25,21 @@ export default class ListCommand extends PrismaticBaseCommand {
       `,
     });
 
-    ux.table(
-      result.organizationRoles,
-      {
-        id: {
-          minWidth: 8,
-          extended: true,
+    if (flags.json) {
+      this.log(JSON.stringify(result.organizationRoles, null, 2));
+    } else {
+      ux.table(
+        result.organizationRoles,
+        {
+          id: {
+            minWidth: 8,
+            extended: true,
+          },
+          name: {},
+          description: {},
         },
-        name: {},
-        description: {},
-      },
-      { ...flags },
-    );
+        { ...flags },
+      );
+    }
   }
 }

--- a/src/commands/translations/list.ts
+++ b/src/commands/translations/list.ts
@@ -10,6 +10,7 @@ import { fs } from "../../fs.js";
 export default class TranslationsCommand extends PrismaticBaseCommand {
   static description = "Generate Dynamic Phrases for Embedded Marketplace";
   static flags = {
+    ...PrismaticBaseCommand.baseFlags,
     "output-file": Flags.string({
       required: false,
       char: "o",

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,6 +74,7 @@ import IntegrationsInitCommand from "./commands/integrations/init/index.js";
 import IntegrationsVersionsCommand from "./commands/integrations/versions/index.js";
 import LogsSeveritiesListCommand from "./commands/logs/severities/list.js";
 import MeTokenRevokeCommand from "./commands/me/token/revoke.js";
+import OrganizationConnectionsListCommand from "./commands/organization/connections/list.js";
 import OrganizationCredentialsCreateCommand from "./commands/organization/credentials/create.js";
 import OrganizationCredentialsDeleteCommand from "./commands/organization/credentials/delete.js";
 import OrganizationCredentialsListCommand from "./commands/organization/credentials/list.js";
@@ -165,6 +166,7 @@ export const Commands = {
   "integrations:versions": IntegrationsVersionsCommand,
   "logs:severities:list": LogsSeveritiesListCommand,
   "me:token:revoke": MeTokenRevokeCommand,
+  "organization:connections:list": OrganizationConnectionsListCommand,
   "organization:credentials:create": OrganizationCredentialsCreateCommand,
   "organization:credentials:delete": OrganizationCredentialsDeleteCommand,
   "organization:credentials:list": OrganizationCredentialsListCommand,


### PR DESCRIPTION
This PR:

1. Adds a new command, `prism organization:connections:list`, which allows users to list the stableKeys of all available integration-agnostic connections in their org (i.e. OAC's, CAC's)
2. Abstracts the `--json` flag into a global flag so that other commands can reference it
3. Updates commands that previously only had `ux.table` output to also have `json` output.

The latter 2 changes makes it so that prism command output more machine-accessible.

There's a pretty large diff in here though most of the changes are just the addition of the `if/else` blocks for output formatting.