### PR TITLE
Centralize env var handling and defaulting

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,10 +29,10 @@ bun run lint-fix      # Auto-fix issues
 bun run format        # Format and fix
 bun run check-format  # Check only
 
-# Testing
-bun run test                # Run all tests
-bun test src/path/to/file   # Run specific test file
-bun run test:snapshots      # Update test snapshots
+# Testing (Vitest)
+bun run test                      # Run all tests
+bun run test src/path/to/file     # Run specific test file
+bun run test:snapshots            # Update test snapshots
 ```
 
 **Pre-pack**: The `prepack` script runs the full build automatically before npm publish.
@@ -84,7 +84,8 @@ Commands handle both types with different code paths (check for YAML vs package.
 
 ## Testing
 
-- Uses Bun's built-in test runner
+- Uses Vitest (`vitest run`), configured in `vitest.config.ts` with global setup in `vitest.setup.ts`
+- `vitest.setup.ts` mocks `src/auth.js` and `src/utils/http.js` and intercepts stdout/stderr; use `vi.stubEnv` to set env vars in tests
 - Test files use `.test.ts` suffix
 - Tests are excluded from TypeScript compilation (`tsconfig.json`)
 - Clean temp directories before tests: `src/commands/components/temp`, `src/commands/components/init/temp`, `src/commands/integrations/convert/temp`

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -5,6 +5,7 @@ import { jwtDecode } from "jwt-decode";
 import inquirer from "inquirer";
 import chalk from "chalk";
 import { configFileExists, deleteConfig, readConfig, writeConfig } from "./config.js";
+import { getEnv } from "./env.js";
 import { gqlRequest, gql } from "./graphql.js";
 import type { AddressInfo } from "net";
 import open from "open";
@@ -41,7 +42,7 @@ const extractRequestParams = (url: string): Record<string, string> => {
   return params;
 };
 
-export const prismaticUrl = process.env.PRISMATIC_URL ?? "https://app.prismatic.io";
+export const prismaticUrl = getEnv().PRISMATIC_URL;
 
 export const createRequestParams = (data: Record<string, string | undefined>): string =>
   Object.entries(data).reduce((result, [key, value]) => {
@@ -465,7 +466,7 @@ export const getAccessToken = async (): Promise<string | undefined> => {
     PRISM_ACCESS_TOKEN: envAccessToken,
     PRISM_REFRESH_TOKEN: envRefreshToken,
     PRISMATIC_TENANT_ID: envTenantId,
-  } = process.env;
+  } = getEnv();
 
   if (envRefreshToken && !envAccessToken) {
     const { accessToken: refreshedAccessToken } = await refresh(envRefreshToken, envTenantId);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
-import { homedir } from "os";
 import path from "path";
 import { z } from "zod";
+import { getEnv } from "./env.js";
 import { exists, fs } from "./fs.js";
 import { dumpYaml, loadYaml } from "./utils/serialize.js";
 import { formatValidationError } from "./utils/validation.js";
@@ -16,9 +16,7 @@ export const configurationSchema = z.object({
 
 export type Configuration = z.infer<typeof configurationSchema>;
 
-const defaultConfigFilePath = () => path.join(homedir(), ".config", "prism", "config.yml");
-
-const getConfigFilePath = (): string => process.env.PRISM_CONFIG_FILE || defaultConfigFilePath();
+const getConfigFilePath = (): string => getEnv().PRISM_CONFIG_FILE;
 
 const ensureConfigDirectoryExists = async (configFilePath: string) => {
   const dir = path.dirname(configFilePath);

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { DEFAULT_PRISMATIC_URL, getDefaultConfigFilePath, getEnv } from "./env.js";
+
+describe("getEnv", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe.each([
+    { key: "PRISM_ACCESS_TOKEN" },
+    { key: "PRISM_REFRESH_TOKEN" },
+    { key: "PRISMATIC_TENANT_ID" },
+  ] as const)("$key (optional)", ({ key }) => {
+    it.each([
+      { label: "unset", input: undefined, expected: undefined },
+      { label: "empty string", input: "", expected: undefined },
+      { label: "whitespace-only", input: "   ", expected: undefined },
+      { label: "real value", input: "some-value", expected: "some-value" },
+    ])("$label → $expected", ({ input, expected }) => {
+      vi.stubEnv(key, input);
+      expect(getEnv()[key]).toBe(expected);
+    });
+  });
+
+  describe("PRISMATIC_URL (defaulted)", () => {
+    it.each([
+      { label: "unset", input: undefined, expected: DEFAULT_PRISMATIC_URL },
+      { label: "empty string", input: "", expected: DEFAULT_PRISMATIC_URL },
+      { label: "whitespace-only", input: "   ", expected: DEFAULT_PRISMATIC_URL },
+      {
+        label: "explicit value",
+        input: "https://custom.example.com",
+        expected: "https://custom.example.com",
+      },
+    ])("$label → $expected", ({ input, expected }) => {
+      vi.stubEnv("PRISMATIC_URL", input);
+      expect(getEnv().PRISMATIC_URL).toBe(expected);
+    });
+  });
+
+  describe("PRISM_CONFIG_FILE (defaulted)", () => {
+    it.each([
+      { label: "unset", input: undefined, expected: getDefaultConfigFilePath() },
+      { label: "empty string", input: "", expected: getDefaultConfigFilePath() },
+      { label: "whitespace-only", input: "   ", expected: getDefaultConfigFilePath() },
+      { label: "explicit value", input: "/tmp/custom.yml", expected: "/tmp/custom.yml" },
+    ])("$label → $expected", ({ input, expected }) => {
+      vi.stubEnv("PRISM_CONFIG_FILE", input);
+      expect(getEnv().PRISM_CONFIG_FILE).toBe(expected);
+    });
+  });
+
+  describe("partial configurations", () => {
+    const clearAll = () => {
+      vi.stubEnv("PRISMATIC_URL", undefined);
+      vi.stubEnv("PRISM_CONFIG_FILE", undefined);
+      vi.stubEnv("PRISM_ACCESS_TOKEN", undefined);
+      vi.stubEnv("PRISM_REFRESH_TOKEN", undefined);
+      vi.stubEnv("PRISMATIC_TENANT_ID", undefined);
+    };
+
+    it("returns defaults / undefined when nothing is set", () => {
+      clearAll();
+      expect(getEnv()).toEqual({
+        PRISMATIC_URL: DEFAULT_PRISMATIC_URL,
+        PRISM_CONFIG_FILE: getDefaultConfigFilePath(),
+        PRISM_ACCESS_TOKEN: undefined,
+        PRISM_REFRESH_TOKEN: undefined,
+        PRISMATIC_TENANT_ID: undefined,
+      });
+    });
+
+    it("supports only PRISMATIC_URL + PRISM_REFRESH_TOKEN set", () => {
+      clearAll();
+      vi.stubEnv("PRISMATIC_URL", "https://custom.example.com");
+      vi.stubEnv("PRISM_REFRESH_TOKEN", "rt-123");
+      expect(getEnv()).toEqual({
+        PRISMATIC_URL: "https://custom.example.com",
+        PRISM_CONFIG_FILE: getDefaultConfigFilePath(),
+        PRISM_ACCESS_TOKEN: undefined,
+        PRISM_REFRESH_TOKEN: "rt-123",
+        PRISMATIC_TENANT_ID: undefined,
+      });
+    });
+
+    it("ignores empty values while honoring set ones", () => {
+      clearAll();
+      vi.stubEnv("PRISMATIC_URL", "https://custom.example.com");
+      vi.stubEnv("PRISM_REFRESH_TOKEN", "rt-123");
+      vi.stubEnv("PRISMATIC_TENANT_ID", "");
+      vi.stubEnv("PRISM_ACCESS_TOKEN", "   ");
+      expect(getEnv()).toEqual({
+        PRISMATIC_URL: "https://custom.example.com",
+        PRISM_CONFIG_FILE: getDefaultConfigFilePath(),
+        PRISM_ACCESS_TOKEN: undefined,
+        PRISM_REFRESH_TOKEN: "rt-123",
+        PRISMATIC_TENANT_ID: undefined,
+      });
+    });
+  });
+});

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,0 +1,34 @@
+import { homedir } from "os";
+import path from "path";
+import { z } from "zod";
+
+/**
+ * Normalizes empty or whitespace-only strings to undefined before validation.
+ * CI systems such as GitHub Actions forward unset action inputs as empty
+ * strings rather than omitting the env var, and we want those to behave the
+ * same as the variable being unset.
+ */
+const normalizeEmpty = (val: unknown) =>
+  typeof val === "string" && val.trim() === "" ? undefined : val;
+
+const optionalEnvString = z.preprocess(normalizeEmpty, z.string().min(1).optional());
+
+export const DEFAULT_PRISMATIC_URL = "https://app.prismatic.io";
+
+export const getDefaultConfigFilePath = (): string =>
+  path.join(homedir(), ".config", "prism", "config.yml");
+
+const envSchema = z.object({
+  PRISMATIC_URL: z.preprocess(normalizeEmpty, z.string().min(1).default(DEFAULT_PRISMATIC_URL)),
+  PRISM_CONFIG_FILE: z.preprocess(
+    normalizeEmpty,
+    z.string().min(1).default(getDefaultConfigFilePath),
+  ),
+  PRISM_ACCESS_TOKEN: optionalEnvString,
+  PRISM_REFRESH_TOKEN: optionalEnvString,
+  PRISMATIC_TENANT_ID: optionalEnvString,
+});
+
+export type Env = z.infer<typeof envSchema>;
+
+export const getEnv = (): Env => envSchema.parse(process.env);


### PR DESCRIPTION
Previously these concerns were handled in the most-relevant places but now there should be an effective "manifest" of our env vars, their requirements, and have easier traceability of where they're used.