### PR TITLE
Template copy-webpack-plugin@14.0.0 for new projects

### DIFF
--- a/src/commands/integrations/init/__snapshots__/index.test.ts.snap
+++ b/src/commands/integrations/init/__snapshots__/index.test.ts.snap
@@ -114,7 +114,7 @@ exports[`integrations:init > clean scaffold generation > should match scaffoldin
   "devDependencies": {
     "@prismatic-io/eslint-config-spectral": "2.1.0",
     "@types/jest": "29.5.14",
-    "copy-webpack-plugin": "13.0.0",
+    "copy-webpack-plugin": "14.0.0",
     "dotenv": "^17.2.2",
     "dotenv-webpack": "^8.1.1",
     "eslint": "^8.57.1",
@@ -418,7 +418,7 @@ exports[`integrations:init > scaffold generation > should match scaffolding snap
   "devDependencies": {
     "@prismatic-io/eslint-config-spectral": "2.1.0",
     "@types/jest": "29.5.14",
-    "copy-webpack-plugin": "13.0.0",
+    "copy-webpack-plugin": "14.0.0",
     "dotenv": "^17.2.2",
     "dotenv-webpack": "^8.1.1",
     "eslint": "^8.57.1",

--- a/src/utils/devDependencies.ts
+++ b/src/utils/devDependencies.ts
@@ -5,7 +5,7 @@
 export const devDependencies = {
   "@prismatic-io/eslint-config-spectral": "2.1.0",
   "@types/jest": "29.5.14",
-  "copy-webpack-plugin": "13.0.0",
+  "copy-webpack-plugin": "14.0.0",
   dotenv: "^17.2.2",
   "dotenv-webpack": "^8.1.1",
   eslint: "^8.57.1",


### PR DESCRIPTION
Template new custom connector and code-native integration projects with `copy-webpack-plugin@14.0.0`, as `13.0.0` depends on a vulnerable version of `serialize-javascript`. 