### PR TITLE
Include "Organization ID" when running `prism me`

### DIFF
--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -6307,5 +6307,5 @@
       "enableJsonFlag": false
     }
   },
-  "version": "9.2.2"
+  "version": "9.2.3"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prismatic-io/prism",
-  "version": "9.2.2",
+  "version": "9.2.3",
   "description": "Build, deploy, and support integrations in Prismatic from the comfort of your command line",
   "keywords": ["prismatic", "cli"],
   "homepage": "https://prismatic.io",

--- a/src/commands/me/index.ts
+++ b/src/commands/me/index.ts
@@ -13,6 +13,7 @@ export default class WhoAmICommand extends Command {
     this.log("Email:", email);
     if (org) {
       this.log("Organization:", org.name);
+      this.log("Organization ID:", org.id);
     } else if (customer) {
       this.log("Customer:", customer.name);
     }

--- a/src/utils/user/query.ts
+++ b/src/utils/user/query.ts
@@ -6,6 +6,7 @@ interface OrgUser {
   email: string;
   tenantId?: string;
   org: {
+    id: string;
     name: string;
   };
   customer: undefined;
@@ -34,6 +35,7 @@ export const whoAmI = async (): Promise<User> => {
           email
           tenantId
           org {
+            id
             name
           }
           customer {


### PR DESCRIPTION
When embedding Prismatic in a web app, you must know your organization's ID. This adds the org ID to the output of `prism me` for easy access.