### PR TITLE
Low-code > CNI converter: Support user-level config pages & org-agnostic connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "7.6.2",
+  "version": "7.6.3",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": ["prismatic", "cli"],
   "homepage": "https://prismatic.io",

--- a/src/commands/integrations/convert/__snapshots__/convert.test.ts.snap
+++ b/src/commands/integrations/convert/__snapshots__/convert.test.ts.snap
@@ -274,9 +274,9 @@ const testIntegrationIntegration = integration({
   name: "Test Integration",
   description: "",
   iconPath: "icon.png",
+  componentRegistry,
   flows,
   configPages,
-  componentRegistry,
 });
 export default testIntegrationIntegration;
 "

--- a/src/generate/formats/writer/yaml/types.ts
+++ b/src/generate/formats/writer/yaml/types.ts
@@ -105,6 +105,7 @@ export type ConfigVarObjectFromYAML = {
       };
     }
   >;
+  useScopedConfigVar?: string;
   meta?: {
     visibleToOrgDeployer: boolean;
     visibleToCustomerDeployer: boolean;
@@ -132,7 +133,7 @@ export type IntegrationObjectFromYAML = {
     }>;
     name: string;
     tagline?: string;
-    userLeveLConfigured: boolean;
+    userLevelConfigured: boolean;
   }>;
   requiredConfigVars: Array<ConfigVarObjectFromYAML>;
 };


### PR DESCRIPTION
See title. No changes should be observed for people converting integrations that use neither of these features; relevant artifacts are only created if needed.