### PR TITLE
Fix deviations from prior cli-ux behavior on table reimplementation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,6 +26,7 @@
         "jwt-decode": "4.0.0",
         "lodash-es": "4.18.1",
         "mime-types": "3.0.2",
+        "natural-orderby": "^5.0.0",
         "number-to-words": "1.2.4",
         "open": "11.0.0",
         "prettier": "3.8.3",
@@ -1343,6 +1344,8 @@
     "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "natural-orderby": ["natural-orderby@5.0.0", "", {}, "sha512-kKHJhxwpR/Okycz4HhQKKlhWe4ASEfPgkSWNmKFHd7+ezuQlxkA5cM3+XkBPvm1gmHen3w53qsYAv+8GwRrBlg=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -151,7 +151,7 @@
           "type": "boolean"
         },
         "filter": {
-          "description": "filter property by partial string matching, ex: name=foo",
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
           "name": "filter",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -192,7 +192,7 @@
           "type": "option"
         },
         "sort": {
-          "description": "property to sort by (prepend '-' for descending)",
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
           "name": "sort",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -491,7 +491,7 @@
           "type": "boolean"
         },
         "filter": {
-          "description": "filter property by partial string matching, ex: name=foo",
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
           "name": "filter",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -532,7 +532,7 @@
           "type": "option"
         },
         "sort": {
-          "description": "property to sort by (prepend '-' for descending)",
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
           "name": "sort",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -944,7 +944,7 @@
           "type": "boolean"
         },
         "filter": {
-          "description": "filter property by partial string matching, ex: name=foo",
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
           "name": "filter",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -985,7 +985,7 @@
           "type": "option"
         },
         "sort": {
-          "description": "property to sort by (prepend '-' for descending)",
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
           "name": "sort",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -1453,7 +1453,7 @@
           "type": "boolean"
         },
         "filter": {
-          "description": "filter property by partial string matching, ex: name=foo",
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
           "name": "filter",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -1494,7 +1494,7 @@
           "type": "option"
         },
         "sort": {
-          "description": "property to sort by (prepend '-' for descending)",
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
           "name": "sort",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -1993,7 +1993,7 @@
           "type": "boolean"
         },
         "filter": {
-          "description": "filter property by partial string matching, ex: name=foo",
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
           "name": "filter",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -2034,7 +2034,7 @@
           "type": "option"
         },
         "sort": {
-          "description": "property to sort by (prepend '-' for descending)",
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
           "name": "sort",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -2301,7 +2301,7 @@
           "type": "boolean"
         },
         "filter": {
-          "description": "filter property by partial string matching, ex: name=foo",
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
           "name": "filter",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -2342,7 +2342,7 @@
           "type": "option"
         },
         "sort": {
-          "description": "property to sort by (prepend '-' for descending)",
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
           "name": "sort",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -2513,7 +2513,7 @@
           "type": "boolean"
         },
         "filter": {
-          "description": "filter property by partial string matching, ex: name=foo",
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
           "name": "filter",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -2554,7 +2554,7 @@
           "type": "option"
         },
         "sort": {
-          "description": "property to sort by (prepend '-' for descending)",
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
           "name": "sort",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -2803,7 +2803,7 @@
           "type": "boolean"
         },
         "filter": {
-          "description": "filter property by partial string matching, ex: name=foo",
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
           "name": "filter",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -2844,7 +2844,7 @@
           "type": "option"
         },
         "sort": {
-          "description": "property to sort by (prepend '-' for descending)",
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
           "name": "sort",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -2910,7 +2910,7 @@
           "type": "boolean"
         },
         "filter": {
-          "description": "filter property by partial string matching, ex: name=foo",
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
           "name": "filter",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -2951,7 +2951,7 @@
           "type": "option"
         },
         "sort": {
-          "description": "property to sort by (prepend '-' for descending)",
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
           "name": "sort",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -3119,7 +3119,7 @@
           "type": "boolean"
         },
         "filter": {
-          "description": "filter property by partial string matching, ex: name=foo",
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
           "name": "filter",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -3160,7 +3160,7 @@
           "type": "option"
         },
         "sort": {
-          "description": "property to sort by (prepend '-' for descending)",
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
           "name": "sort",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -3242,7 +3242,7 @@
           "type": "boolean"
         },
         "filter": {
-          "description": "filter property by partial string matching, ex: name=foo",
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
           "name": "filter",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -3283,7 +3283,7 @@
           "type": "option"
         },
         "sort": {
-          "description": "property to sort by (prepend '-' for descending)",
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
           "name": "sort",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -3375,7 +3375,7 @@
           "type": "boolean"
         },
         "filter": {
-          "description": "filter property by partial string matching, ex: name=foo",
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
           "name": "filter",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -3416,7 +3416,7 @@
           "type": "option"
         },
         "sort": {
-          "description": "property to sort by (prepend '-' for descending)",
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
           "name": "sort",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -3776,7 +3776,7 @@
           "type": "boolean"
         },
         "filter": {
-          "description": "filter property by partial string matching, ex: name=foo",
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
           "name": "filter",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -3817,7 +3817,7 @@
           "type": "option"
         },
         "sort": {
-          "description": "property to sort by (prepend '-' for descending)",
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
           "name": "sort",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -4019,7 +4019,7 @@
           "type": "boolean"
         },
         "filter": {
-          "description": "filter property by partial string matching, ex: name=foo",
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
           "name": "filter",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -4060,7 +4060,7 @@
           "type": "option"
         },
         "sort": {
-          "description": "property to sort by (prepend '-' for descending)",
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
           "name": "sort",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -4126,7 +4126,7 @@
           "type": "boolean"
         },
         "filter": {
-          "description": "filter property by partial string matching, ex: name=foo",
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
           "name": "filter",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -4167,7 +4167,7 @@
           "type": "option"
         },
         "sort": {
-          "description": "property to sort by (prepend '-' for descending)",
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
           "name": "sort",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -4378,7 +4378,7 @@
           "type": "boolean"
         },
         "filter": {
-          "description": "filter property by partial string matching, ex: name=foo",
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
           "name": "filter",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -4419,7 +4419,7 @@
           "type": "option"
         },
         "sort": {
-          "description": "property to sort by (prepend '-' for descending)",
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
           "name": "sort",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -4491,7 +4491,7 @@
           "type": "boolean"
         },
         "filter": {
-          "description": "filter property by partial string matching, ex: name=foo",
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
           "name": "filter",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -4532,7 +4532,7 @@
           "type": "option"
         },
         "sort": {
-          "description": "property to sort by (prepend '-' for descending)",
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
           "name": "sort",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -4748,7 +4748,7 @@
           "type": "boolean"
         },
         "filter": {
-          "description": "filter property by partial string matching, ex: name=foo",
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
           "name": "filter",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -4789,7 +4789,7 @@
           "type": "option"
         },
         "sort": {
-          "description": "property to sort by (prepend '-' for descending)",
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
           "name": "sort",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -5153,7 +5153,7 @@
           "type": "boolean"
         },
         "filter": {
-          "description": "filter property by partial string matching, ex: name=foo",
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
           "name": "filter",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -5194,7 +5194,7 @@
           "type": "option"
         },
         "sort": {
-          "description": "property to sort by (prepend '-' for descending)",
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
           "name": "sort",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -5267,7 +5267,7 @@
           "type": "boolean"
         },
         "filter": {
-          "description": "filter property by partial string matching, ex: name=foo",
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
           "name": "filter",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -5308,7 +5308,7 @@
           "type": "option"
         },
         "sort": {
-          "description": "property to sort by (prepend '-' for descending)",
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
           "name": "sort",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -5410,7 +5410,7 @@
           "type": "boolean"
         },
         "filter": {
-          "description": "filter property by partial string matching, ex: name=foo",
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
           "name": "filter",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -5451,7 +5451,7 @@
           "type": "option"
         },
         "sort": {
-          "description": "property to sort by (prepend '-' for descending)",
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
           "name": "sort",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -5647,7 +5647,7 @@
           "type": "boolean"
         },
         "filter": {
-          "description": "filter property by partial string matching, ex: name=foo",
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
           "name": "filter",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -5688,7 +5688,7 @@
           "type": "option"
         },
         "sort": {
-          "description": "property to sort by (prepend '-' for descending)",
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
           "name": "sort",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -5856,7 +5856,7 @@
           "type": "boolean"
         },
         "filter": {
-          "description": "filter property by partial string matching, ex: name=foo",
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
           "name": "filter",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -5897,7 +5897,7 @@
           "type": "option"
         },
         "sort": {
-          "description": "property to sort by (prepend '-' for descending)",
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
           "name": "sort",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -5963,7 +5963,7 @@
           "type": "boolean"
         },
         "filter": {
-          "description": "filter property by partial string matching, ex: name=foo",
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
           "name": "filter",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -6004,7 +6004,7 @@
           "type": "option"
         },
         "sort": {
-          "description": "property to sort by (prepend '-' for descending)",
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
           "name": "sort",
           "hasDynamicHelp": false,
           "multiple": false,
@@ -6307,5 +6307,5 @@
       "enableJsonFlag": false
     }
   },
