### PR TITLE
Add handling of suspended orgs

### DIFF
--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -1,6 +1,32 @@
-import { describe, expect, it } from "vitest";
-import { Authenticate, createRequestParams } from "./auth.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import inquirer from "inquirer";
+import { Authenticate, createRequestParams, selectTenant, type Tenant } from "./auth.js";
+import { deleteConfig } from "./config.js";
 import { fetch } from "./utils/http.js";
+
+vi.unmock("./auth.js");
+
+vi.mock("./config.js", () => ({
+  configFileExists: vi.fn(),
+  deleteConfig: vi.fn(),
+  readConfig: vi.fn(),
+  writeConfig: vi.fn(),
+}));
+
+vi.mock("inquirer", () => ({
+  default: {
+    prompt: vi.fn(),
+  },
+}));
+
+const makeTenant = (id: string, overrides: Partial<Tenant> = {}): Tenant => ({
+  tenantId: id,
+  url: `https://${id}.example.com`,
+  orgName: `Org ${id}`,
+  awsRegion: "us-west-2",
+  systemSuspended: false,
+  ...overrides,
+});
 
 const domain = "prismatic-io-dev.auth0.com";
 const clientId = "R3uA27LbxqyanGVXjKpXgQo5A4TK44s7";
@@ -28,6 +54,89 @@ describe("createRequestParams", () => {
     // This is due to the reuse of the method for form data
     const [firstCharacter] = createRequestParams({ foo: "bar" });
     expect(firstCharacter).not.toBe("?");
+  });
+});
+
+describe("selectTenant", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it("logs an error and returns undefined when every tenant is suspended", async () => {
+    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const tenants = [
+      makeTenant("a", { systemSuspended: true }),
+      makeTenant("b", { systemSuspended: true }),
+    ];
+
+    const result = await selectTenant(tenants, { currentTenantId: "a" });
+
+    expect(result).toBeUndefined();
+    expect(inquirer.prompt).not.toHaveBeenCalled();
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("no active tenants"));
+  });
+
+  it("deletes the config when the current tenant is suspended", async () => {
+    vi.mocked(inquirer.prompt).mockResolvedValueOnce({ tenantId: "b" });
+    const tenants = [makeTenant("a", { systemSuspended: true }), makeTenant("b")];
+
+    await selectTenant(tenants, { currentTenantId: "a" });
+
+    expect(deleteConfig).toHaveBeenCalledOnce();
+  });
+
+  it("does not delete the config when the current tenant is active", async () => {
+    vi.mocked(inquirer.prompt).mockResolvedValueOnce({ tenantId: "a" });
+    const tenants = [makeTenant("a"), makeTenant("b")];
+
+    await selectTenant(tenants, { currentTenantId: "a" });
+
+    expect(deleteConfig).not.toHaveBeenCalled();
+  });
+
+  it("filters suspended tenants out of the choice list", async () => {
+    let capturedChoices: Array<{ value: string }> = [];
+    vi.mocked(inquirer.prompt).mockImplementationOnce(async (questions) => {
+      capturedChoices = (questions as Array<{ choices: typeof capturedChoices }>)[0].choices;
+      return { tenantId: "b" };
+    });
+    const tenants = [
+      makeTenant("a", { systemSuspended: true }),
+      makeTenant("b"),
+      makeTenant("c", { systemSuspended: true }),
+      makeTenant("d"),
+    ];
+
+    await selectTenant(tenants);
+
+    expect(capturedChoices.map((c) => c.value)).toEqual(["b", "d"]);
+  });
+
+  it("omits the suspended current tenant from the prompt default", async () => {
+    let capturedDefault: string | undefined;
+    vi.mocked(inquirer.prompt).mockImplementationOnce(async (questions) => {
+      capturedDefault = (questions as Array<{ default?: string }>)[0].default;
+      return { tenantId: "b" };
+    });
+    const tenants = [makeTenant("a", { systemSuspended: true }), makeTenant("b")];
+
+    await selectTenant(tenants, { currentTenantId: "a" });
+
+    expect(capturedDefault).toBeUndefined();
+  });
+
+  it("passes the active current tenant through as the prompt default", async () => {
+    let capturedDefault: string | undefined;
+    vi.mocked(inquirer.prompt).mockImplementationOnce(async (questions) => {
+      capturedDefault = (questions as Array<{ default?: string }>)[0].default;
+      return { tenantId: "a" };
+    });
+    const tenants = [makeTenant("a"), makeTenant("b")];
+
+    await selectTenant(tenants, { currentTenantId: "a" });
+
+    expect(capturedDefault).toBe("a");
   });
 });
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -311,6 +311,7 @@ export interface Tenant {
   url: string;
   orgName: string;
   awsRegion: string;
+  systemSuspended: boolean;
 }
 
 interface ListUserTenantsResponse {
@@ -329,6 +330,7 @@ export const fetchUserTenants = async (): Promise<Tenant[]> => {
             url
             orgName
             awsRegion
+            systemSuspended
           }
         }
       }
