### PR TITLE
feat(SC-36963): serialize outputSchema when publishing components

### DIFF
--- a/src/utils/component/publish.ts
+++ b/src/utils/component/publish.ts
@@ -1,3 +1,4 @@
+import type { OutputSchema } from "@prismatic-io/spectral";
 import crypto from "crypto";
 import mimetypes from "mime-types";
 import { extname } from "path";
@@ -66,6 +67,33 @@ export const confirmPublish = async (
   return await ux.confirm(`Would you like to publish ${label}? (y/N)`);
 };
 
+const serializeOutputSchema = (
+  outputSchemaBase: unknown,
+):
+  | { type: string; schema?: string; schemas?: Array<{ name: string; schema: string }> }
+  | undefined => {
+  if (!outputSchemaBase || typeof outputSchemaBase !== "object") {
+    return undefined;
+  }
+
+  const outputSchema = outputSchemaBase as OutputSchema;
+
+  if (outputSchema.type === "actionOutput") {
+    return { type: "actionOutput", schema: JSON.stringify(outputSchema.schema) };
+  }
+
+  if (outputSchema.type === "branchingOutput") {
+    const schemas = outputSchema.branches.map((b) => ({
+      name: b.name,
+      schema: JSON.stringify(b.schema),
+    }));
+
+    return { type: "branchingOutput", schemas };
+  }
+
+  return undefined;
+};
+
 export const publishDefinition = async (
   { actions, triggers, dataSources, connections, ...rest }: ComponentDefinition,
   {
@@ -106,11 +134,13 @@ export const publishDefinition = async (
   componentDefinition.forCodeNativeIntegration = forCodeNativeIntegration;
 
   const actionDefinitions = Object.values(actions || {}).map((action) => {
+    const outputSchema = serializeOutputSchema(action?.outputSchema);
     return {
       ...action,
       examplePayload: action?.examplePayload
         ? JSON.stringify(action?.examplePayload)
         : JSON.stringify({}),
+      ...(outputSchema ? { outputSchema } : {}),
     };
   });
 


### PR DESCRIPTION
## Summary

- Adds `serializeOutputSchema()` helper in `publish.ts` that converts a component action's `outputSchema` from the Spectral SDK format to the `OutputSchemaInput` format required by the `publishComponent` GraphQL mutation
- For `actionOutput`: stringifies the `JsonSchema` object to `JSONString`
- For `branchingOutput`: maps the `branches: [{ name, schema }]` array to `schemas: [{ name, schema: JSONString }]` (the API input field is `schemas`; the response type uses `branches` — asymmetry is intentional on the backend)

## Context

Part of SC-36963 outputSchema end-to-end. The frontend branch (`jc/sc-36963/output-schema-ref`) consumes `outputSchema` from the GraphQL response to power schema-driven reference suggestions. This PR ensures that components built with the Spectral SDK can actually publish their `outputSchema` declarations to the platform.

Depends on `@prismatic-io/spectral` at or above the version that includes `OutputSchema` in `ActionDefinition` (Stephen's `add-output` branch / PR #484).

## Test plan

- [x] Published `output-schema-test` component (v3) to Robbie's stack with both `actionOutput` and `branchingOutput` schemas — published successfully without API errors
- [ ] Verify `outputSchema` is readable via GraphQL on the published component