### PR TITLE
Bugfixes: low-code converter issues with missing requiredConfigVars & htmlElements

### DIFF
--- a/src/commands/integrations/convert/__snapshots__/convert.test.ts.snap
+++ b/src/commands/integrations/convert/__snapshots__/convert.test.ts.snap
@@ -183,7 +183,8 @@ export const configPages = {
     tagline: "",
     elements: {
       "<h3>Set up your configVars</h3>": configVar({
-        stableKey: "h3SetUpYourConfigVarsH3",
+        stableKey:
+          "41d4e86eb4330e09cf49e90dc7278954d48dd8f12b24fb5d26af8bf518e714c6",
         dataType: "htmlElement",
         description: "",
       }),

--- a/src/generate/formats/utils.ts
+++ b/src/generate/formats/utils.ts
@@ -52,7 +52,7 @@ export const escapeText = (text?: unknown): string => {
   if (!text) {
     return "";
   }
-  return `${text}`.replace(/"/g, '\\"');
+  return `${text}`.replace(/\s+/g, " ").trim().replace(/"/g, '\\"');
 };
 
 export type GeneratedFunction = string | WriterFunction;

--- a/src/generate/formats/writer/yaml/index.ts
+++ b/src/generate/formats/writer/yaml/index.ts
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import { camelCase, kebabCase } from "lodash-es";
 import {
   ActionObjectFromYAML,
@@ -449,7 +450,10 @@ function writeConfigPages(project: Project, integration: IntegrationObjectFromYA
                     .writeLine(
                       `stableKey: "${
                         configVar.dataType === "htmlElement"
-                          ? camelCase(configVar.key).substring(0, MAX_HTML_STABLEKEY_LENGTH)
+                          ? crypto
+                              .createHash("sha256")
+                              .update(camelCase(configVar.key))
+                              .digest("hex")
                           : camelCase(configVar.key)
                       }",`,
                     )

--- a/src/generate/formats/writer/yaml/utils.ts
+++ b/src/generate/formats/writer/yaml/utils.ts
@@ -9,7 +9,7 @@ import {
 import { camelCase } from "lodash-es";
 import { writeBranchString, getBranchKind } from "./branching.js";
 import { SourceFile } from "ts-morph";
-import { escapeText as escapeDoubleQuotes } from "../../utils.js";
+import { escapeText } from "../../utils.js";
 
 export function valueIsNumber(value: unknown) {
   return typeof value === "number" || (typeof value === "string" && !Number.isNaN(Number(value)));
@@ -52,7 +52,7 @@ export function formatInputValue(
   } else if (typeof value === "object") {
     return convertYAMLObjectIntoString(value as ValidComplexYAMLValue);
   } else {
-    return `"${escapeDoubleQuotes(value)}"`;
+    return `"${escapeText(value)}"`;
   }
 }
 
@@ -328,7 +328,7 @@ export function writeLoopString(
 
 /* Config Vars: Given a config var object, format its inputs so it is consumable by the writers. */
 export function formatConfigVarInputs(configVar: ConfigVarObjectFromYAML) {
-  return Object.entries(configVar.inputs || []).map(([key, input]) => {
+  return Object.entries(configVar?.inputs || {}).map(([key, input]) => {
     return {
       name: key,
       type: input.type,
@@ -369,8 +369,8 @@ export async function extractComponentList(
   const { flows, requiredConfigVars } = integration;
 
   // Flows
-  flows.forEach((flow) => {
-    flow.steps.forEach((step) => {
+  (flows ?? []).forEach((flow) => {
+    (flow.steps ?? []).forEach((step) => {
       const { component } = step.action;
       if (!EXCLUDED_PUBLIC_COMPONENTS.includes(component.key)) {
         componentMap[component.key] = _extractComponentData(component, customRegistry);
@@ -411,7 +411,7 @@ export async function extractComponentList(
   }
 
   // Config vars
-  requiredConfigVars.forEach((configVar) => {
+  (requiredConfigVars ?? []).forEach((configVar) => {
     if (configVar.dataSource) {
       const { component } = configVar.dataSource;
       if (!EXCLUDED_PUBLIC_COMPONENTS.includes(component.key)) {

--- a/src/generate/formats/writer/yaml/utils.ts
+++ b/src/generate/formats/writer/yaml/utils.ts
@@ -369,8 +369,8 @@ export async function extractComponentList(
   const { flows, requiredConfigVars } = integration;
 
   // Flows
-  (flows ?? []).forEach((flow) => {
-    (flow.steps ?? []).forEach((step) => {
+  flows.forEach((flow) => {
+    flow.steps.forEach((step) => {
       const { component } = step.action;
       if (!EXCLUDED_PUBLIC_COMPONENTS.includes(component.key)) {
         componentMap[component.key] = _extractComponentData(component, customRegistry);


### PR DESCRIPTION
This PR fixes a couple of different low-code converter issues:

* Integrations without any requiredConfigVars were failing to convert
* stableKeys for multiline htmlElements would fail to convert
* stableKeys for long htmlElements were a bit absurd

No package bump since I'm hoping to bundle this in a release alongside https://github.com/prismatic-io/prism/pull/159.