### PR TITLE
Support .env in new integrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "7.6.5",
+  "version": "7.6.6",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": ["prismatic", "cli"],
   "homepage": "https://prismatic.io",

--- a/src/utils/devDependencies.ts
+++ b/src/utils/devDependencies.ts
@@ -6,6 +6,7 @@ export const devDependencies = {
   "@prismatic-io/eslint-config-spectral": "2.1.0",
   "@types/jest": "29.5.14",
   "copy-webpack-plugin": "13.0.0",
+  "dotenv-webpack": "^8.1.1",
   eslint: "^8.57.1",
   jest: "29.7.0",
   "ts-jest": "29.3.2",

--- a/templates/integration/webpack.config.js.ejs
+++ b/templates/integration/webpack.config.js.ejs
@@ -1,5 +1,6 @@
 const path = require("path");
 const CopyPlugin = require("copy-webpack-plugin");
+const Dotenv = require("dotenv-webpack");
 
 module.exports = {
   mode: "production",
@@ -8,6 +9,7 @@ module.exports = {
     new CopyPlugin({
       patterns: [{ from: "assets", to: path.resolve(__dirname, "dist") }],
     }),
+    new Dotenv(),
   ],
   module: {
     rules: [


### PR DESCRIPTION
Newly generated integrations will now support environment variables out of the box. Note that `dotenv-webpack` does not support destructuring (e.g. `const { MY_VAR } = process.env`), so environment variables should be referenced explicitly wherever they are (e.g. `process.env.MY_VAR`).

These changes do not include a blank `.env` or `.gitignore`.