### PR TITLE
Fix oclif "unparsed command" warnings

### DIFF
--- a/src/commands/login/switch.ts
+++ b/src/commands/login/switch.ts
@@ -7,6 +7,7 @@ export default class LoginSwitchCommand extends Command {
   static description = "Switch between organization tenants";
 
   async run() {
+    await this.parse(LoginSwitchCommand);
     const config = await readConfig();
     const loggedIn = (await isLoggedIn()) && config;
     if (!loggedIn) {

--- a/src/commands/me/index.ts
+++ b/src/commands/me/index.ts
@@ -6,6 +6,7 @@ export default class WhoAmICommand extends Command {
   static description = "Print your user profile information";
 
   async run() {
+    await this.parse(WhoAmICommand);
     const me = await whoAmI();
     const { name, email, org, customer, tenantId } = me;
     this.log("Name:", name);

--- a/src/commands/organization/signingKeys/generate.ts
+++ b/src/commands/organization/signingKeys/generate.ts
@@ -6,6 +6,7 @@ export default class GenerateCommand extends PrismaticBaseCommand {
     "Generate an embedded marketplace signing key.\nThe RSA public key is saved in Prismatic, and the private key is returned and immediately removed from Prismatic. Once the private key is returned, it cannot be retrieved again.";
 
   async run() {
+    await this.parse(GenerateCommand);
     const result = await gqlRequest({
       document: gql`
         mutation generateSigningKey {


### PR DESCRIPTION
Apparently the new oclif warns, at runtime, about unparsed commands. We had a few commands that didn't include any args/flags so add those in to silence these warnings.