### PR TITLE
Allow users to pass API key to integrations:flows:test

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "7.6.4",
+  "version": "7.6.5",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": ["prismatic", "cli"],
   "homepage": "https://prismatic.io",

--- a/src/commands/integrations/flows/test.ts
+++ b/src/commands/integrations/flows/test.ts
@@ -93,6 +93,9 @@ export default class TestFlowCommand extends PrismaticBaseCommand {
     debug: Flags.boolean({
       description: "Enables debug mode on the test execution.",
     }),
+    apiKey: Flags.string({
+      description: "Optional API key for flows with secured endpoints.",
+    }),
   };
 
   async run() {
@@ -110,6 +113,7 @@ export default class TestFlowCommand extends PrismaticBaseCommand {
         timeout,
         debug,
         quiet,
+        apiKey,
       },
     } = await this.parse(TestFlowCommand);
 
@@ -244,6 +248,7 @@ export default class TestFlowCommand extends PrismaticBaseCommand {
         ...(sync ? { "prismatic-synchronous": true } : {}),
         ...(debug ? { "prismatic-debug": true } : {}),
         ...(contentType && triggerPayload ? { "Content-Type": contentType } : {}),
+        ...(apiKey ? { "Api-Key": apiKey } : {}),
       },
     });
     ux.action.stop();


### PR DESCRIPTION
This should allow users to test flows with that have endpoint security configurations.