### PR TITLE
Adhere to package.json standards

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/prismatic-io/prism.git"
+    "url": "git+https://github.com/prismatic-io/prism.git"
   },
   "license": "MIT",
   "bin": {
-    "prism": "./lib/run.js"
+    "prism": "lib/run.js"
   },
   "type": "module",
   "engines": {


### PR DESCRIPTION
- Fix repository URL
- Remove leading ./ for bin command

When we publish prism, we get warnings from `npm`:

```
npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm WARN publish errors corrected:
npm WARN publish "bin[prism]" script name was cleaned
npm WARN publish "repository.url" was normalized to "git+https://github.com/prismatic-io/prism.git"
```


The published version of `prism` "fixes" our repository URL and removes the leading `./` from our `bin` command, adhering to npm's documentation https://docs.npmjs.com/cli/v11/configuring-npm/package-json#bin . This is fine - bin paths resolve relative to package root.

This PR doesn't affect the behavior of prism - only fixes a couple of issues that are fixed automatically anyways by npm on publish.