@@ -347,12 +349,31 @@ export const selectTenant = async (
 ): Promise<string | undefined> => {
   const { currentTenantId, message = "Select a tenant:" } = options;
 
-  const choices = tenants.map((tenant) => {
-    const isCurrent = tenant.tenantId === currentTenantId;
+  const currentTenant = tenants.find((t) => t.tenantId === currentTenantId);
+  const currentTenantSuspended = currentTenant?.systemSuspended ?? false;
+
+  // Delete config when org is suspended to avoid an active session with a suspended org.
+  if (currentTenantSuspended) {
+    await deleteConfig();
+  }
+
+  const activeTenants = tenants.filter((t) => !t.systemSuspended);
+  if (activeTenants.length === 0) {
+    console.log(
+      chalk.red(
+        "You have no active tenants on this stack. Please contact Prismatic support for assistance.",
+      ),
+    );
+    return;
+  }
+
+  const effectiveCurrentId = currentTenantSuspended ? undefined : currentTenantId;
+
+  const choices = activeTenants.map((tenant) => {
+    const isCurrent = tenant.tenantId === effectiveCurrentId;
     const checkmark = isCurrent ? chalk.green("✓ ") : "  ";
-    const displayName = isCurrent
-      ? chalk.green(`${tenant.orgName} - ${tenant.url} (${tenant.awsRegion})`)
-      : `${tenant.orgName} - ${tenant.url} (${tenant.awsRegion})`;
+    const label = `${tenant.orgName} - ${tenant.url} (${tenant.awsRegion})`;
+    const displayName = isCurrent ? chalk.green(label) : label;
 
     return {
       name: `${checkmark}${displayName}`,
@@ -368,7 +389,7 @@ export const selectTenant = async (
         name: "tenantId",
         message,
         choices,
-        default: currentTenantId,
+        default: effectiveCurrentId,
       },
     ]);
 
@@ -391,22 +412,24 @@ export const login = async (props?: { url: boolean }) => {
 
   const user = await whoAmI();
   const initialTenantId = user.tenantId;
+  const initialTenant = tenants.find((t) => t.tenantId === initialTenantId);
+  const initialTenantSuspended = initialTenant?.systemSuspended ?? false;
 
-  if (initialTenantId) {
+  if (!initialTenantSuspended && initialTenantId) {
     await writeConfig({
       ...initialAuth,
       tenantId: initialTenantId,
     });
   }
 
-  if (tenants.length <= 1) {
+  const activeTenants = tenants.filter((t) => !t.systemSuspended);
+  if (!initialTenantSuspended && activeTenants.length <= 1) {
     return;
   }
 
-  const selectedTenantId = await selectTenant(
-    tenants,
-    initialTenantId ? { currentTenantId: initialTenantId } : undefined,
-  );
+  const selectedTenantId = await selectTenant(tenants, {
+    currentTenantId: initialTenantId,
+  });
 
   if (selectedTenantId) {
     const tenantAuth = await auth.refresh(initialAuth.refreshToken, selectedTenantId);

--- a/src/commands/login/switch.ts
+++ b/src/commands/login/switch.ts
@@ -7,7 +7,6 @@ export default class LoginSwitchCommand extends Command {
   static description = "Switch between organization tenants";
 
   async run() {
-    // Check if user is logged in
     const config = await readConfig();
     const loggedIn = (await isLoggedIn()) && config;
     if (!loggedIn) {
@@ -17,16 +16,6 @@ export default class LoginSwitchCommand extends Command {
 
     const tenants = await fetchUserTenants();
 
-    if (tenants.length <= 1) {
-      const log_msg =
-        tenants.length === 1
-          ? "You are currently authenticated with the only tenant available on this stack. To switch to a tenant on another stack, update the PRISMATIC_URL value to access additional tenants."
-          : "Your user does not have access to tenants on this stack. Check the PRISMATIC_URL value.";
-      this.log(log_msg);
-      return;
-    }
-
-    // Get current tenant ID - either from config or from API
     let currentTenantId = config.tenantId;
     if (!currentTenantId) {
       const user = await whoAmI();
@@ -34,7 +23,19 @@ export default class LoginSwitchCommand extends Command {
     }
 
     const currentTenant = tenants.find((t) => t.tenantId === currentTenantId);
-    if (currentTenant) {
+    const currentTenantSuspended = currentTenant?.systemSuspended ?? false;
+    const activeTenants = tenants.filter((t) => !t.systemSuspended);
+
+    if (!currentTenantSuspended && activeTenants.length <= 1) {
+      const log_msg =
+        activeTenants.length === 1
+          ? "You are currently authenticated with the only tenant available on this stack. To switch to a tenant on another stack, update the PRISMATIC_URL value to access additional tenants."
+          : "Your user does not have access to tenants on this stack. Check the PRISMATIC_URL value.";
+      this.log(log_msg);
+      return;
+    }
+
+    if (!currentTenantSuspended && currentTenant) {
       this.log(`Current tenant: ${currentTenant.orgName} (${currentTenant.url})\n`);
     }
 
@@ -44,13 +45,12 @@ export default class LoginSwitchCommand extends Command {
     });
 
     if (!selectedTenantId || selectedTenantId === currentTenantId) {
-      if (currentTenantId) {
+      if (currentTenantId && !currentTenantSuspended) {
         await writeConfig({
           ...config,
           tenantId: currentTenantId,
         });
-        const selectedTenant = tenants.find((t) => t.tenantId === currentTenantId);
-        this.log(`Active tenant: ${selectedTenant?.orgName} (${selectedTenant?.url})`);
+        this.log(`Active tenant: ${currentTenant?.orgName} (${currentTenant?.url})`);
       }
       return;
     }


### PR DESCRIPTION
Better handling for users with suspended orgs that forces authorization only with an active org.

- Drop `systemSuspended` orgs from the picker
- `deleteConfig` in the auth path when the current org is suspended