-  "version": "9.2.3"
+  "version": "9.3.1"
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "jwt-decode": "4.0.0",
     "lodash-es": "4.18.1",
     "mime-types": "3.0.2",
+    "natural-orderby": "^5.0.0",
     "number-to-words": "1.2.4",
     "open": "11.0.0",
     "prettier": "3.8.3",

--- a/src/utils/table.test.ts
+++ b/src/utils/table.test.ts
@@ -68,8 +68,8 @@ describe("printTable", () => {
 
   it("uses startCase on unspecified headers and preserves explicit `header` overrides", async () => {
     const stdout = await render();
-    expect(stdout).toContain("Role"); // explicit header
-    expect(stdout).toContain("Name"); // startCase("name")
+    expect(stdout).toContain("Role");
+    expect(stdout).toContain("Name");
   });
 
   it("invokes `get` to resolve column values", async () => {
@@ -78,7 +78,7 @@ describe("printTable", () => {
     expect(stdout).toContain("EX-A");
   });
 
-  it("renders a ─ separator row beneath the header (cli-ux parity)", async () => {
+  it("renders a ─ separator row beneath the header", async () => {
     const stdout = await render();
     const headerRowIndex = stdout.indexOf("Name");
     const separatorIndex = stdout.indexOf("─");
@@ -100,14 +100,14 @@ describe("printTable", () => {
     expect(stdout).toMatch(/zeta|alpha|mike/);
   });
 
-  it("filters rows with --filter key=substr (substring anywhere, case-sensitive)", async () => {
+  it("filters rows with --filter key=pattern (regex, matches anywhere by default)", async () => {
     const stdout = await render({ filter: "name=mi" });
     expect(stdout).toContain("mike");
     expect(stdout).not.toContain("alpha");
     expect(stdout).not.toContain("zeta");
   });
 
-  it("filter matches substring anywhere in the value, not just a prefix", async () => {
+  it("filter matches anywhere in the value, not just a prefix", async () => {
     const stdout = await render({ filter: "name=lpha" });
     expect(stdout).toContain("alpha");
     expect(stdout).not.toContain("mike");
@@ -119,6 +119,36 @@ describe("printTable", () => {
     expect(stdout).not.toContain("mike");
     expect(stdout).not.toContain("alpha");
     expect(stdout).not.toContain("zeta");
+  });
+
+  it("filter supports regex anchors, metacharacters, and alternation", async () => {
+    const anchored = await render({ filter: "name=^m" });
+    expect(anchored).toContain("mike");
+    expect(anchored).not.toContain("alpha");
+    expect(anchored).not.toContain("zeta");
+
+    const metachar = await render({ filter: "name=.ke" });
+    expect(metachar).toContain("mike");
+    expect(metachar).not.toContain("alpha");
+
+    const alternation = await render({ filter: "name=^(zeta|alpha)$" });
+    expect(alternation).toContain("zeta");
+    expect(alternation).toContain("alpha");
+    expect(alternation).not.toContain("mike");
+  });
+
+  it("filter negates the match when the key is prefixed with -", async () => {
+    const stdout = await render({ filter: "-name=^m" });
+    expect(stdout).toContain("alpha");
+    expect(stdout).toContain("zeta");
+    expect(stdout).not.toContain("mike");
+  });
+
+  it("filter rejects invalid regex patterns", async () => {
+    const { error } = await captureOutput(async () => {
+      printTable(rows, columns, { filter: "name=[unclosed" });
+    });
+    expect(error?.message).toBe("Filter flag has an invalid value");
   });
 
   it("filter preserves `=` characters inside the value (splits on first `=` only)", async () => {
@@ -153,6 +183,74 @@ describe("printTable", () => {
     expect(error?.message).toBe("Filter flag has an invalid value");
   });
 
+  it("filter resolves keys case-insensitively against the raw key", async () => {
+    const stdout = await render({ filter: "NAME=mike" });
+    expect(stdout).toContain("mike");
+    expect(stdout).not.toContain("alpha");
+  });
+
+  it("filter resolves keys against display headers (startCase-derived)", async () => {
+    const stdout = await render({ filter: "Name=mike" });
+    expect(stdout).toContain("mike");
+    expect(stdout).not.toContain("alpha");
+  });
+
+  it("filter resolves keys against explicit header overrides", async () => {
+    const stdout = await render({ filter: "Role=admin" });
+    expect(stdout).toContain("zeta");
+    expect(stdout).not.toContain("mike");
+    expect(stdout).not.toContain("alpha");
+  });
+
+  it("--columns accepts raw keys, display headers, and mixed case", async () => {
+    const stdout = await render({ columns: "Role,NAME" });
+    const headerLine = stdout.split("\n")[0];
+    expect(headerLine.indexOf("Role")).toBeLessThan(headerLine.indexOf("Name"));
+    expect(headerLine).not.toMatch(/\bId\b/);
+  });
+
+  it("--columns matches extended columns by header (e.g. `Id`)", async () => {
+    const stdout = await render({ columns: "Id" });
+    expect(stdout).toMatch(/\bId\b/);
+    expect(stdout).toContain("a1");
+  });
+
+  it("filter runs on the full dataset when --columns hides the filter column", async () => {
+    const stdout = await render({ filter: "name=alpha", columns: "role" });
+    expect(stdout).toContain("user");
+    expect(stdout).not.toContain("admin");
+    const lines = stdout.trim().split("\n");
+    expect(lines).toHaveLength(3);
+  });
+
+  it("sort runs on the full dataset when --columns hides the sort column", async () => {
+    const stdout = await render({ sort: "name", columns: "role" });
+    const headerLine = stdout.split("\n")[0];
+    expect(headerLine).not.toMatch(/\bName\b/);
+    const dataLines = stdout.trim().split("\n").slice(2);
+    expect(dataLines[0]).toContain("user");
+    expect(dataLines[2]).toContain("admin");
+  });
+
+  it("filter can match an extended column even without --extended", async () => {
+    const stdout = await render({ filter: "extra=EX-Z" });
+    expect(stdout).toContain("zeta");
+    expect(stdout).not.toContain("alpha");
+    expect(stdout).not.toMatch(/\bExtra\b/);
+  });
+
+  it("sort accepts case-insensitive header match", async () => {
+    const stdout = await render({ sort: "Name" });
+    const positions = ["alpha", "mike", "zeta"].map((name) => stdout.indexOf(name));
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
+  });
+
+  it("--columns narrows JSON output to requested columns in requested order", async () => {
+    const stdout = await render({ output: "json", columns: "role,name" });
+    const parsed = JSON.parse(stdout) as Array<Record<string, string>>;
+    expect(Object.keys(parsed[0])).toEqual(["role", "name"]);
+  });
+
   it.each([
     ["ascending", "name", ["alpha", "mike", "zeta"]],
     ["descending", "-name", ["zeta", "mike", "alpha"]],
@@ -162,13 +260,58 @@ describe("printTable", () => {
     expect(positions).toEqual([...positions].sort((a, b) => a - b));
   });
 
+  it("sorts by multiple keys with --sort key1,key2", async () => {
+    const multi = [
+      { id: "1", name: "b", role: "user" },
+      { id: "2", name: "a", role: "user" },
+      { id: "3", name: "a", role: "admin" },
+    ];
+    const { stdout } = await captureOutput(async () => {
+      printTable(multi, columns, { sort: "name,role" });
+    });
+    const dataLines = stdout.trim().split("\n").slice(2);
+    expect(dataLines[0]).toContain("admin");
+    expect(dataLines[1]).toMatch(/a .* user/);
+    expect(dataLines[2]).toMatch(/b .* user/);
+  });
+
+  it("supports per-key direction in multi-key sort", async () => {
+    const multi = [
+      { id: "1", name: "b", role: "user" },
+      { id: "2", name: "a", role: "user" },
+      { id: "3", name: "a", role: "admin" },
+    ];
+    const { stdout } = await captureOutput(async () => {
+      printTable(multi, columns, { sort: "name,-role" });
+    });
+    const dataLines = stdout.trim().split("\n").slice(2);
+    expect(dataLines[0]).toMatch(/a .* user/);
+    expect(dataLines[1]).toMatch(/a .* admin/);
+    expect(dataLines[2]).toMatch(/b .* user/);
+  });
+
+  it("sorts naturally — item2 comes before item10", async () => {
+    const natural = [{ name: "item10" }, { name: "item2" }, { name: "item1" }];
+    const { stdout } = await captureOutput(async () => {
+      printTable(natural, { name: {} }, { sort: "name" });
+    });
+    const positions = ["item1", "item2", "item10"].map((n) => stdout.indexOf(n));
+    expect(positions).toEqual([...positions].sort((a, b) => a - b));
+  });
+
+  it("--columns dedupes repeated entries", async () => {
+    const stdout = await render({ columns: "name,name,Name" });
+    const headerLine = stdout.split("\n")[0];
+    expect(headerLine.match(/Name/g)).toHaveLength(1);
+  });
+
   it("emits JSON with --output=json", async () => {
     const stdout = await render({ output: "json" });
     const parsed = JSON.parse(stdout);
     expect(Array.isArray(parsed)).toBe(true);
     expect(parsed).toHaveLength(rows.length);
     expect(parsed[0]).toHaveProperty("name");
-    expect(parsed[0]).not.toHaveProperty("id"); // extended column hidden
+    expect(parsed[0]).not.toHaveProperty("id");
   });
 
   it.each([
@@ -192,7 +335,6 @@ describe("printTable", () => {
     });
     const lines = stdout.trim().split("\n");
     expect(lines[1]).toBe('"has, comma","has ""quote"""');
-    // embedded \n splits the row across two CSV lines
     expect(lines[2]).toContain('"has');
   });
 

--- a/src/utils/table.ts
+++ b/src/utils/table.ts
@@ -1,5 +1,11 @@
+// Minimal reimplementation of @oclif/core v3's ux.table (removed in v4), preserving the
+// flag shape, output format, and the case-insensitive key-or-header lookup that --filter,
+// --columns, and --sort used.
+
 import { Errors, Flags } from "@oclif/core";
+import chalk from "chalk";
 import { startCase } from "lodash-es";
+import { orderBy } from "natural-orderby";
 import { dumpYaml } from "./serialize.js";
 
 export type ColumnDef<T> = {
@@ -32,7 +38,7 @@ export type TableFlags = {
   "no-truncate"?: boolean;
 };
 
-// Order matches cli-ux's ux.table.flags() so oclif.manifest.json stays byte-stable. Don't reorder.
+// Flag order is part of the oclif manifest contract; don't reorder.
 const allFlags = () => ({
   columns: Flags.string({
     exclusive: ["extended"],
@@ -48,7 +54,7 @@ const allFlags = () => ({
     description: "show extra columns",
   }),
   filter: Flags.string({
-    description: "filter property by partial string matching, ex: name=foo",
+    description: "filter property by regex, ex: name=^foo (prefix key with - to invert)",
   }),
   "no-header": Flags.boolean({
     exclusive: ["csv"],
@@ -64,7 +70,7 @@ const allFlags = () => ({
     options: ["csv", "json", "yaml"],
   }),
   sort: Flags.string({
-    description: "property to sort by (prepend '-' for descending)",
+    description: "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
   }),
 });
 
@@ -76,10 +82,7 @@ export const tableFlags = (opts: { only?: TableFlagKey[]; except?: TableFlagKey[
   return Object.fromEntries(keys.map((k) => [k, flags[k]])) as Partial<ReturnType<typeof allFlags>>;
 };
 
-// Display-only view of a column — what format functions need.
 type Column = { key: string; header: string; minWidth: number };
-
-// Adds the value accessor used by `project` to resolve each cell from its source row.
 type ResolvedColumn<T> = Column & { get: (row: T) => unknown };
 
 const toCell = (value: unknown): string => {
@@ -94,51 +97,92 @@ const toCell = (value: unknown): string => {
   return String(value);
 };
 
-// RFC 4180 per-cell quoting. (cli-ux quoted whole rows; we don't — any parser handles this.)
 const csvEscape = (cell: string): string =>
   /[",\n\r]/.test(cell) ? `"${cell.replaceAll('"', '""')}"` : cell;
 
-const resolveColumns = <T>(columns: ColumnsConfig<T>, flags: TableFlags): ResolvedColumn<T>[] => {
-  const entries = Object.entries(columns) as Array<[string, ColumnDef<T>]>;
-  const picked = flags.columns
-    ? flags.columns
-        .split(",")
-        .map((k) => k.trim())
-        .filter(Boolean)
-        .flatMap((key) => {
-          const def = columns[key];
-          return def ? [[key, def] as [string, ColumnDef<T>]] : [];
-        })
-    : entries.filter(([, def]) => flags.extended || !def.extended);
-  return picked.map(([key, def]) => ({
+// Raw keys take precedence over headers on collision.
+const buildKeyIndex = <T>(columns: ColumnsConfig<T>): Map<string, string> => {
+  const index = new Map<string, string>();
+  for (const [key, def] of Object.entries(columns)) {
+    index.set(key.toLowerCase(), key);
+    const header = (def.header ?? startCase(key)).toLowerCase();
+    if (!index.has(header)) index.set(header, key);
+  }
+  return index;
+};
+
+const buildAllColumns = <T>(columns: ColumnsConfig<T>): ResolvedColumn<T>[] =>
+  Object.entries(columns).map(([key, def]) => ({
     key,
     header: def.header ?? startCase(key),
     minWidth: def.minWidth ?? 0,
     get: def.get ?? ((row: T) => (row as Record<string, unknown>)[key]),
   }));
+
+const pickDisplayColumns = <T>(
+  all: ResolvedColumn<T>[],
+  columns: ColumnsConfig<T>,
+  flags: TableFlags,
+): ResolvedColumn<T>[] => {
+  if (flags.columns) {
+    const index = buildKeyIndex(columns);
+    const seen = new Set<string>();
+    return flags.columns
+      .split(",")
+      .map((k) => k.trim())
+      .filter(Boolean)
+      .flatMap((input) => {
+        const key = index.get(input.toLowerCase());
+        if (!key || seen.has(key)) return [];
+        seen.add(key);
+        const col = all.find((c) => c.key === key);
+        return col ? [col] : [];
+      });
+  }
+  return all.filter((c) => flags.extended || !columns[c.key].extended);
 };
 
 const project = <T>(data: T[], columns: ResolvedColumn<T>[]): Array<Record<string, string>> =>
   data.map((row) => Object.fromEntries(columns.map((c) => [c.key, toCell(c.get(row))])));
 
-// cli-ux contract: `key=needle`, case-sensitive substring match. `key` must be a declared
-// column (whitespace-free, non-empty) and `needle` must be non-empty — otherwise hard-error
-// so scripts relying on exit code 2 keep working.
-const applyFilter = (rows: Array<Record<string, string>>, filter: string, validKeys: string[]) => {
+const applyFilter = <T>(
+  rows: Array<Record<string, string>>,
+  filter: string,
+  columns: ColumnsConfig<T>,
+): Array<Record<string, string>> => {
+  const invalid = () => new Errors.CLIError("Filter flag has an invalid value", { exit: 1 });
   const eq = filter.indexOf("=");
-  const key = eq < 0 ? "" : filter.slice(0, eq);
-  const needle = eq < 0 ? "" : filter.slice(eq + 1);
-  if (!key || !needle || /\s/.test(key) || !validKeys.includes(key)) {
-    throw new Errors.CLIError("Filter flag has an invalid value", { exit: 1 });
+  const rawInput = eq < 0 ? "" : filter.slice(0, eq);
+  const pattern = eq < 0 ? "" : filter.slice(eq + 1);
+  const negate = rawInput.startsWith("-");
+  const input = negate ? rawInput.slice(1) : rawInput;
+  const key = input ? buildKeyIndex(columns).get(input.toLowerCase()) : undefined;
+  if (!key || !pattern) throw invalid();
+  let regex: RegExp;
+  try {
+    regex = new RegExp(pattern);
+  } catch {
+    throw invalid();
   }
-  return rows.filter((r) => (r[key] ?? "").includes(needle));
+  return rows.filter((r) => negate !== regex.test(r[key] ?? ""));
 };
 
-const applySort = (rows: Array<Record<string, string>>, sort: string) => {
-  const desc = sort.startsWith("-");
-  const key = desc ? sort.slice(1) : sort;
-  const direction = desc ? -1 : 1;
-  return [...rows].sort((a, b) => direction * (a[key] ?? "").localeCompare(b[key] ?? ""));
+const applySort = <T>(
+  rows: Array<Record<string, string>>,
+  sort: string,
+  columns: ColumnsConfig<T>,
+): Array<Record<string, string>> => {
+  const index = buildKeyIndex(columns);
+  const sorters = sort.split(",").map((s) => {
+    const desc = s.startsWith("-");
+    const input = desc ? s.slice(1) : s;
+    return { key: index.get(input.toLowerCase()) ?? input, order: desc ? "desc" : "asc" } as const;
+  });
+  return orderBy(
+    rows,
+    sorters.map((s) => (r: Record<string, string>) => r[s.key] ?? ""),
+    sorters.map((s) => s.order),
+  );
 };
 
 const formatText = (
@@ -146,7 +190,6 @@ const formatText = (
   rows: Array<Record<string, string>>,
   flags: TableFlags,
 ): string => {
-  // Cells with embedded \n expand into continuation rows (other columns blank).
   const rowLines = rows.map((row) => {
     const cellLines = columns.map((c) => (row[c.key] ?? "").split("\n"));
     const height = Math.max(...cellLines.map((l) => l.length));
@@ -154,7 +197,7 @@ const formatText = (
   });
 
   const widths = columns.map((c, i) => {
-    // cli-ux's minWidth includes the trailing separator, so text is padded to minWidth - 1.
+    // minWidth counts the trailing separator; subtract 1 for pad width.
     const fromCells = rowLines.flat().reduce((m, line) => Math.max(m, (line[i] ?? "").length), 0);
     return Math.max(Math.max(0, c.minWidth - 1), c.header.length, fromCells);
   });
@@ -162,16 +205,16 @@ const formatText = (
   const pad = (cell: string, width: number) =>
     flags["no-truncate"] || cell.length <= width
       ? cell.padEnd(width)
-      : `${cell.slice(0, Math.max(0, width - 1))}…`;
+      : `${cell.slice(0, Math.max(0, width - 2))}… `;
 
-  // Leading + trailing space margin matches cli-ux; scripts parsing by column position depend on it.
+  // Scripts parse output by column position; the leading/trailing space margin is load-bearing.
   const line = (cells: string[]) =>
     ` ${cells.map((c, i) => pad(c, widths[i] ?? c.length)).join(" ")} `;
 
   const out: string[] = [];
   if (!flags["no-header"]) {
-    out.push(line(columns.map((c) => c.header)));
-    out.push(line(widths.map((w) => "─".repeat(w))));
+    out.push(chalk.bold(line(columns.map((c) => c.header))));
+    out.push(chalk.bold(line(widths.map((w) => "─".repeat(w)))));
   }
   for (const physicalRow of rowLines) {
     for (const logicalLine of physicalRow) {
@@ -199,23 +242,30 @@ export const printTable = <T>(
   columns: ColumnsConfig<T>,
   flags: TableFlags = {},
 ): void => {
-  const resolved = resolveColumns(columns, flags);
-  let rows = project(data, resolved);
-  if (flags.filter) rows = applyFilter(rows, flags.filter, Object.keys(columns));
-  if (flags.sort) rows = applySort(rows, flags.sort);
+  // Filter and sort run against every column, then we narrow to the display set — so
+  // `--filter label=X --columns id` still matches rows by the hidden `label`.
+  const all = buildAllColumns(columns);
+  let rows = project(data, all);
+  if (flags.filter) rows = applyFilter(rows, flags.filter, columns);
+  if (flags.sort) rows = applySort(rows, flags.sort, columns);
+
+  const display = pickDisplayColumns(all, columns, flags);
+  const displayRows = rows.map((r) =>
+    Object.fromEntries(display.map((c) => [c.key, r[c.key] ?? ""])),
+  );
 
   switch (resolveOutput(flags)) {
     case "json":
-      process.stdout.write(`${JSON.stringify(rows, null, 2)}\n`);
+      process.stdout.write(`${JSON.stringify(displayRows, null, 2)}\n`);
       return;
     case "yaml":
-      process.stdout.write(dumpYaml(rows));
+      process.stdout.write(dumpYaml(displayRows));
       return;
     case "csv":
-      process.stdout.write(`${formatCsv(resolved, rows)}\n`);
+      process.stdout.write(`${formatCsv(display, displayRows)}\n`);
       return;
     case "text": {
-      const text = formatText(resolved, rows, flags);
+      const text = formatText(display, displayRows, flags);
       if (text) process.stdout.write(`${text}\n`);
       return;
     }


### PR DESCRIPTION
- Match column names case-insensitively for --filter, --columns, and --sort against both raw keys and display headers
- Run --filter and --sort against the full dataset so they work even when --columns hides the target column
- Compile --filter values as regex rather than literal substring, with a leading - on the key inverting the match
- Sort naturally so item2 comes before item10
- Accept comma-separated keys in --sort for primary/secondary ordering with per-key direction