### PR TITLE
Allow changing config file location and support skipping the file entirely

### DIFF
--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -6,14 +6,14 @@ import { fetch } from "./utils/http.js";
 
 vi.unmock("./auth.js");
 
-vi.mock("./config.js", () => ({
+vi.mock(import("./config.js"), () => ({
   configFileExists: vi.fn(),
   deleteConfig: vi.fn(),
   readConfig: vi.fn(),
   writeConfig: vi.fn(),
 }));
 
-vi.mock("inquirer", () => ({
+vi.mock(import("inquirer"), () => ({
   default: {
     prompt: vi.fn(),
   },

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,0 +1,163 @@
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  type Configuration,
+  configFileExists,
+  deleteConfig,
+  readConfig,
+  writeConfig,
+} from "./config.js";
+
+const makeConfig = (overrides: Partial<Configuration> = {}): Configuration => ({
+  accessToken: "access",
+  expiresIn: 3600,
+  refreshToken: "refresh",
+  scope: "openid profile email",
+  tokenType: "Bearer",
+  ...overrides,
+});
+
+const stubFakeHome = (homeDir: string) => {
+  vi.stubEnv("HOME", homeDir);
+  vi.stubEnv("USERPROFILE", homeDir);
+};
+
+describe("config with PRISM_CONFIG_FILE override", () => {
+  let tmpDir: string;
+  let configPath: string;
+
+  beforeAll(async () => {
+    tmpDir = await mkdtemp(path.join(tmpdir(), "prism-config-test-"));
+  });
+
+  afterAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    configPath = path.join(tmpDir, "config.yml");
+    stubFakeHome(tmpDir);
+    vi.stubEnv("PRISM_CONFIG_FILE", configPath);
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await rm(configPath, { force: true });
+  });
+
+  it("writes to the path specified by PRISM_CONFIG_FILE", async () => {
+    await writeConfig(makeConfig({ accessToken: "tok-1" }));
+
+    const contents = await readFile(configPath, { encoding: "utf-8" });
+    expect(contents).toContain("accessToken: tok-1");
+  });
+
+  it("reads from the path specified by PRISM_CONFIG_FILE", async () => {
+    await writeConfig(makeConfig({ accessToken: "tok-2" }));
+
+    const result = await readConfig();
+    expect(result?.accessToken).toBe("tok-2");
+  });
+
+  it("creates the parent directory when it does not exist", async () => {
+    const nested = path.join(tmpDir, "nested", "dir", "config.yml");
+    vi.stubEnv("PRISM_CONFIG_FILE", nested);
+
+    await writeConfig(makeConfig({ accessToken: "tok-3" }));
+
+    await expect(stat(nested)).resolves.toBeDefined();
+    await rm(path.join(tmpDir, "nested"), { recursive: true, force: true });
+  });
+
+  it("reports the file as existing only after a write", async () => {
+    expect(await configFileExists()).toBe(false);
+    await writeConfig(makeConfig());
+    expect(await configFileExists()).toBe(true);
+  });
+
+  it("deletes the file at the overridden path", async () => {
+    await writeConfig(makeConfig());
+    expect(await configFileExists()).toBe(true);
+
+    await deleteConfig();
+    expect(await configFileExists()).toBe(false);
+  });
+});
+
+describe("config with PRISM_CONFIG_FILE=/dev/null", () => {
+  let tmpDir: string;
+
+  beforeAll(async () => {
+    tmpDir = await mkdtemp(path.join(tmpdir(), "prism-config-devnull-"));
+  });
+
+  afterAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    stubFakeHome(tmpDir);
+    vi.stubEnv("PRISM_CONFIG_FILE", "/dev/null");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("treats writes as a no-op so concurrent invocations cannot corrupt the file", async () => {
+    const writers = Array.from({ length: 25 }, (_, i) =>
+      writeConfig(makeConfig({ accessToken: `tok-${i}` })),
+    );
+    await expect(Promise.all(writers)).resolves.toBeDefined();
+  });
+
+  it("returns null on read since /dev/null is empty", async () => {
+    await writeConfig(makeConfig({ accessToken: "ignored" }));
+    const result = await readConfig();
+    expect(result).toBeNull();
+  });
+});
+
+describe("config without PRISM_CONFIG_FILE", () => {
+  let homeDir: string;
+
+  beforeAll(async () => {
+    homeDir = await mkdtemp(path.join(tmpdir(), "prism-config-home-"));
+  });
+
+  afterAll(async () => {
+    await rm(homeDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    stubFakeHome(homeDir);
+    vi.stubEnv("PRISM_CONFIG_FILE", "");
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await rm(path.join(homeDir, ".config"), { recursive: true, force: true });
+  });
+
+  it("falls back to the default path under HOME/.config/prism/config.yml", async () => {
+    await writeConfig(makeConfig({ accessToken: "default-path" }));
+
+    const expectedPath = path.join(homeDir, ".config", "prism", "config.yml");
+    const contents = await readFile(expectedPath, { encoding: "utf-8" });
+    expect(contents).toContain("accessToken: default-path");
+  });
+
+  it("returns null when the default file does not exist", async () => {
+    expect(await readConfig()).toBeNull();
+  });
+
+  it("returns null when the file exists but is empty", async () => {
+    const expectedPath = path.join(homeDir, ".config", "prism", "config.yml");
+    await writeConfig(makeConfig());
+    await writeFile(expectedPath, "", { encoding: "utf-8" });
+
+    expect(await readConfig()).toBeNull();
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,30 +12,33 @@ export interface Configuration {
   tenantId?: string;
 }
 
-const configDirectory = path.join(homedir(), ".config", "prism");
-const configFilePath = path.join(configDirectory, "config.yml");
+const defaultConfigFilePath = () => path.join(homedir(), ".config", "prism", "config.yml");
 
-const ensureConfigDirectoryExists = async () => {
-  if (await exists(configDirectory)) return;
-  await fs.mkdir(configDirectory, { recursive: true });
+const getConfigFilePath = (): string => process.env.PRISM_CONFIG_FILE || defaultConfigFilePath();
+
+const ensureConfigDirectoryExists = async (configFilePath: string) => {
+  const dir = path.dirname(configFilePath);
+  if (await exists(dir)) return;
+  await fs.mkdir(dir, { recursive: true });
 };
 
-export const configFileExists = async () => exists(configFilePath);
+export const configFileExists = async () => exists(getConfigFilePath());
 
 export const deleteConfig = async () => {
   if (!(await configFileExists())) return;
-  return fs.unlink(configFilePath);
+  return fs.unlink(getConfigFilePath());
 };
 
 export const writeConfig = async (config: Configuration) => {
-  await ensureConfigDirectoryExists();
+  const configFilePath = getConfigFilePath();
+  await ensureConfigDirectoryExists(configFilePath);
   const contents = dumpYaml(config, { skipInvalid: true });
   await fs.writeFile(configFilePath, contents, { encoding: "utf-8" });
 };
 
 export const readConfig = async (): Promise<Configuration | null> => {
   if (!(await configFileExists())) return null;
-  const contents = await fs.readFile(configFilePath, { encoding: "utf-8" });
-  const config = (await loadYaml(contents.toString())) as Configuration;
-  return config;
+  const contents = await fs.readFile(getConfigFilePath(), { encoding: "utf-8" });
+  const config = (await loadYaml(contents.toString())) as Configuration | null | undefined;
+  return config ?? null;
 };

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -2,7 +2,7 @@ import { beforeEach, onTestFailed, vi } from "vitest";
 
 export const TEST_PRISMATIC_URL = "https://example.com";
 
-vi.mock("./src/auth.js", () => ({
+vi.mock(import("./src/auth.js"), () => ({
   getAccessToken: vi.fn(() => Promise.resolve("test-token")),
   prismaticUrl: TEST_PRISMATIC_URL,
   createRequestParams: (data: Record<string, string | undefined>): string =>
@@ -11,7 +11,7 @@ vi.mock("./src/auth.js", () => ({
     ).toString(),
 }));
 
-vi.mock("./src/utils/http.js", () => ({
+vi.mock(import("./src/utils/http.js"), () => ({
   fetch: (...args: Parameters<typeof fetch>) => fetch(...args),
   createFetch: () => fetch,
 }));


### PR DESCRIPTION
This should help with CI/CD scenarios where you're using env vars and don't want any of the config file read/writes.