### PR TITLE
Multi-profile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,37 @@ Name: John Doe
 Email: john.doe@example.com
 Organization: Example Software Company
 Endpoint URL: https://app.prismatic.io
+Profile: default
 ```
+
+### Profiles
+
+Profiles let Prism stay logged in to multiple stacks or tenants at once. Each
+profile keeps its credentials, stack, and tenant together. Commands use the
+default profile unless another is selected.
+
+Existing Prism configuration is used automatically and migrated to the profile
+format the next time Prism updates it.
+
+```bash
+# Log in to a profile on another stack.
+$ PRISMATIC_URL=https://my-stack.prismatic.io prism login --profile staging
+
+# Select a profile for one command or the current shell.
+$ prism integrations:list --profile staging
+$ export PRISM_PROFILE=staging
+
+# View, change, or delete saved profiles.
+$ prism profiles:list
+$ prism profiles:use staging
+$ prism profiles:delete staging
+```
+
+Prism selects a profile from `--profile`, then `PRISM_PROFILE`, then the saved
+default. Environment credentials take precedence over credentials stored in the
+selected profile. When environment credentials are set, they use `PRISMATIC_URL`
+and `PRISMATIC_TENANT_ID` instead of values from a profile. Login, logout, and
+tenant switching still operate on the selected profile.
 
 For help with Prism, please see our [Prism documentation page](https://prismatic.io/docs/cli/).
 There, you will find information about the various subcommands you can run, troubleshooting tips, etc.

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -5,6 +5,30 @@
       "args": {},
       "description": "Log in to your Prismatic account",
       "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "force": {
           "char": "f",
           "description": "re-authenticate, even if you are already logged in",
@@ -33,7 +57,32 @@
       "aliases": [],
       "args": {},
       "description": "Switch between organization tenants",
-      "flags": {},
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
       "hasDynamicHelp": false,
       "hiddenAliases": [],
       "id": "login:switch",
@@ -48,6 +97,30 @@
       "args": {},
       "description": "Log out of your Prismatic account",
       "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "browser": {
           "char": "b",
           "description": "additionally log out of your default browser's session",
@@ -90,6 +163,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         }
       },
       "hasDynamicHelp": false,
@@ -120,6 +202,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "columns": {
           "description": "only show provided columns (comma-separated)",
@@ -251,6 +342,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "comment": {
           "char": "c",
           "description": "Comment about changes in this Publish",
@@ -361,6 +461,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "name": {
           "char": "n",
           "description": "short name of the new customer",
@@ -430,6 +539,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         }
       },
       "hasDynamicHelp": false,
@@ -460,6 +578,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "columns": {
           "description": "only show provided columns (comma-separated)",
@@ -580,6 +707,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "name": {
           "char": "n",
           "description": "name of the customer",
@@ -661,6 +797,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "name": {
           "char": "n",
@@ -750,6 +895,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         }
       },
       "hasDynamicHelp": false,
@@ -786,6 +940,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "force": {
           "char": "f",
@@ -829,6 +992,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         }
       },
       "hasDynamicHelp": false,
@@ -865,6 +1037,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         }
       },
       "hasDynamicHelp": false,
@@ -895,6 +1076,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "customer": {
           "char": "c",
@@ -1027,6 +1217,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "name": {
           "char": "n",
           "description": "Name of the instance",
@@ -1101,6 +1300,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "available": {
           "char": "a",
           "description": "Version is available or unavailable",
@@ -1138,6 +1346,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "name": {
           "char": "n",
@@ -1200,6 +1417,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         }
       },
       "hasDynamicHelp": false,
@@ -1236,6 +1462,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "latest-components": {
           "char": "l",
@@ -1288,6 +1523,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "name": {
           "char": "n",
           "description": "name of the forked integration",
@@ -1335,6 +1579,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "path": {
           "char": "p",
@@ -1422,6 +1675,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "columns": {
           "description": "only show provided columns (comma-separated)",
@@ -1566,6 +1828,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "available": {
           "char": "a",
           "description": "Mark this Integration version available in the marketplace",
@@ -1616,7 +1887,32 @@
         }
       },
       "description": "Open the Designer for the specified Integration",
-      "flags": {},
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
       "hasDynamicHelp": false,
       "hiddenAliases": [],
       "id": "integrations:open",
@@ -1651,6 +1947,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "comment": {
           "char": "c",
@@ -1729,6 +2034,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "integration-id": {
           "char": "i",
           "description": "ID of the integration containing the flow to test.",
@@ -1772,6 +2086,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "name": {
           "char": "n",
@@ -1853,6 +2176,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         }
       },
       "hasDynamicHelp": false,
@@ -1868,7 +2200,32 @@
       "aliases": [],
       "args": {},
       "description": "Print your user profile information",
-      "flags": {},
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
       "hasDynamicHelp": false,
       "hiddenAliases": [],
       "id": "me",
@@ -1883,6 +2240,30 @@
       "args": {},
       "description": "Print your authorization tokens",
       "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "type": {
           "char": "t",
           "description": "Which token type to print",
@@ -1900,6 +2281,212 @@
       "hasDynamicHelp": false,
       "hiddenAliases": [],
       "id": "me:token",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "profiles:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List profiles",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "profiles:list",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "profiles:use": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "Profile to use by default",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Set the default profile",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "profiles:use",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "profiles:delete": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "Profile to delete",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Delete a profile",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "profiles:delete",
       "pluginAlias": "@prismatic-io/prism",
       "pluginName": "@prismatic-io/prism",
       "pluginType": "core",
@@ -1931,6 +2518,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         }
       },
       "hasDynamicHelp": false,
@@ -1961,6 +2557,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "columns": {
           "description": "only show provided columns (comma-separated)",
@@ -2077,6 +2682,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "customerId": {
           "char": "c",
           "description": "The ID of the customer for which to create the JWT. Only valid for Organization users.",
@@ -2139,6 +2753,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "name": {
           "char": "n",
           "description": "name of the organization",
@@ -2176,6 +2799,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "organizationId": {
           "description": "ID of an organization",
@@ -2224,6 +2856,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "output-file": {
           "char": "o",
           "description": "Output the results of the action to a specified file",
@@ -2269,6 +2910,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "columns": {
           "description": "only show provided columns (comma-separated)",
@@ -2383,6 +3033,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "name": {
           "char": "n",
           "description": "name of the group to be created",
@@ -2445,6 +3104,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         }
       },
       "hasDynamicHelp": false,
@@ -2481,6 +3149,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "columns": {
           "description": "only show provided columns (comma-separated)",
@@ -2594,6 +3271,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         }
       },
       "hasDynamicHelp": false,
@@ -2642,6 +3328,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "name": {
           "char": "n",
@@ -2741,6 +3436,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         }
       },
       "hasDynamicHelp": false,
@@ -2771,6 +3475,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "columns": {
           "description": "only show provided columns (comma-separated)",
@@ -2879,6 +3592,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "columns": {
           "description": "only show provided columns (comma-separated)",
           "exclusive": [
@@ -2986,6 +3708,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "name": {
           "char": "n",
           "description": "name of the webhook to be created",
@@ -3057,6 +3788,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         }
       },
       "hasDynamicHelp": false,
@@ -3087,6 +3827,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "columns": {
           "description": "only show provided columns (comma-separated)",
@@ -3210,6 +3959,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "columns": {
           "description": "only show provided columns (comma-separated)",
@@ -3343,6 +4101,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "columns": {
           "description": "only show provided columns (comma-separated)",
@@ -3479,6 +4246,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "integrationId": {
           "char": "i",
           "description": "Integration ID",
@@ -3534,6 +4310,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "envPath": {
           "char": "e",
@@ -3591,6 +4376,30 @@
       "args": {},
       "description": "Initialize a new Component",
       "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "name": {
           "char": "n",
           "description": "Name of the component",
@@ -3651,6 +4460,30 @@
         }
       ],
       "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "wsdl-path": {
           "description": "Path to the WSDL definition file used to generate a Component",
           "name": "wsdl-path",
@@ -3716,6 +4549,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "skip-signature-verify": {
           "description": "This consistently returns a signature, regardless of whether the corresponding component has been published to the platform or not.",
           "name": "skip-signature-verify",
@@ -3768,6 +4610,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "columns": {
           "description": "only show provided columns (comma-separated)",
@@ -3904,6 +4755,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "email": {
           "char": "e",
           "description": "email address",
@@ -3975,6 +4835,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         }
       },
       "hasDynamicHelp": false,
@@ -4011,6 +4880,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "columns": {
           "description": "only show provided columns (comma-separated)",
@@ -4118,6 +4996,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "columns": {
           "description": "only show provided columns (comma-separated)",
@@ -4232,6 +5119,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "name": {
           "char": "n",
           "description": "name of the user",
@@ -4308,6 +5204,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "executionId": {
           "char": "e",
           "description": "ID of an Execution",
@@ -4370,6 +5275,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "columns": {
           "description": "only show provided columns (comma-separated)",
@@ -4484,6 +5398,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "columns": {
           "description": "only show provided columns (comma-separated)",
           "exclusive": [
@@ -4597,6 +5520,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "extended": {
           "char": "x",
           "description": "show extra columns",
@@ -4679,6 +5611,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "registryPrefix": {
           "char": "r",
           "description": "The registry prefix to use for the converted integration",
@@ -4740,6 +5681,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "columns": {
           "description": "only show provided columns (comma-separated)",
@@ -4848,6 +5798,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "integration-id": {
           "char": "i",
           "description": "ID of the integration containing the flow to listen to.",
@@ -4946,6 +5905,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "flow-id": {
           "char": "f",
@@ -5104,6 +6072,30 @@
         }
       ],
       "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "clean": {
           "description": "Generate clean scaffold without example code",
           "name": "clean",
@@ -5157,6 +6149,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "columns": {
           "description": "only show provided columns (comma-separated)",
@@ -5272,6 +6273,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "columns": {
           "description": "only show provided columns (comma-separated)",
           "exclusive": [
@@ -5379,6 +6389,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "confirm": {
           "description": "Prompt for confirmation before revoking tokens. Use --no-confirm to skip.",
           "name": "confirm",
@@ -5414,6 +6433,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "columns": {
           "description": "only show provided columns (comma-separated)",
@@ -5538,6 +6566,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         }
       },
       "hasDynamicHelp": false,
@@ -5568,6 +6605,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         }
       },
       "hasDynamicHelp": false,
@@ -5613,6 +6659,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "public-key-file": {
           "char": "p",
           "description": "public key file",
@@ -5651,6 +6706,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "columns": {
           "description": "only show provided columns (comma-separated)",
@@ -5769,6 +6833,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "name": {
           "char": "n",
           "description": "name of the user",
@@ -5830,6 +6903,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         }
       },
       "hasDynamicHelp": false,
@@ -5860,6 +6942,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "columns": {
           "description": "only show provided columns (comma-separated)",
@@ -5967,6 +7058,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "columns": {
           "description": "only show provided columns (comma-separated)",
@@ -6081,6 +7181,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "name": {
           "char": "n",
           "description": "name of the user",
@@ -6149,6 +7258,15 @@
           "allowNo": false,
           "type": "boolean"
         },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
         "latest-components": {
           "char": "l",
           "description": "Use the latest available version of each component upon import. Defaults to true.",
@@ -6185,6 +7303,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "path": {
           "char": "p",
@@ -6278,6 +7405,15 @@
           "required": false,
           "allowNo": false,
           "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
         },
         "file": {
           "char": "f",

--- a/package.json
+++ b/package.json
@@ -164,6 +164,9 @@
       "organization": {
         "description": "Manage your Organization"
       },
+      "profiles": {
+        "description": "Manage authentication profiles"
+      },
       "organization:users": {
         "description": "Manage Organization Users"
       },

--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -4,19 +4,34 @@ import {
   Authenticate,
   createRequestParams,
   getAccessToken,
+  login,
   selectTenant,
   type Tenant,
 } from "./auth.js";
-import { deleteConfig, readConfig, writeConfig } from "./config.js";
+import { deleteProfile, readProfileSelection, writeActiveProfile } from "./config.js";
+import { getAuthContext } from "./context.js";
+import { gqlRequest } from "./graphql.js";
 import { fetch } from "./utils/http.js";
 
 vi.unmock("./auth.js");
 
 vi.mock(import("./config.js"), () => ({
-  configFileExists: vi.fn(),
-  deleteConfig: vi.fn(),
-  readConfig: vi.fn(),
-  writeConfig: vi.fn(),
+  deleteProfile: vi.fn(),
+  getActiveProfileName: vi.fn(),
+  readProfile: vi.fn(),
+  readProfileSelection: vi.fn(),
+  writeActiveProfile: vi.fn(),
+}));
+
+vi.mock(import("./context.js"), () => ({
+  getAuthContext: vi.fn(),
+  useProfileAuthContext: vi.fn(),
+  getPrismaticUrl: vi.fn(() => Promise.resolve("https://auth.example.com")),
+}));
+
+vi.mock(import("./graphql.js"), () => ({
+  gql: (strings: TemplateStringsArray) => strings.join(""),
+  gqlRequest: vi.fn(),
 }));
 
 vi.mock(import("inquirer"), () => ({
@@ -78,24 +93,6 @@ describe("selectTenant", () => {
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("no active tenants"));
   });
 
-  it("deletes the config when the current tenant is suspended", async () => {
-    vi.mocked(inquirer.prompt).mockResolvedValueOnce({ tenantId: "b" });
-    const tenants = [makeTenant("a", { systemSuspended: true }), makeTenant("b")];
-
-    await selectTenant(tenants, { currentTenantId: "a" });
-
-    expect(deleteConfig).toHaveBeenCalledOnce();
-  });
-
-  it("does not delete the config when the current tenant is active", async () => {
-    vi.mocked(inquirer.prompt).mockResolvedValueOnce({ tenantId: "a" });
-    const tenants = [makeTenant("a"), makeTenant("b")];
-
-    await selectTenant(tenants, { currentTenantId: "a" });
-
-    expect(deleteConfig).not.toHaveBeenCalled();
-  });
-
   it("filters suspended tenants out of the choice list", async () => {
     let capturedChoices: Array<{ value: string }> = [];
     vi.mocked(inquirer.prompt).mockImplementationOnce(async (questions) => {
@@ -142,22 +139,49 @@ describe("selectTenant", () => {
 });
 
 describe("getAccessToken", () => {
-  it("does not use the config tenant when both tokens are supplied via environment variables", async () => {
-    const expiredAccessToken = [
+  const tokenExpiringAt = (exp: number) =>
+    [
       Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url"),
-      Buffer.from(JSON.stringify({ exp: 0 })).toString("base64url"),
+      Buffer.from(JSON.stringify({ exp })).toString("base64url"),
       "signature",
     ].join(".");
-    vi.stubEnv("PRISM_ACCESS_TOKEN", expiredAccessToken);
-    vi.stubEnv("PRISM_REFRESH_TOKEN", "env-refresh-token");
-    vi.stubEnv("PRISMATIC_TENANT_ID", undefined);
-    vi.mocked(readConfig).mockResolvedValue({
-      accessToken: "config-access-token",
-      expiresIn: 3600,
-      refreshToken: "config-refresh-token",
-      scopes: "openid",
-      tokenType: "Bearer",
-      tenantId: "config-tenant",
+
+  it("refreshes an expired environment token without persisting it", async () => {
+    vi.mocked(getAuthContext).mockResolvedValue({
+      source: "environment",
+      url: "https://auth.example.com",
+      accessToken: tokenExpiringAt(0),
+      refreshToken: "env-refresh-token",
+    });
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        Response.json({ domain: "auth.example.com", clientId: "client", audience: "audience" }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          access_token: "refreshed-access-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+      );
+
+    await expect(getAccessToken()).resolves.toBe("refreshed-access-token");
+
+    const refreshRequest = fetchSpy.mock.calls[1];
+    expect(refreshRequest[0].toString()).toBe("https://auth.example.com/oauth/token");
+    expect(refreshRequest[1]?.body).toBe(
+      "grant_type=refresh_token&client_id=client&refresh_token=env-refresh-token",
+    );
+    expect(writeActiveProfile).not.toHaveBeenCalled();
+  });
+
+  it("does not persist a session obtained from an environment refresh token", async () => {
+    vi.mocked(getAuthContext).mockResolvedValue({
+      source: "environment",
+      url: "https://auth.example.com",
+      refreshToken: "env-refresh-token",
+      tenantId: "env-tenant",
     });
 
     const fetchSpy = vi
@@ -175,39 +199,146 @@ describe("getAccessToken", () => {
 
     await expect(getAccessToken()).resolves.toBe("refreshed-access-token");
 
-    const refreshRequest = fetchSpy.mock.calls[1];
-    expect(refreshRequest[0]).toBe("https://auth.example.com/oauth/token");
-    expect(refreshRequest[1]?.body).toBe(
-      "grant_type=refresh_token&client_id=client&refresh_token=env-refresh-token",
+    expect(readProfileSelection).not.toHaveBeenCalled();
+    expect(fetchSpy.mock.calls[1][1]?.body).toBe(
+      "grant_type=refresh_token&client_id=client&refresh_token=env-refresh-token&tenant_id=env-tenant",
     );
-    expect(writeConfig).not.toHaveBeenCalled();
+    expect(writeActiveProfile).not.toHaveBeenCalled();
   });
 
-  it("does not persist a session obtained from an environment refresh token", async () => {
-    vi.stubEnv("PRISM_ACCESS_TOKEN", undefined);
-    vi.stubEnv("PRISM_REFRESH_TOKEN", "env-refresh-token");
-    vi.stubEnv("PRISMATIC_TENANT_ID", "env-tenant");
+  it("returns a valid profile access token without refreshing it", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const accessToken = tokenExpiringAt(Math.floor(Date.now() / 1000) + 600);
+    vi.mocked(getAuthContext).mockResolvedValue({
+      source: "profile",
+      profileName: "staging",
+      url: "https://staging.example.com",
+      accessToken,
+      refreshToken: "profile-refresh-token",
+      tenantId: "profile-tenant",
+    });
 
-    const fetchSpy = vi
-      .spyOn(globalThis, "fetch")
+    await expect(getAccessToken()).resolves.toBe(accessToken);
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(writeActiveProfile).not.toHaveBeenCalled();
+  });
+
+  it("refreshes an expired profile token into the same profile", async () => {
+    vi.mocked(getAuthContext).mockResolvedValue({
+      source: "profile",
+      profileName: "staging",
+      url: "https://staging.example.com",
+      accessToken: tokenExpiringAt(0),
+      refreshToken: "profile-refresh-token",
+      tenantId: "profile-tenant",
+    });
+    vi.spyOn(globalThis, "fetch")
       .mockResolvedValueOnce(
         Response.json({ domain: "auth.example.com", clientId: "client", audience: "audience" }),
       )
       .mockResolvedValueOnce(
         Response.json({
-          access_token: "refreshed-access-token",
+          access_token: "refreshed-profile-token",
           expires_in: 3600,
+          scope: "openid",
           token_type: "Bearer",
         }),
       );
 
-    await expect(getAccessToken()).resolves.toBe("refreshed-access-token");
+    await expect(getAccessToken()).resolves.toBe("refreshed-profile-token");
 
-    expect(readConfig).not.toHaveBeenCalled();
-    expect(fetchSpy.mock.calls[1][1]?.body).toBe(
-      "grant_type=refresh_token&client_id=client&refresh_token=env-refresh-token&tenant_id=env-tenant",
+    expect(writeActiveProfile).toHaveBeenCalledWith(
+      {
+        accessToken: "refreshed-profile-token",
+        expiresIn: 3600,
+        refreshToken: "profile-refresh-token",
+        scope: "openid",
+        tokenType: "Bearer",
+        tenantId: "profile-tenant",
+      },
+      "staging",
     );
-    expect(writeConfig).not.toHaveBeenCalled();
+  });
+
+  it("returns an environment access token without borrowing a profile refresh token", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    vi.mocked(getAuthContext).mockResolvedValue({
+      source: "environment",
+      url: "https://ci.example.com",
+      accessToken: "opaque-ci-token",
+    });
+
+    await expect(getAccessToken()).resolves.toBe("opaque-ci-token");
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(readProfileSelection).not.toHaveBeenCalled();
+    expect(writeActiveProfile).not.toHaveBeenCalled();
+  });
+});
+
+describe("login", () => {
+  const initialAuth = {
+    accessToken: "initial-access",
+    expiresIn: 3600,
+    refreshToken: "initial-refresh",
+    scope: "openid",
+    tokenType: "Bearer",
+  };
+
+  const mockLogin = (tenants: Tenant[], tenantId: string) => {
+    vi.spyOn(Authenticate.prototype, "login").mockResolvedValue(initialAuth);
+    vi.spyOn(globalThis, "fetch").mockResolvedValueOnce(
+      Response.json({ domain: "auth.example.com", clientId: "client", audience: "audience" }),
+    );
+    vi.mocked(gqlRequest)
+      .mockResolvedValueOnce({ listUserTenants: { nodes: tenants } })
+      .mockResolvedValueOnce({
+        authenticatedUser: {
+          name: "User",
+          email: "user@example.com",
+          tenantId,
+          org: { id: "org-1", name: "Org" },
+          customer: undefined,
+        },
+      });
+  };
+
+  it("writes every authentication update to the selected profile", async () => {
+    mockLogin([makeTenant("tenant-1")], "tenant-1");
+
+    await login({ url: false, profileName: "staging" });
+
+    expect(writeActiveProfile).toHaveBeenNthCalledWith(1, initialAuth, "staging");
+    expect(writeActiveProfile).toHaveBeenNthCalledWith(
+      2,
+      { ...initialAuth, tenantId: "tenant-1" },
+      "staging",
+    );
+    expect(deleteProfile).not.toHaveBeenCalled();
+  });
+
+  it("deletes the selected profile when its tenant is suspended and none are active", async () => {
+    mockLogin([makeTenant("suspended", { systemSuspended: true })], "suspended");
+
+    await login({ url: false, profileName: "staging" });
+
+    expect(deleteProfile).toHaveBeenCalledWith("staging");
+  });
+
+  it("retains the profile when a suspended tenant is replaced with an active one", async () => {
+    const refreshedAuth = { ...initialAuth, accessToken: "refreshed", tenantId: "active" };
+    mockLogin(
+      [makeTenant("suspended", { systemSuspended: true }), makeTenant("active")],
+      "suspended",
+    );
+    vi.mocked(inquirer.prompt).mockResolvedValueOnce({ tenantId: "active" });
+    vi.spyOn(Authenticate.prototype, "refresh").mockResolvedValueOnce(refreshedAuth);
+
+    await login({ url: false, profileName: "staging" });
+
+    expect(writeActiveProfile).toHaveBeenLastCalledWith(refreshedAuth, "staging");
+    expect(deleteProfile).not.toHaveBeenCalled();
   });
 });
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,11 +1,10 @@
 import crypto from "crypto";
 import http from "http";
-import url from "url";
 import { jwtDecode } from "jwt-decode";
 import inquirer from "inquirer";
 import chalk from "chalk";
-import { configFileExists, deleteConfig, readConfig, writeConfig } from "./config.js";
-import { getEnv } from "./env.js";
+import { deleteProfile, getActiveProfileName, writeActiveProfile } from "./config.js";
+import { type AuthContext, getAuthContext, getPrismaticUrl } from "./context.js";
 import { gqlRequest, gql } from "./graphql.js";
 import type { AddressInfo } from "net";
 import open from "open";
@@ -27,6 +26,13 @@ const codeChallenge = (verifier: string): string => urlEncodeBase64(sha256(verif
 
 const codeState = (): string => urlEncodeBase64(crypto.randomBytes(12));
 
+const httpsUrl = (host: string, pathname: string): URL => {
+  const result = new URL("https://localhost");
+  result.host = host;
+  result.pathname = pathname;
+  return result;
+};
+
 const randomPort = (low: number, high: number): number =>
   Math.floor(Math.random() * (high - low + 1) + low);
 
@@ -41,8 +47,6 @@ const extractRequestParams = (url: string): Record<string, string> => {
 
   return params;
 };
-
-export const prismaticUrl = getEnv().PRISMATIC_URL;
 
 export const createRequestParams = (data: Record<string, string | undefined>): string =>
   Object.entries(data).reduce((result, [key, value]) => {
@@ -168,7 +172,7 @@ export class Authenticate {
       tenant_id: tenantId,
     };
 
-    const fetchResponse = await fetch(`https://${this.options.domain}/oauth/token`, {
+    const fetchResponse = await fetch(httpsUrl(this.options.domain, "/oauth/token").toString(), {
       method: "POST",
       body: createRequestParams(data),
       headers: {
@@ -201,9 +205,9 @@ export class Authenticate {
       client_id: this.options.clientId,
       returnTo: this.options.successRedirectUri,
     };
-    const queryString = createRequestParams(params);
-    await open(`https://${this.options.domain}/logout?${queryString}`);
-    await deleteConfig();
+    const logoutUrl = httpsUrl(this.options.domain, "/logout");
+    logoutUrl.search = new URLSearchParams(params).toString();
+    await open(logoutUrl.toString());
   }
 
   private async attemptServerCreate(): Promise<http.Server> {
@@ -228,7 +232,9 @@ export class Authenticate {
         .then((server) => {
           this.redirectServer = server;
           const info = server.address() as AddressInfo;
-          resolve(`http://localhost:${info.port}`);
+          const redirectUrl = new URL("http://localhost");
+          redirectUrl.port = String(info.port);
+          resolve(redirectUrl.toString());
         })
         .catch(reject);
     });
@@ -247,7 +253,7 @@ export class Authenticate {
       redirect_uri: redirectUri,
     };
 
-    const fetchResponse = await fetch(`https://${this.options.domain}/oauth/token`, {
+    const fetchResponse = await fetch(httpsUrl(this.options.domain, "/oauth/token").toString(), {
       method: "POST",
       body: createRequestParams(data),
       headers: {
@@ -286,15 +292,16 @@ export class Authenticate {
       state,
       audience,
     };
-    const queryString = createRequestParams(params);
-
-    return `https://${this.options.domain}/authorize?${queryString}`;
+    const authorizeUrl = httpsUrl(this.options.domain, "/authorize");
+    authorizeUrl.search = new URLSearchParams(params).toString();
+    return authorizeUrl.toString();
   }
 }
 
 // TODO: Need to factor this out if we look to open source this auth logic.
-const getAuthOptions = async () => {
-  const fetchResponse = await fetch(new url.URL("/auth/meta", prismaticUrl).toString());
+const getAuthOptions = async (prismaticUrl?: string) => {
+  const resolvedUrl = prismaticUrl ?? (await getPrismaticUrl());
+  const fetchResponse = await fetch(new URL("/auth/meta", resolvedUrl).toString());
   const authConfig = (await fetchResponse.json()) as any;
 
   const { domain, clientId, audience } = authConfig;
@@ -353,11 +360,6 @@ export const selectTenant = async (
   const currentTenant = tenants.find((t) => t.tenantId === currentTenantId);
   const currentTenantSuspended = currentTenant?.systemSuspended ?? false;
 
-  // Delete config when org is suspended to avoid an active session with a suspended org.
-  if (currentTenantSuspended) {
-    await deleteConfig();
-  }
-
   const activeTenants = tenants.filter((t) => !t.systemSuspended);
   if (activeTenants.length === 0) {
     console.log(
@@ -402,12 +404,14 @@ export const selectTenant = async (
   }
 };
 
-export const login = async (props?: { url: boolean }) => {
-  const authOptions = await getAuthOptions();
+export const login = async (props?: { url: boolean; profileName?: string }) => {
+  const profileName = props?.profileName ?? (await getActiveProfileName());
+  const prismaticUrl = await getPrismaticUrl();
+  const authOptions = await getAuthOptions(prismaticUrl);
   const auth = new Authenticate(authOptions);
 
   const initialAuth = await auth.login({ url: props?.url });
-  await writeConfig(initialAuth);
+  await writeActiveProfile(initialAuth, profileName);
 
   const tenants = await fetchUserTenants();
 
@@ -417,10 +421,13 @@ export const login = async (props?: { url: boolean }) => {
   const initialTenantSuspended = initialTenant?.systemSuspended ?? false;
 
   if (!initialTenantSuspended && initialTenantId) {
-    await writeConfig({
-      ...initialAuth,
-      tenantId: initialTenantId,
-    });
+    await writeActiveProfile(
+      {
+        ...initialAuth,
+        tenantId: initialTenantId,
+      },
+      profileName,
+    );
   }
 
   const activeTenants = tenants.filter((t) => !t.systemSuspended);
@@ -434,22 +441,25 @@ export const login = async (props?: { url: boolean }) => {
 
   if (selectedTenantId) {
     const tenantAuth = await auth.refresh(initialAuth.refreshToken, selectedTenantId);
-    await writeConfig(tenantAuth);
+    await writeActiveProfile(tenantAuth, profileName);
+  } else if (initialTenantSuspended) {
+    await deleteProfile(profileName);
   }
 
   return;
 };
 
-const refreshAuthentication = async (refreshToken: string, tenantId?: string) => {
-  const authOptions = await getAuthOptions();
+const refreshAuthentication = async (refreshToken: string, tenantId?: string, url?: string) => {
+  const authOptions = await getAuthOptions(url);
   const auth = new Authenticate(authOptions);
 
   return auth.refresh(refreshToken, tenantId);
 };
 
-export const refresh = async (refreshToken: string, tenantId?: string) => {
-  const response = await refreshAuthentication(refreshToken, tenantId);
-  await writeConfig(response);
+export const refresh = async (refreshToken: string, tenantId?: string, profileName?: string) => {
+  const selectedName = profileName ?? (await getActiveProfileName());
+  const response = await refreshAuthentication(refreshToken, tenantId, await getPrismaticUrl());
+  await writeActiveProfile(response, selectedName);
   return response;
 };
 
@@ -466,39 +476,24 @@ export const logout = async () => {
  * also refresh the access token using the provided refresh token if possible.
  */
 export const getAccessToken = async (): Promise<string | undefined> => {
-  const {
-    PRISM_ACCESS_TOKEN: envAccessToken,
-    PRISM_REFRESH_TOKEN: envRefreshToken,
-    PRISMATIC_TENANT_ID: envTenantId,
-  } = getEnv();
+  const { source, profileName, accessToken, refreshToken, tenantId, url } = await getAuthContext();
 
-  if (envRefreshToken && !envAccessToken) {
-    const { accessToken: refreshedAccessToken } = await refreshAuthentication(
-      envRefreshToken,
-      envTenantId,
-    );
-    return refreshedAccessToken;
+  if (!accessToken && refreshToken) {
+    const refreshed = await refreshAuthentication(refreshToken, tenantId, url);
+    if (source === "profile") await writeActiveProfile(refreshed, profileName);
+    return refreshed.accessToken;
   }
 
-  const config = await readConfig();
-  const { accessToken: configAccessToken, refreshToken: configRefreshToken } = config ?? {};
-  const configTenantId = config?.tenantId;
-
-  const accessToken = envAccessToken ?? configAccessToken;
-  const refreshToken = envRefreshToken ?? configRefreshToken;
-  const hasEnvTokenPair = envAccessToken !== undefined && envRefreshToken !== undefined;
-  const tenantId = envTenantId ?? (hasEnvTokenPair ? undefined : configTenantId);
-
   if (accessToken && refreshToken) {
-    // biome-ignore lint/complexity/useDateNow: TODO
-    const now = Math.floor(new Date().getTime() / 1000);
+    const now = Math.floor(Date.now() / 1000);
     const { exp } = jwtDecode<{ exp: number }>(accessToken);
 
-    // Refresh if expired or expiring in 5 minutes or less
     if (exp - now < 5 * 60) {
-      const refreshTokenPair = envRefreshToken ? refreshAuthentication : refresh;
-      const { accessToken: refreshedAccessToken } = await refreshTokenPair(refreshToken, tenantId);
-      return refreshedAccessToken;
+      const refreshed =
+        source === "environment"
+          ? await refreshAuthentication(refreshToken, tenantId, url)
+          : await refresh(refreshToken, tenantId, profileName);
+      return refreshed.accessToken;
     }
   }
 
@@ -509,8 +504,8 @@ export const getAccessToken = async (): Promise<string | undefined> => {
  * Check if the user is currently logged in. Return true if so, and false otherwise.
  */
 export const isLoggedIn = async (): Promise<boolean> => {
-  const configExists = await configFileExists();
-  if (!configExists) {
+  const resolvedContext = await getAuthContext();
+  if (!resolvedContext.accessToken && !resolvedContext.refreshToken) {
     return false;
   }
 
@@ -534,22 +529,24 @@ export const isLoggedIn = async (): Promise<boolean> => {
 /**
  * Revoke ALL refresh tokens for the logged in user
  */
-export const revokeRefreshToken = async (): Promise<void> => {
+export const revokeRefreshToken = async (): Promise<AuthContext["source"]> => {
+  const authContext = await getAuthContext();
   const loggedIn = await isLoggedIn();
   if (!loggedIn) {
     throw new Error("You are not currently logged in.");
   }
 
-  const config = await readConfig();
-  const { refreshToken } = config ?? {};
-  await fetch(new url.URL("/auth/revoke", prismaticUrl).toString(), {
+  await fetch(new URL("/auth/revoke", authContext.url).toString(), {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      refresh_token: refreshToken,
+      refresh_token: authContext.refreshToken,
     }),
   });
-  await logout();
+  if (authContext.source === "profile" && authContext.profileName) {
+    await deleteProfile(authContext.profileName);
+  }
+  return authContext.source;
 };

--- a/src/baseCommand.ts
+++ b/src/baseCommand.ts
@@ -1,5 +1,7 @@
-import { Command, Flags } from "@oclif/core";
+import { Command, Flags, type Interfaces } from "@oclif/core";
 import type { z } from "zod";
+import { selectProfile } from "./config.js";
+import { useDefaultAuthContext, useProfileAuthContext } from "./context.js";
 import { validateFlags } from "./utils/validation.js";
 
 export abstract class PrismaticBaseCommand extends Command {
@@ -22,9 +24,35 @@ export abstract class PrismaticBaseCommand extends Command {
         return input;
       },
     }),
+    profile: Flags.string({
+      description: "Use a profile",
+      env: "PRISM_PROFILE",
+      helpGroup: "GLOBAL",
+    }),
   };
 
-  // Ensure consistency across commands and allow for easier parsing in documentation generation
+  protected authContext: "default" | "profile" = "default";
+  protected profileName?: string;
+
+  protected async parse<
+    CommandFlags extends Record<string, unknown>,
+    BaseFlags extends Record<string, unknown>,
+    CommandArgs extends Record<string, unknown>,
+  >(
+    options?: Interfaces.Input<CommandFlags, BaseFlags, CommandArgs>,
+    argv?: string[],
+  ): Promise<Interfaces.ParserOutput<CommandFlags, BaseFlags, CommandArgs>> {
+    const result = await super.parse(options, argv);
+    this.profileName = result.flags.profile as string | undefined;
+    selectProfile(this.profileName);
+    if (this.authContext === "profile") {
+      useProfileAuthContext();
+    } else {
+      useDefaultAuthContext();
+    }
+    return result;
+  }
+
   static examples: Array<{ description: string; command: string }>;
 
   protected quietLog(message: string, quiet = false, type?: "warn"): void {
@@ -37,10 +65,6 @@ export abstract class PrismaticBaseCommand extends Command {
     }
   }
 
-  /**
-   * Parse command arguments and validate flags against a Zod schema.
-   * Returns parsed args and validated, typed flags.
-   */
   protected async parseWithSchema<T extends z.ZodType>(
     schema: T,
   ): Promise<{ args: Record<string, unknown>; flags: z.infer<T> }> {

--- a/src/commands/components/init/component.ts
+++ b/src/commands/components/init/component.ts
@@ -1,4 +1,5 @@
-import { Command, type Config, Flags } from "@oclif/core";
+import { type Config, Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import inquirer from "inquirer";
 import { camelCase } from "lodash-es";
 import path from "path";
@@ -9,7 +10,7 @@ import {
   TOOLCHAIN_NAMES,
 } from "../../../utils/toolchain/index.js";
 
-export default class GenerateComponentCommand extends Command {
+export default class GenerateComponentCommand extends PrismaticBaseCommand {
   static hidden = true;
   static description = "Initialize a new Component";
   static flags = {

--- a/src/commands/components/init/formats.ts
+++ b/src/commands/components/init/formats.ts
@@ -1,4 +1,5 @@
-import { Command, type Config, Flags } from "@oclif/core";
+import { type Config, Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { copy } from "fs-extra";
 import { camelCase } from "lodash-es";
 import path, { extname } from "path";
@@ -11,7 +12,7 @@ import {
   TOOLCHAIN_NAMES,
 } from "../../../utils/toolchain/index.js";
 
-export default class GenerateFormatsCommand extends Command {
+export default class GenerateFormatsCommand extends PrismaticBaseCommand {
   static hidden = true;
   static description = "Initialize a new Component from a format";
   static flags = {

--- a/src/commands/components/init/index.ts
+++ b/src/commands/components/init/index.ts
@@ -1,4 +1,5 @@
-import { Args, Command, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { promises as fs } from "fs";
 import * as path from "path";
 import { parseAndGenerate } from "wsdl-tsclient";
@@ -14,7 +15,7 @@ import {
 import GenerateComponentCommand from "./component.js";
 import GenerateFormatsCommand from "./formats.js";
 
-export default class InitializeComponent extends Command {
+export default class InitializeComponent extends PrismaticBaseCommand {
   static description = "Initialize a new Component";
 
   static examples = [
@@ -81,10 +82,10 @@ prism components:publish`,
       const openApiPath = rawOpenApiPath ? path.resolve(rawOpenApiPath) : undefined;
 
       if (!VALID_NAME_REGEX.test(name)) {
+        const regexUrl = new URL("https://regex101.com");
+        regexUrl.searchParams.set("regex", VALID_NAME_REGEX.source);
         this.error(
-          `'${name}' contains invalid characters. Please select a component name that starts and ends with alphanumeric characters, and contains only alphanumeric characters, hyphens, and underscores. See https://regex101.com/?regex=${encodeURIComponent(
-            VALID_NAME_REGEX.source,
-          )}`,
+          `'${name}' contains invalid characters. Please select a component name that starts and ends with alphanumeric characters, and contains only alphanumeric characters, hyphens, and underscores. See ${regexUrl}`,
           { exit: 1 },
         );
       }

--- a/src/commands/integrations/flows/test.ts
+++ b/src/commands/integrations/flows/test.ts
@@ -2,8 +2,9 @@ import { decode } from "@msgpack/msgpack";
 import { Flags } from "@oclif/core";
 import open from "open";
 import z from "zod";
-import { getAccessToken, prismaticUrl } from "../../../auth.js";
+import { getAccessToken } from "../../../auth.js";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
+import { getPrismaticUrl } from "../../../context.js";
 import { exists, fs } from "../../../fs.js";
 import { handleError } from "../../../utils/errors.js";
 import { fetch } from "../../../utils/http.js";
@@ -649,7 +650,11 @@ async function promptIntegrationValidation(
     ...CONFIGURE_INSTANCE_PARAMS,
     ...(accessToken && { jwt: accessToken }),
   });
-  const configUrl = `${prismaticUrl}/configure-instance/${systemInstanceId}/?${params.toString()}`;
+  const configUrl = new URL(
+    `/configure-instance/${encodeURIComponent(systemInstanceId)}/`,
+    await getPrismaticUrl(),
+  );
+  configUrl.search = params.toString();
 
   if (!isConfigured) {
     if (quiet) {
@@ -660,7 +665,7 @@ async function promptIntegrationValidation(
       );
 
       if (shouldOpen) {
-        await open(configUrl);
+        await open(configUrl.toString());
       } else {
         console.log(
           `\nYou can configure the test instance later by visiting the following URL:\n${configUrl}`,

--- a/src/commands/integrations/init/index.ts
+++ b/src/commands/integrations/init/index.ts
@@ -1,10 +1,11 @@
-import { Args, Command, Flags } from "@oclif/core";
+import { Args, Flags } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import fs from "fs/promises";
 import { camelCase } from "lodash-es";
 import path from "path";
 import { v4 as uuid4 } from "uuid";
-import { prismaticUrl } from "../../../auth.js";
 import { template, updatePackageJson } from "../../../generate/util.js";
+import { getPrismaticUrl } from "../../../context.js";
 import { VALID_NAME_REGEX } from "../../../utils/generate.js";
 import {
   DEFAULT_TOOLCHAIN,
@@ -19,7 +20,7 @@ const CLEANABLE_TEMPLATES = [
   "src/configPages.ts",
 ];
 
-export default class InitializeIntegration extends Command {
+export default class InitializeIntegration extends PrismaticBaseCommand {
   static description = "Initialize a new Code Native Integration";
 
   static examples = [
@@ -70,10 +71,10 @@ export default class InitializeIntegration extends Command {
     const toolchain = getToolchain(toolchainName);
 
     if (!VALID_NAME_REGEX.test(name)) {
+      const regexUrl = new URL("https://regex101.com");
+      regexUrl.searchParams.set("regex", VALID_NAME_REGEX.source);
       this.error(
-        `'${name}' contains invalid characters. Please select an integration name that starts and ends with alphanumeric characters, and contains only alphanumeric characters, hyphens, and underscores. See https://regex101.com/?regex=${encodeURIComponent(
-          VALID_NAME_REGEX.source,
-        )}`,
+        `'${name}' contains invalid characters. Please select an integration name that starts and ends with alphanumeric characters, and contains only alphanumeric characters, hyphens, and underscores. See ${regexUrl}`,
         { exit: 1 },
       );
     }
@@ -81,6 +82,7 @@ export default class InitializeIntegration extends Command {
     await fs.mkdir(name);
     process.chdir(name);
 
+    const registryUrl = new URL("/packages/npm", await getPrismaticUrl()).toString();
     const context = {
       integration: { name, description: "Prism-generated Integration", key: camelCase(name) },
       flow: {
@@ -95,7 +97,7 @@ export default class InitializeIntegration extends Command {
         },
       },
       registry: {
-        url: new URL("/packages/npm", prismaticUrl).toString(),
+        url: registryUrl,
         scope: "@component-manifests",
       },
     };

--- a/src/commands/integrations/open.ts
+++ b/src/commands/integrations/open.ts
@@ -1,7 +1,8 @@
-import { Args, Command } from "@oclif/core";
+import { Args } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { openIntegration } from "../../utils/integration/open.js";
 
-export default class OpenCommand extends Command {
+export default class OpenCommand extends PrismaticBaseCommand {
   static description = "Open the Designer for the specified Integration";
   static args = {
     integrationId: Args.string({

--- a/src/commands/login/index.ts
+++ b/src/commands/login/index.ts
@@ -1,8 +1,10 @@
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
 import { isLoggedIn, login } from "../../auth.js";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
+import { getActiveProfileName } from "../../config.js";
 import { ux } from "../../utils/ux.js";
 
-export default class LoginCommand extends Command {
+export default class LoginCommand extends PrismaticBaseCommand {
   static description = "Log in to your Prismatic account";
 
   static flags = {
@@ -18,13 +20,17 @@ export default class LoginCommand extends Command {
     }),
   };
 
+  protected authContext = "profile" as const;
+
   async run() {
     const {
       flags: { force, url },
     } = await this.parse(LoginCommand);
 
+    const profileName = await getActiveProfileName();
+
     if (!force && (await isLoggedIn())) {
-      this.log("You are already logged in and ready to go!");
+      this.log(`Already logged in to '${profileName}'.`);
       return;
     }
 
@@ -32,7 +38,7 @@ export default class LoginCommand extends Command {
       await ux.anykey("Press any key to open prismatic.io in your default browser");
     }
 
-    await login({ url });
-    this.log("Login complete!");
+    await login({ url, profileName });
+    this.log(`Logged in to '${profileName}'.`);
   }
 }

--- a/src/commands/login/switch.ts
+++ b/src/commands/login/switch.ts
@@ -1,17 +1,20 @@
-import { Command } from "@oclif/core";
 import { fetchUserTenants, isLoggedIn, refresh, selectTenant } from "../../auth.js";
-import { readConfig, writeConfig } from "../../config.js";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
+import { getActiveProfileName, readProfile, writeActiveProfile } from "../../config.js";
 import { whoAmI } from "../../utils/user/query.js";
 
-export default class LoginSwitchCommand extends Command {
+export default class LoginSwitchCommand extends PrismaticBaseCommand {
   static description = "Switch between organization tenants";
+
+  protected authContext = "profile" as const;
 
   async run() {
     await this.parse(LoginSwitchCommand);
-    const config = await readConfig();
+    const profileName = this.profileName ?? (await getActiveProfileName());
+    const config = await readProfile(profileName);
     const loggedIn = (await isLoggedIn()) && config;
     if (!loggedIn) {
-      this.log("You are not logged in. Please run 'prism login' first.");
+      this.log("Not logged in. Run 'prism login'.");
       return;
     }
 
@@ -28,11 +31,11 @@ export default class LoginSwitchCommand extends Command {
     const activeTenants = tenants.filter((t) => !t.systemSuspended);
 
     if (!currentTenantSuspended && activeTenants.length <= 1) {
-      const log_msg =
+      const message =
         activeTenants.length === 1
-          ? "You are currently authenticated with the only tenant available on this stack. To switch to a tenant on another stack, update the PRISMATIC_URL value to access additional tenants."
-          : "Your user does not have access to tenants on this stack. Check the PRISMATIC_URL value.";
-      this.log(log_msg);
+          ? "This is the only tenant available to this profile."
+          : "No tenants are available to this profile.";
+      this.log(message);
       return;
     }
 
@@ -47,19 +50,22 @@ export default class LoginSwitchCommand extends Command {
 
     if (!selectedTenantId || selectedTenantId === currentTenantId) {
       if (currentTenantId && !currentTenantSuspended) {
-        await writeConfig({
-          ...config,
-          tenantId: currentTenantId,
-        });
+        await writeActiveProfile(
+          {
+            ...config,
+            tenantId: currentTenantId,
+          },
+          profileName,
+        );
         this.log(`Active tenant: ${currentTenant?.orgName} (${currentTenant?.url})`);
       }
       return;
     }
 
     this.log("\nSwitching tenant...");
-    await refresh(config.refreshToken, selectedTenantId);
+    await refresh(config.refreshToken, selectedTenantId, profileName);
 
     const selectedTenant = tenants.find((t) => t.tenantId === selectedTenantId);
-    this.log(`Successfully switched to: ${selectedTenant?.orgName} (${selectedTenant?.url})`);
+    this.log(`Switched to: ${selectedTenant?.orgName} (${selectedTenant?.url})`);
   }
 }

--- a/src/commands/logout.test.ts
+++ b/src/commands/logout.test.ts
@@ -1,0 +1,75 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { logout } from "../auth.js";
+import { type Profile, readConfigFile, selectProfile, writeProfile } from "../config.js";
+import LogoutCommand from "./logout.js";
+
+const profile: Profile = {
+  accessToken: "access",
+  expiresIn: 3600,
+  refreshToken: "refresh",
+  scope: "openid profile email",
+  tokenType: "Bearer",
+  prismaticUrl: "https://app.prismatic.io",
+};
+
+describe("logout", () => {
+  let tmpDir: string;
+  let configPath: string;
+
+  beforeAll(async () => {
+    tmpDir = await mkdtemp(path.join(tmpdir(), "prism-logout-test-"));
+  });
+
+  afterAll(async () => rm(tmpDir, { recursive: true, force: true }));
+
+  beforeEach(() => {
+    configPath = path.join(tmpDir, "config.yml");
+    vi.stubEnv("PRISM_CONFIG_FILE", configPath);
+    vi.stubEnv("PRISM_PROFILE", "");
+    selectProfile(undefined);
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await rm(configPath, { force: true });
+  });
+
+  it("removes only the original profile during browser logout", async () => {
+    await writeProfile("default", profile);
+    await writeProfile("staging", { ...profile, prismaticUrl: "https://staging.example.io" });
+
+    await LogoutCommand.run(["--browser"]);
+
+    expect(logout).toHaveBeenCalledOnce();
+    const config = await readConfigFile();
+    expect(Object.keys(config?.profiles ?? {})).toEqual(["staging"]);
+    expect(config?.defaultProfile).toBe("staging");
+  });
+
+  it("uses oclif's inherited profile flag without changing the default", async () => {
+    await writeProfile("default", profile);
+    await writeProfile("staging", { ...profile, prismaticUrl: "https://staging.example.io" });
+
+    await LogoutCommand.run(["--profile", "staging"]);
+
+    const config = await readConfigFile();
+    expect(Object.keys(config?.profiles ?? {})).toEqual(["default"]);
+    expect(config?.defaultProfile).toBe("default");
+  });
+
+  it("warns when environment credentials remain active", async () => {
+    await writeProfile("default", profile);
+    vi.stubEnv("PRISM_ACCESS_TOKEN", "environment-token");
+
+    await LogoutCommand.run([]);
+
+    await expect(readConfigFile()).resolves.toBeNull();
+  });
+
+  it("does not report a successful logout when the profile does not exist", async () => {
+    await expect(LogoutCommand.run([])).rejects.toThrow(/does not exist/);
+  });
+});

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,8 +1,10 @@
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
 import { logout } from "../auth.js";
-import { deleteConfig } from "../config.js";
+import { PrismaticBaseCommand } from "../baseCommand.js";
+import { deleteProfile, getActiveProfileName } from "../config.js";
+import { hasEnvironmentCredentials } from "../context.js";
 
-export default class LogoutCommand extends Command {
+export default class LogoutCommand extends PrismaticBaseCommand {
   static description = "Log out of your Prismatic account";
   static flags = {
     browser: Flags.boolean({
@@ -11,16 +13,32 @@ export default class LogoutCommand extends Command {
     }),
   };
 
+  protected authContext = "profile" as const;
+
   async run() {
     const {
       flags: { browser },
     } = await this.parse(LogoutCommand);
 
+    const profileName = await getActiveProfileName();
+    const environmentCredentialsActive = hasEnvironmentCredentials();
+
     if (browser) {
       await logout();
     }
 
-    await deleteConfig();
-    this.log("Logout complete!");
+    const result = await deleteProfile(profileName);
+    if (!result.deleted) {
+      const environmentHint = environmentCredentialsActive
+        ? " Environment credentials remain active until you unset PRISM_ACCESS_TOKEN and PRISM_REFRESH_TOKEN."
+        : "";
+      this.error(`Profile '${profileName}' does not exist.${environmentHint}`, { exit: 1 });
+    }
+    this.log(`Logged out of '${profileName}'.`);
+    if (environmentCredentialsActive) {
+      this.warn(
+        "Environment credentials are still active. Unset PRISM_ACCESS_TOKEN and PRISM_REFRESH_TOKEN to stop using them.",
+      );
+    }
   }
 }

--- a/src/commands/me/index.ts
+++ b/src/commands/me/index.ts
@@ -1,12 +1,13 @@
-import { Command } from "@oclif/core";
-import { prismaticUrl } from "../../auth.js";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
+import { getAuthContext } from "../../context.js";
 import { whoAmI } from "../../utils/user/query.js";
 
-export default class WhoAmICommand extends Command {
+export default class WhoAmICommand extends PrismaticBaseCommand {
   static description = "Print your user profile information";
 
   async run() {
     await this.parse(WhoAmICommand);
+    const authContext = await getAuthContext();
     const me = await whoAmI();
     const { name, email, org, customer, tenantId } = me;
     this.log("Name:", name);
@@ -20,6 +21,10 @@ export default class WhoAmICommand extends Command {
     if (tenantId) {
       this.log("Tenant ID:", tenantId);
     }
-    this.log("Endpoint URL:", prismaticUrl);
+    this.log("Endpoint URL:", authContext.url);
+    this.log("Authentication:", authContext.source === "environment" ? "Environment" : "Profile");
+    if (authContext.profileName) {
+      this.log("Profile:", authContext.profileName);
+    }
   }
 }

--- a/src/commands/me/token.test.ts
+++ b/src/commands/me/token.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from "vitest";
+import { getAuthContext } from "../../context.js";
+import { getStdout } from "../../../vitest.setup.js";
+import PrintTokenCommand from "./token.js";
+
+describe("me:token", () => {
+  it("prints the refresh token from the active environment session", async () => {
+    vi.mocked(getAuthContext).mockResolvedValue({
+      source: "environment",
+      url: "https://ci.example.io",
+      refreshToken: "environment-refresh-token",
+    });
+
+    await PrintTokenCommand.run(["--type", "refresh"]);
+
+    expect(getStdout()).toContain("environment-refresh-token");
+  });
+});

--- a/src/commands/me/token.ts
+++ b/src/commands/me/token.ts
@@ -1,7 +1,8 @@
-import { Command, Flags } from "@oclif/core";
+import { Flags } from "@oclif/core";
 import { getAccessToken } from "../../auth.js";
-import { readConfig } from "../../config.js";
-export default class PrintTokenCommand extends Command {
+import { PrismaticBaseCommand } from "../../baseCommand.js";
+import { getAuthContext } from "../../context.js";
+export default class PrintTokenCommand extends PrismaticBaseCommand {
   static description = "Print your authorization tokens";
 
   static flags = {
@@ -18,11 +19,8 @@ export default class PrintTokenCommand extends Command {
       flags: { type: tokenType },
     } = await this.parse(PrintTokenCommand);
 
-    //refresh before logging token
-    await getAccessToken();
-
-    const config = await readConfig();
-    const token = tokenType === "access" ? config?.accessToken : config?.refreshToken;
+    const token =
+      tokenType === "access" ? await getAccessToken() : (await getAuthContext()).refreshToken;
     this.log(token);
   }
 }

--- a/src/commands/me/token/revoke.ts
+++ b/src/commands/me/token/revoke.ts
@@ -28,7 +28,12 @@ export default class RevokeTokenCommand extends PrismaticBaseCommand {
       }
     }
 
-    await revokeRefreshToken();
+    const source = await revokeRefreshToken();
     this.log("All refresh tokens for your user have been revoked.");
+    if (source === "environment") {
+      this.warn(
+        "Remove PRISM_ACCESS_TOKEN and PRISM_REFRESH_TOKEN from your environment before running more commands.",
+      );
+    }
   }
 }

--- a/src/commands/profiles/delete.ts
+++ b/src/commands/profiles/delete.ts
@@ -1,0 +1,35 @@
+import { Args } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
+import { deleteProfile } from "../../config.js";
+
+export default class ProfilesDeleteCommand extends PrismaticBaseCommand {
+  static description = "Delete a profile";
+
+  static args = {
+    name: Args.string({
+      required: true,
+      description: "Profile to delete",
+    }),
+  };
+
+  async run() {
+    const {
+      args: { name },
+    } = await this.parse(ProfilesDeleteCommand);
+
+    const result = await deleteProfile(name);
+    if (!result.deleted) {
+      this.error(`Profile '${name}' does not exist.`, { exit: 1 });
+    }
+
+    if (result.isLast) {
+      this.log(`Deleted '${name}'. No profiles remain.`);
+      return;
+    }
+
+    this.log(`Deleted '${name}'.`);
+    if (result.defaultChanged) {
+      this.log(`Default profile is now '${result.defaultProfile}'.`);
+    }
+  }
+}

--- a/src/commands/profiles/list.ts
+++ b/src/commands/profiles/list.ts
@@ -1,0 +1,31 @@
+import { PrismaticBaseCommand } from "../../baseCommand.js";
+import { listProfiles } from "../../config.js";
+import { ux } from "../../utils/ux.js";
+
+export default class ProfilesListCommand extends PrismaticBaseCommand {
+  static description = "List profiles";
+
+  static flags = {
+    ...ux.table.flags(),
+  };
+
+  async run() {
+    const { flags } = await this.parse(ProfilesListCommand);
+
+    const profiles = await listProfiles();
+    if (profiles.length === 0) {
+      this.log("No profiles found.");
+      return;
+    }
+
+    ux.table(
+      profiles,
+      {
+        name: { header: "Profile", get: (p) => (p.isDefault ? `${p.name} (default)` : p.name) },
+        prismaticUrl: { header: "Endpoint URL" },
+        tenantId: { header: "Tenant ID", get: (p) => p.tenantId ?? "" },
+      },
+      flags,
+    );
+  }
+}

--- a/src/commands/profiles/profiles.test.ts
+++ b/src/commands/profiles/profiles.test.ts
@@ -1,0 +1,106 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { getStdout } from "../../../vitest.setup.js";
+import { type Profile, readConfigFile, writeProfile } from "../../config.js";
+import ProfilesDeleteCommand from "./delete.js";
+import ProfilesListCommand from "./list.js";
+import ProfilesUseCommand from "./use.js";
+
+const makeProfile = (overrides: Partial<Profile> = {}): Profile => ({
+  accessToken: "access",
+  expiresIn: 3600,
+  refreshToken: "refresh",
+  scope: "openid profile email",
+  tokenType: "Bearer",
+  prismaticUrl: "https://app.prismatic.io",
+  ...overrides,
+});
+
+describe("profiles commands", () => {
+  let tmpDir: string;
+  let configPath: string;
+
+  beforeAll(async () => {
+    tmpDir = await mkdtemp(path.join(tmpdir(), "prism-profiles-cmd-"));
+  });
+
+  afterAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    configPath = path.join(tmpDir, "config.yml");
+    vi.stubEnv("HOME", tmpDir);
+    vi.stubEnv("USERPROFILE", tmpDir);
+    vi.stubEnv("PRISM_CONFIG_FILE", configPath);
+    vi.stubEnv("PRISM_PROFILE", "");
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await rm(configPath, { force: true });
+  });
+
+  describe("profiles:list", () => {
+    it("lists profiles and marks the default", async () => {
+      await writeProfile("default", makeProfile({ tenantId: "t-1" }));
+      await writeProfile("staging", makeProfile({ prismaticUrl: "https://staging.example.io" }));
+
+      await ProfilesListCommand.run([]);
+
+      const out = getStdout();
+      expect(out).toContain("default (default)");
+      expect(out).toContain("staging");
+      expect(out).toContain("https://staging.example.io");
+      expect(out).toContain("t-1");
+    });
+
+    it("prints a hint when there are no profiles", async () => {
+      await ProfilesListCommand.run([]);
+      expect(getStdout()).toContain("No profiles found.");
+    });
+  });
+
+  describe("profiles:use", () => {
+    it("repoints the default and keeps the other profiles", async () => {
+      await writeProfile("default", makeProfile());
+      await writeProfile("staging", makeProfile());
+
+      await ProfilesUseCommand.run(["staging"]);
+
+      const file = await readConfigFile();
+      expect(file?.defaultProfile).toBe("staging");
+      expect(Object.keys(file?.profiles ?? {})).toEqual(["default", "staging"]);
+      expect(getStdout()).toContain("Using 'staging' by default.");
+    });
+  });
+
+  describe("profiles:delete", () => {
+    it("deletes a profile and reports it", async () => {
+      await writeProfile("default", makeProfile());
+      await writeProfile("staging", makeProfile());
+
+      await ProfilesDeleteCommand.run(["staging"]);
+
+      const file = await readConfigFile();
+      expect(Object.keys(file?.profiles ?? {})).toEqual(["default"]);
+      expect(getStdout()).toContain("Deleted 'staging'.");
+    });
+
+    it("removes the config file when the last profile is deleted", async () => {
+      await writeProfile("default", makeProfile());
+
+      await ProfilesDeleteCommand.run(["default"]);
+
+      expect(await readConfigFile()).toBeNull();
+      expect(getStdout()).toContain("No profiles remain.");
+    });
+
+    it("errors when the profile does not exist", async () => {
+      await writeProfile("default", makeProfile());
+      await expect(ProfilesDeleteCommand.run(["missing"])).rejects.toThrow(/does not exist/);
+    });
+  });
+});

--- a/src/commands/profiles/use.ts
+++ b/src/commands/profiles/use.ts
@@ -1,0 +1,23 @@
+import { Args } from "@oclif/core";
+import { PrismaticBaseCommand } from "../../baseCommand.js";
+import { useProfile } from "../../config.js";
+
+export default class ProfilesUseCommand extends PrismaticBaseCommand {
+  static description = "Set the default profile";
+
+  static args = {
+    name: Args.string({
+      required: true,
+      description: "Profile to use by default",
+    }),
+  };
+
+  async run() {
+    const {
+      args: { name },
+    } = await this.parse(ProfilesUseCommand);
+
+    await useProfile(name);
+    this.log(`Using '${name}' by default.`);
+  }
+}

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -4,11 +4,18 @@ import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type Configuration,
-  configFileExists,
-  deleteConfig,
-  readConfig,
-  writeConfig,
+  deleteProfile,
+  getActiveProfileName,
+  listProfiles,
+  type Profile,
+  readConfigFile,
+  readProfile,
+  useProfile,
+  writeActiveProfile,
+  writeProfile,
 } from "./config.js";
+import { DEFAULT_PRISMATIC_URL } from "./env.js";
+import { dumpYaml } from "./utils/serialize.js";
 
 const makeConfig = (overrides: Partial<Configuration> = {}): Configuration => ({
   accessToken: "access",
@@ -16,6 +23,12 @@ const makeConfig = (overrides: Partial<Configuration> = {}): Configuration => ({
   refreshToken: "refresh",
   scope: "openid profile email",
   tokenType: "Bearer",
+  ...overrides,
+});
+
+const makeProfile = (overrides: Partial<Profile> = {}): Profile => ({
+  ...makeConfig(),
+  prismaticUrl: "https://app.prismatic.io",
   ...overrides,
 });
 
@@ -48,16 +61,16 @@ describe("config with PRISM_CONFIG_FILE override", () => {
   });
 
   it("writes to the path specified by PRISM_CONFIG_FILE", async () => {
-    await writeConfig(makeConfig({ accessToken: "tok-1" }));
+    await writeActiveProfile(makeConfig({ accessToken: "tok-1" }));
 
     const contents = await readFile(configPath, { encoding: "utf-8" });
     expect(contents).toContain("accessToken: tok-1");
   });
 
   it("reads from the path specified by PRISM_CONFIG_FILE", async () => {
-    await writeConfig(makeConfig({ accessToken: "tok-2" }));
+    await writeActiveProfile(makeConfig({ accessToken: "tok-2" }));
 
-    const result = await readConfig();
+    const result = await readProfile();
     expect(result?.accessToken).toBe("tok-2");
   });
 
@@ -65,24 +78,16 @@ describe("config with PRISM_CONFIG_FILE override", () => {
     const nested = path.join(tmpDir, "nested", "dir", "config.yml");
     vi.stubEnv("PRISM_CONFIG_FILE", nested);
 
-    await writeConfig(makeConfig({ accessToken: "tok-3" }));
+    await writeActiveProfile(makeConfig({ accessToken: "tok-3" }));
 
     await expect(stat(nested)).resolves.toBeDefined();
     await rm(path.join(tmpDir, "nested"), { recursive: true, force: true });
   });
 
-  it("reports the file as existing only after a write", async () => {
-    expect(await configFileExists()).toBe(false);
-    await writeConfig(makeConfig());
-    expect(await configFileExists()).toBe(true);
-  });
-
   it("deletes the file at the overridden path", async () => {
-    await writeConfig(makeConfig());
-    expect(await configFileExists()).toBe(true);
-
-    await deleteConfig();
-    expect(await configFileExists()).toBe(false);
+    await writeActiveProfile(makeConfig());
+    await deleteProfile(await getActiveProfileName());
+    expect(await readConfigFile()).toBeNull();
   });
 });
 
@@ -108,14 +113,14 @@ describe("config with PRISM_CONFIG_FILE=/dev/null", () => {
 
   it("treats writes as a no-op so concurrent invocations cannot corrupt the file", async () => {
     const writers = Array.from({ length: 25 }, (_, i) =>
-      writeConfig(makeConfig({ accessToken: `tok-${i}` })),
+      writeActiveProfile(makeConfig({ accessToken: `tok-${i}` })),
     );
     await expect(Promise.all(writers)).resolves.toBeDefined();
   });
 
   it("returns null on read since /dev/null is empty", async () => {
-    await writeConfig(makeConfig({ accessToken: "ignored" }));
-    const result = await readConfig();
+    await writeActiveProfile(makeConfig({ accessToken: "ignored" }));
+    const result = await readProfile();
     expect(result).toBeNull();
   });
 });
@@ -142,7 +147,7 @@ describe("config without PRISM_CONFIG_FILE", () => {
   });
 
   it("falls back to the default path under HOME/.config/prism/config.yml", async () => {
-    await writeConfig(makeConfig({ accessToken: "default-path" }));
+    await writeActiveProfile(makeConfig({ accessToken: "default-path" }));
 
     const expectedPath = path.join(homeDir, ".config", "prism", "config.yml");
     const contents = await readFile(expectedPath, { encoding: "utf-8" });
@@ -150,15 +155,15 @@ describe("config without PRISM_CONFIG_FILE", () => {
   });
 
   it("returns null when the default file does not exist", async () => {
-    expect(await readConfig()).toBeNull();
+    expect(await readProfile()).toBeNull();
   });
 
   it("returns null when the file exists but is empty", async () => {
     const expectedPath = path.join(homeDir, ".config", "prism", "config.yml");
-    await writeConfig(makeConfig());
+    await writeActiveProfile(makeConfig());
     await writeFile(expectedPath, "", { encoding: "utf-8" });
 
-    expect(await readConfig()).toBeNull();
+    expect(await readProfile()).toBeNull();
   });
 });
 
@@ -187,47 +192,264 @@ describe("config schema validation", () => {
 
   it("refuses to write a configuration missing required fields", async () => {
     const invalid = { accessToken: "tok" } as unknown as Configuration;
-    await expect(writeConfig(invalid)).rejects.toThrow(/Refusing to write invalid configuration/);
+    await expect(writeActiveProfile(invalid)).rejects.toThrow(/could not save its configuration/);
   });
 
   it("refuses to write a configuration with empty required strings", async () => {
     const invalid = makeConfig({ accessToken: "" });
-    await expect(writeConfig(invalid)).rejects.toThrow(/accessToken cannot be empty/);
+    await expect(writeActiveProfile(invalid)).rejects.toThrow(/accessToken cannot be empty/);
   });
 
   it("refuses to write a configuration with the wrong field type", async () => {
     const invalid = makeConfig({ expiresIn: "soon" as unknown as number });
-    await expect(writeConfig(invalid)).rejects.toThrow(/Refusing to write invalid configuration/);
+    await expect(writeActiveProfile(invalid)).rejects.toThrow(/could not save its configuration/);
   });
 
   it("rejects a config file missing required fields when reading", async () => {
-    await writeFile(configPath, "accessToken: tok\n", { encoding: "utf-8" });
-    await expect(readConfig()).rejects.toThrow(/Invalid configuration/);
+    await writeFile(configPath, dumpYaml({ accessToken: "tok" }), { encoding: "utf-8" });
+    await expect(readProfile()).rejects.toThrow(/could not read the configuration/);
   });
 
   it("rejects a config file containing the wrong field type when reading", async () => {
     await writeFile(
       configPath,
-      [
-        "accessToken: tok",
-        "expiresIn: not-a-number",
-        "refreshToken: r",
-        "scope: s",
-        "tokenType: Bearer",
-      ].join("\n"),
+      dumpYaml({
+        accessToken: "tok",
+        expiresIn: "not-a-number",
+        refreshToken: "r",
+        scope: "s",
+        tokenType: "Bearer",
+      }),
       { encoding: "utf-8" },
     );
-    await expect(readConfig()).rejects.toThrow(/Invalid configuration/);
+    await expect(readProfile()).rejects.toThrow(/could not read the configuration/);
   });
 
   it("throws a helpful error when the config file is not valid yaml", async () => {
     await writeFile(configPath, "::: not yaml :::\n\t- :", { encoding: "utf-8" });
-    await expect(readConfig()).rejects.toThrow(/Failed to parse configuration/);
+    await expect(readProfile()).rejects.toThrow(/Failed to parse configuration/);
   });
 
   it("accepts an optional tenantId when present", async () => {
-    await writeConfig(makeConfig({ tenantId: "tenant-1" }));
-    const result = await readConfig();
+    await writeActiveProfile(makeConfig({ tenantId: "tenant-1" }));
+    const result = await readProfile();
     expect(result?.tenantId).toBe("tenant-1");
+  });
+});
+
+describe("multi-profile config", () => {
+  let tmpDir: string;
+  let configPath: string;
+
+  beforeAll(async () => {
+    tmpDir = await mkdtemp(path.join(tmpdir(), "prism-config-profiles-"));
+  });
+
+  afterAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    configPath = path.join(tmpDir, "config.yml");
+    stubFakeHome(tmpDir);
+    vi.stubEnv("PRISM_CONFIG_FILE", configPath);
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await rm(configPath, { force: true });
+  });
+
+  it("writes a versioned file that points its default at the first profile", async () => {
+    await writeProfile("staging", makeProfile({ accessToken: "stg" }));
+
+    const contents = await readFile(configPath, { encoding: "utf-8" });
+    expect(contents).toContain("version: 1");
+    expect(contents).toContain("defaultProfile: staging");
+
+    const file = await readConfigFile();
+    expect(file?.version).toBe(1);
+    expect(file?.defaultProfile).toBe("staging");
+    expect(file?.profiles.staging?.accessToken).toBe("stg");
+  });
+
+  it("merges additional profiles while preserving the default pointer", async () => {
+    await writeProfile("default", makeProfile({ accessToken: "def" }));
+    await writeProfile("staging", makeProfile({ accessToken: "stg" }));
+
+    const file = await readConfigFile();
+    expect(file?.defaultProfile).toBe("default");
+    expect(Object.keys(file?.profiles ?? {})).toEqual(["default", "staging"]);
+    expect(file?.profiles.default?.accessToken).toBe("def");
+    expect(file?.profiles.staging?.accessToken).toBe("stg");
+  });
+
+  it("reads the default profile when no name is given, or a named one when asked", async () => {
+    await writeProfile("default", makeProfile({ accessToken: "def" }));
+    await writeProfile("staging", makeProfile({ accessToken: "stg" }));
+
+    expect((await readProfile())?.accessToken).toBe("def");
+    expect((await readProfile("staging"))?.accessToken).toBe("stg");
+    expect(await readProfile("missing")).toBeNull();
+  });
+
+  it("lists profiles and marks the default", async () => {
+    await writeProfile("default", makeProfile({ tenantId: "t-1" }));
+    await writeProfile("staging", makeProfile({ prismaticUrl: "https://staging.example.io" }));
+
+    const profiles = await listProfiles();
+    expect(profiles).toEqual([
+      {
+        name: "default",
+        prismaticUrl: "https://app.prismatic.io",
+        tenantId: "t-1",
+        isDefault: true,
+      },
+      {
+        name: "staging",
+        prismaticUrl: "https://staging.example.io",
+        tenantId: undefined,
+        isDefault: false,
+      },
+    ]);
+  });
+
+  it("repoints the default to a remaining profile when the default is deleted", async () => {
+    await writeProfile("default", makeProfile());
+    await writeProfile("staging", makeProfile());
+
+    await deleteProfile("default");
+
+    const file = await readConfigFile();
+    expect(file?.defaultProfile).toBe("staging");
+    expect(Object.keys(file?.profiles ?? {})).toEqual(["staging"]);
+  });
+
+  it("unlinks the file once the last profile is deleted", async () => {
+    await writeProfile("default", makeProfile());
+
+    await deleteProfile("default");
+
+    expect(await readConfigFile()).toBeNull();
+  });
+
+  it("rejects a config file declaring an unsupported version", async () => {
+    await writeFile(configPath, dumpYaml({ version: 2, defaultProfile: "default", profiles: {} }), {
+      encoding: "utf-8",
+    });
+    await expect(readConfigFile()).rejects.toThrow(/could not read the configuration/);
+  });
+
+  it("rejects a default profile pointer that does not exist", async () => {
+    await writeFile(
+      configPath,
+      dumpYaml({
+        version: 1,
+        defaultProfile: "missing",
+        profiles: { default: makeProfile() },
+      }),
+      { encoding: "utf-8" },
+    );
+
+    await expect(readConfigFile()).rejects.toThrow(/default profile does not exist/);
+  });
+
+  it("resolves the active profile name from PRISM_PROFILE, then the file default", async () => {
+    await writeProfile("default", makeProfile());
+    await writeProfile("staging", makeProfile());
+
+    expect(await getActiveProfileName()).toBe("default");
+
+    vi.stubEnv("PRISM_PROFILE", "staging");
+    expect(await getActiveProfileName()).toBe("staging");
+  });
+
+  it("repoints the default pointer with useProfile without touching profiles", async () => {
+    await writeProfile("default", makeProfile({ accessToken: "def" }));
+    await writeProfile("staging", makeProfile({ accessToken: "stg" }));
+
+    await useProfile("staging");
+
+    const file = await readConfigFile();
+    expect(file?.defaultProfile).toBe("staging");
+    expect(Object.keys(file?.profiles ?? {})).toEqual(["default", "staging"]);
+    expect(file?.profiles.default?.accessToken).toBe("def");
+  });
+
+  it("throws when useProfile targets a profile that does not exist", async () => {
+    await writeProfile("default", makeProfile());
+    await expect(useProfile("missing")).rejects.toThrow(/Profile "missing" does not exist/);
+  });
+});
+
+describe("unversioned config support", () => {
+  let tmpDir: string;
+  let configPath: string;
+
+  beforeAll(async () => {
+    tmpDir = await mkdtemp(path.join(tmpdir(), "prism-config-unversioned-"));
+  });
+
+  afterAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    configPath = path.join(tmpDir, "config.yml");
+    stubFakeHome(tmpDir);
+    vi.stubEnv("PRISM_CONFIG_FILE", configPath);
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    await rm(configPath, { force: true });
+  });
+
+  const writeUnversionedFile = (overrides: Partial<Configuration> = {}) =>
+    writeFile(configPath, dumpYaml(makeConfig(overrides)), { encoding: "utf-8" });
+
+  it("reads an unversioned session as the default profile", async () => {
+    await writeUnversionedFile({ accessToken: "session-token", tenantId: "tenant-1" });
+
+    const file = await readConfigFile();
+    expect(file?.version).toBe(1);
+    expect(file?.defaultProfile).toBe("default");
+    expect(file?.profiles.default?.accessToken).toBe("session-token");
+    expect(file?.profiles.default?.tenantId).toBe("tenant-1");
+
+    const profile = await readProfile();
+    expect(profile?.accessToken).toBe("session-token");
+  });
+
+  it("resolves the unversioned session URL from the environment or default", async () => {
+    await writeUnversionedFile();
+
+    vi.stubEnv("PRISMATIC_URL", "");
+    const fromDefault = await readProfile();
+    expect(fromDefault?.prismaticUrl).toBe(DEFAULT_PRISMATIC_URL);
+
+    vi.stubEnv("PRISMATIC_URL", "https://staging.example.io");
+    const fromEnv = await readProfile();
+    expect(fromEnv?.prismaticUrl).toBe("https://staging.example.io");
+  });
+
+  it("does not change the file during a read", async () => {
+    await writeUnversionedFile({ accessToken: "session-token" });
+    const contents = await readFile(configPath, { encoding: "utf-8" });
+
+    await readConfigFile();
+
+    expect(await readFile(configPath, { encoding: "utf-8" })).toBe(contents);
+  });
+
+  it("persists the multi-profile shape on the next write", async () => {
+    await writeUnversionedFile({ accessToken: "session-token" });
+
+    await writeActiveProfile(makeConfig({ accessToken: "fresh-token" }));
+
+    const contents = await readFile(configPath, { encoding: "utf-8" });
+    expect(contents).toContain("version: 1");
+    expect(contents).toContain("defaultProfile: default");
+    expect(contents).toContain("accessToken: fresh-token");
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import { z } from "zod";
-import { getEnv } from "./env.js";
-import { exists, fs } from "./fs.js";
+import { DEFAULT_PRISMATIC_URL, getEnv } from "./env.js";
+import { fs } from "./fs.js";
 import { dumpYaml, loadYaml } from "./utils/serialize.js";
 import { formatValidationError } from "./utils/validation.js";
 
@@ -14,40 +14,78 @@ export const configurationSchema = z.object({
   tenantId: z.string().min(1).optional(),
 });
 
+export const profileSchema = configurationSchema.extend({
+  prismaticUrl: z.string().min(1, "prismaticUrl cannot be empty"),
+});
+
+const CONFIG_VERSION = 1;
+const hasProfile = (profiles: Record<string, Profile>, name: string): boolean =>
+  Object.hasOwn(profiles, name);
+
+export const configFileSchema = z
+  .object({
+    version: z.literal(CONFIG_VERSION),
+    defaultProfile: z.string().min(1),
+    profiles: z.record(z.string().min(1), profileSchema),
+  })
+  .refine(({ defaultProfile, profiles }) => hasProfile(profiles, defaultProfile), {
+    message: "The default profile does not exist",
+    path: ["defaultProfile"],
+  });
+
 export type Configuration = z.infer<typeof configurationSchema>;
+export type Profile = z.infer<typeof profileSchema>;
+export type ConfigFile = z.infer<typeof configFileSchema>;
+export type ProfileName = string;
+
+const resolveProfileUrl = (): string => getEnv().PRISMATIC_URL ?? DEFAULT_PRISMATIC_URL;
+const withProfile = (file: ConfigFile | null, name: ProfileName, profile: Profile): ConfigFile =>
+  file
+    ? { ...file, profiles: { ...file.profiles, [name]: profile } }
+    : { version: CONFIG_VERSION, defaultProfile: name, profiles: { [name]: profile } };
+let selectedProfile: string | undefined;
+
+export const selectProfile = (name?: string): void => {
+  selectedProfile = name;
+};
+
+const isUnversionedConfig = (raw: unknown): raw is Record<string, unknown> =>
+  typeof raw === "object" &&
+  raw !== null &&
+  !("version" in raw) &&
+  !("profiles" in raw) &&
+  "accessToken" in raw;
+
+const normalizeUnversionedConfig = (raw: Record<string, unknown>): unknown => ({
+  version: CONFIG_VERSION,
+  defaultProfile: "default",
+  profiles: { default: { ...raw, prismaticUrl: resolveProfileUrl() } },
+});
 
 const getConfigFilePath = (): string => getEnv().PRISM_CONFIG_FILE;
 
-const ensureConfigDirectoryExists = async (configFilePath: string) => {
-  const dir = path.dirname(configFilePath);
-  if (await exists(dir)) return;
-  await fs.mkdir(dir, { recursive: true });
-};
-
-export const configFileExists = async () => exists(getConfigFilePath());
-
-export const deleteConfig = async () => {
-  if (!(await configFileExists())) return;
-  return fs.unlink(getConfigFilePath());
-};
-
-export const writeConfig = async (config: Configuration) => {
-  const result = configurationSchema.safeParse(config);
+const writeConfigFile = async (configFile: ConfigFile) => {
+  const result = configFileSchema.safeParse(configFile);
   if (!result.success) {
     throw new Error(
-      `Refusing to write invalid configuration:\n${formatValidationError(result.error)}`,
+      `Prism could not save its configuration:\n${formatValidationError(result.error)}`,
     );
   }
   const configFilePath = getConfigFilePath();
-  await ensureConfigDirectoryExists(configFilePath);
+  await fs.mkdir(path.dirname(configFilePath), { recursive: true });
   const contents = dumpYaml(result.data, { skipInvalid: true });
   await fs.writeFile(configFilePath, contents, { encoding: "utf-8" });
 };
 
-export const readConfig = async (): Promise<Configuration | null> => {
+export const readConfigFile = async (): Promise<ConfigFile | null> => {
   const configFilePath = getConfigFilePath();
-  if (!(await configFileExists())) return null;
-  const contents = await fs.readFile(configFilePath, { encoding: "utf-8" });
+  let contents: string;
+  try {
+    contents = await fs.readFile(configFilePath, { encoding: "utf-8" });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
 
   let raw: unknown;
   try {
@@ -58,11 +96,84 @@ export const readConfig = async (): Promise<Configuration | null> => {
   }
   if (raw === null || raw === undefined) return null;
 
-  const result = configurationSchema.safeParse(raw);
+  const candidate = isUnversionedConfig(raw) ? normalizeUnversionedConfig(raw) : raw;
+  const result = configFileSchema.safeParse(candidate);
   if (!result.success) {
     throw new Error(
-      `Invalid configuration at ${configFilePath}:\n${formatValidationError(result.error)}`,
+      `Prism could not read the configuration at ${configFilePath}:\n${formatValidationError(result.error)}`,
     );
   }
   return result.data;
+};
+
+const resolveActiveName = (file: ConfigFile | null): ProfileName => {
+  if (selectedProfile) return selectedProfile;
+  const envProfile = getEnv().PRISM_PROFILE;
+  if (envProfile) return envProfile;
+  return file?.defaultProfile ?? "default";
+};
+
+export const getActiveProfileName = async (): Promise<ProfileName> =>
+  resolveActiveName(await readConfigFile());
+
+export const readProfileSelection = async (
+  name?: ProfileName,
+): Promise<{ name: ProfileName; profile: Profile | null }> => {
+  const file = await readConfigFile();
+  const profileName = name ?? resolveActiveName(file);
+  return { name: profileName, profile: file?.profiles[profileName] ?? null };
+};
+
+export const readProfile = async (name?: ProfileName): Promise<Profile | null> =>
+  (await readProfileSelection(name)).profile;
+
+export const writeProfile = async (name: ProfileName, profile: Profile) => {
+  await writeConfigFile(withProfile(await readConfigFile(), name, profile));
+};
+
+export const deleteProfile = async (name: ProfileName) => {
+  const file = await readConfigFile();
+  if (!file || !hasProfile(file.profiles, name)) return { deleted: false } as const;
+
+  const { [name]: _removed, ...remaining } = file.profiles;
+  const remainingNames = Object.keys(remaining);
+
+  if (remainingNames.length === 0) {
+    await fs.unlink(getConfigFilePath());
+    return { deleted: true, isLast: true } as const;
+  }
+
+  const defaultChanged = file.defaultProfile === name;
+  const defaultProfile = defaultChanged ? remainingNames[0] : file.defaultProfile;
+  await writeConfigFile({ version: CONFIG_VERSION, defaultProfile, profiles: remaining });
+  return { deleted: true, isLast: false, defaultChanged, defaultProfile } as const;
+};
+
+export const useProfile = async (name: ProfileName) => {
+  const file = await readConfigFile();
+  if (!file || !hasProfile(file.profiles, name)) {
+    throw new Error(`Profile "${name}" does not exist.`);
+  }
+  if (file.defaultProfile === name) return;
+  await writeConfigFile({ ...file, defaultProfile: name });
+};
+
+export const listProfiles = async (): Promise<
+  { name: ProfileName; prismaticUrl: string; tenantId?: string; isDefault: boolean }[]
+> => {
+  const file = await readConfigFile();
+  if (!file) return [];
+  return Object.entries(file.profiles).map(([name, profile]) => ({
+    name,
+    prismaticUrl: profile.prismaticUrl,
+    tenantId: profile.tenantId,
+    isDefault: name === file.defaultProfile,
+  }));
+};
+
+export const writeActiveProfile = async (config: Configuration, name?: ProfileName) => {
+  const file = await readConfigFile();
+  const profileName = name ?? resolveActiveName(file);
+  const prismaticUrl = file?.profiles[profileName]?.prismaticUrl ?? resolveProfileUrl();
+  await writeConfigFile(withProfile(file, profileName, { ...config, prismaticUrl }));
 };

--- a/src/context.test.ts
+++ b/src/context.test.ts
@@ -1,0 +1,155 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { type Profile, selectProfile, writeProfile } from "./config.js";
+import {
+  getAuthContext,
+  getPrismaticUrl,
+  useDefaultAuthContext,
+  useProfileAuthContext,
+} from "./context.js";
+import { DEFAULT_PRISMATIC_URL } from "./env.js";
+
+vi.unmock("./context.js");
+
+const makeProfile = (overrides: Partial<Profile> = {}): Profile => ({
+  accessToken: "access",
+  expiresIn: 3600,
+  refreshToken: "refresh",
+  scope: "openid profile email",
+  tokenType: "Bearer",
+  prismaticUrl: DEFAULT_PRISMATIC_URL,
+  ...overrides,
+});
+
+describe("profile context", () => {
+  let tmpDir: string;
+  let configPath: string;
+
+  beforeAll(async () => {
+    tmpDir = await mkdtemp(path.join(tmpdir(), "prism-context-test-"));
+  });
+
+  afterAll(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  beforeEach(() => {
+    configPath = path.join(tmpDir, "config.yml");
+    vi.stubEnv("PRISM_CONFIG_FILE", configPath);
+    vi.stubEnv("PRISMATIC_URL", "");
+    vi.stubEnv("PRISMATIC_TENANT_ID", "");
+    vi.stubEnv("PRISM_PROFILE", "");
+    vi.stubEnv("PRISM_ACCESS_TOKEN", "");
+    vi.stubEnv("PRISM_REFRESH_TOKEN", "");
+    selectProfile(undefined);
+    useDefaultAuthContext();
+  });
+
+  afterEach(async () => {
+    selectProfile(undefined);
+    vi.unstubAllEnvs();
+    await rm(configPath, { force: true });
+  });
+
+  it("uses the default URL without a profile or environment override", async () => {
+    expect(await getPrismaticUrl()).toBe(DEFAULT_PRISMATIC_URL);
+  });
+
+  it("uses the selected profile URL", async () => {
+    await writeProfile("default", makeProfile());
+    await writeProfile("staging", makeProfile({ prismaticUrl: "https://staging.example.io" }));
+    selectProfile("staging");
+
+    expect(await getPrismaticUrl()).toBe("https://staging.example.io");
+  });
+
+  it("rejects a URL that conflicts with stored profile credentials", async () => {
+    await writeProfile("default", makeProfile({ prismaticUrl: "https://stored.example.io" }));
+    vi.stubEnv("PRISMATIC_URL", "https://other.example.io");
+
+    await expect(getPrismaticUrl()).rejects.toThrow(/does not match profile 'default'/);
+  });
+
+  it("accepts a matching URL override", async () => {
+    await writeProfile("default", makeProfile({ prismaticUrl: "https://stored.example.io" }));
+    vi.stubEnv("PRISMATIC_URL", "https://stored.example.io");
+
+    expect(await getPrismaticUrl()).toBe("https://stored.example.io");
+  });
+
+  it("uses the environment URL with environment credentials", async () => {
+    await writeProfile("default", makeProfile({ prismaticUrl: "https://stored.example.io" }));
+    vi.stubEnv("PRISMATIC_URL", "https://ci.example.io");
+    vi.stubEnv("PRISM_ACCESS_TOKEN", "ci-token");
+
+    expect(await getPrismaticUrl()).toBe("https://ci.example.io");
+  });
+
+  it("keeps a profile tenant with its profile credentials", async () => {
+    await writeProfile("default", makeProfile({ tenantId: "stored-tenant" }));
+    expect((await getAuthContext()).tenantId).toBe("stored-tenant");
+
+    vi.stubEnv("PRISMATIC_TENANT_ID", "env-tenant");
+    expect((await getAuthContext()).tenantId).toBe("stored-tenant");
+
+    vi.stubEnv("PRISM_ACCESS_TOKEN", "ci-token");
+    expect((await getAuthContext()).tenantId).toBe("env-tenant");
+  });
+
+  it("does not borrow a profile tenant for environment credentials", async () => {
+    await writeProfile("default", makeProfile({ tenantId: "stored-tenant" }));
+    vi.stubEnv("PRISM_ACCESS_TOKEN", "ci-token");
+
+    expect((await getAuthContext()).tenantId).toBeUndefined();
+  });
+
+  it("uses the whole environment credential set instead of mixing it with a profile", async () => {
+    await writeProfile(
+      "default",
+      makeProfile({
+        accessToken: "profile-access",
+        refreshToken: "profile-refresh",
+        tenantId: "profile-tenant",
+        prismaticUrl: "https://profile.example.io",
+      }),
+    );
+    vi.stubEnv("PRISM_ACCESS_TOKEN", "environment-access");
+
+    expect(await getAuthContext()).toEqual({
+      source: "environment",
+      url: DEFAULT_PRISMATIC_URL,
+      accessToken: "environment-access",
+      refreshToken: undefined,
+      tenantId: undefined,
+    });
+  });
+
+  it("forces profile credentials for profile-management auth flows", async () => {
+    await writeProfile(
+      "staging",
+      makeProfile({
+        accessToken: "profile-access",
+        refreshToken: "profile-refresh",
+        tenantId: "profile-tenant",
+        prismaticUrl: "https://staging.example.io",
+      }),
+    );
+    selectProfile("staging");
+    vi.stubEnv("PRISM_ACCESS_TOKEN", "environment-access");
+    vi.stubEnv("PRISM_REFRESH_TOKEN", "environment-refresh");
+    vi.stubEnv("PRISMATIC_TENANT_ID", "environment-tenant");
+    vi.stubEnv("PRISMATIC_URL", "https://environment.example.io");
+    useProfileAuthContext();
+
+    expect(await getAuthContext()).toEqual({
+      source: "profile",
+      profileName: "staging",
+      url: "https://staging.example.io",
+      accessToken: "profile-access",
+      refreshToken: "profile-refresh",
+      tenantId: "profile-tenant",
+    });
+  });
+});

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,0 +1,69 @@
+import { readProfileSelection } from "./config.js";
+import { DEFAULT_PRISMATIC_URL, getEnv } from "./env.js";
+
+export type AuthContext = {
+  source: "environment" | "profile";
+  profileName?: string;
+  url: string;
+  accessToken?: string;
+  refreshToken?: string;
+  tenantId?: string;
+};
+
+let profileOnly = false;
+
+export const hasEnvironmentCredentials = (): boolean => {
+  const env = getEnv();
+  return Boolean(env.PRISM_ACCESS_TOKEN || env.PRISM_REFRESH_TOKEN);
+};
+
+export const useDefaultAuthContext = (): void => {
+  profileOnly = false;
+};
+
+export const useProfileAuthContext = (): void => {
+  profileOnly = true;
+};
+
+export const getAuthContext = async (): Promise<AuthContext> => {
+  const env = getEnv();
+  if (profileOnly) return resolveProfileAuthContext();
+  if (!profileOnly && (env.PRISM_ACCESS_TOKEN || env.PRISM_REFRESH_TOKEN)) {
+    return {
+      source: "environment",
+      url: env.PRISMATIC_URL ?? DEFAULT_PRISMATIC_URL,
+      accessToken: env.PRISM_ACCESS_TOKEN,
+      refreshToken: env.PRISM_REFRESH_TOKEN,
+      tenantId: env.PRISMATIC_TENANT_ID,
+    };
+  }
+
+  const { name, profile } = await readProfileSelection();
+  if (profile && env.PRISMATIC_URL && env.PRISMATIC_URL !== profile.prismaticUrl) {
+    throw new Error(`PRISMATIC_URL does not match profile '${name}'.`);
+  }
+
+  return {
+    source: "profile",
+    profileName: name,
+    url: profile?.prismaticUrl ?? env.PRISMATIC_URL ?? DEFAULT_PRISMATIC_URL,
+    accessToken: profile?.accessToken,
+    refreshToken: profile?.refreshToken,
+    tenantId: profile?.tenantId,
+  };
+};
+
+const resolveProfileAuthContext = async (): Promise<AuthContext> => {
+  const selection = await readProfileSelection();
+  const profile = selection.profile;
+  return {
+    source: "profile",
+    profileName: selection.name,
+    url: profile?.prismaticUrl ?? getEnv().PRISMATIC_URL ?? DEFAULT_PRISMATIC_URL,
+    accessToken: profile?.accessToken,
+    refreshToken: profile?.refreshToken,
+    tenantId: profile?.tenantId,
+  };
+};
+
+export const getPrismaticUrl = async (): Promise<string> => (await getAuthContext()).url;

--- a/src/env.test.ts
+++ b/src/env.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { DEFAULT_PRISMATIC_URL, getDefaultConfigFilePath, getEnv } from "./env.js";
+import { getDefaultConfigFilePath, getEnv } from "./env.js";
 
 describe("getEnv", () => {
   afterEach(() => {
@@ -7,6 +7,8 @@ describe("getEnv", () => {
   });
 
   describe.each([
+    { key: "PRISMATIC_URL" },
+    { key: "PRISM_PROFILE" },
     { key: "PRISM_ACCESS_TOKEN" },
     { key: "PRISM_REFRESH_TOKEN" },
     { key: "PRISMATIC_TENANT_ID" },
@@ -19,22 +21,6 @@ describe("getEnv", () => {
     ])("$label → $expected", ({ input, expected }) => {
       vi.stubEnv(key, input);
       expect(getEnv()[key]).toBe(expected);
-    });
-  });
-
-  describe("PRISMATIC_URL (defaulted)", () => {
-    it.each([
-      { label: "unset", input: undefined, expected: DEFAULT_PRISMATIC_URL },
-      { label: "empty string", input: "", expected: DEFAULT_PRISMATIC_URL },
-      { label: "whitespace-only", input: "   ", expected: DEFAULT_PRISMATIC_URL },
-      {
-        label: "explicit value",
-        input: "https://custom.example.com",
-        expected: "https://custom.example.com",
-      },
-    ])("$label → $expected", ({ input, expected }) => {
-      vi.stubEnv("PRISMATIC_URL", input);
-      expect(getEnv().PRISMATIC_URL).toBe(expected);
     });
   });
 
@@ -54,6 +40,7 @@ describe("getEnv", () => {
     const clearAll = () => {
       vi.stubEnv("PRISMATIC_URL", undefined);
       vi.stubEnv("PRISM_CONFIG_FILE", undefined);
+      vi.stubEnv("PRISM_PROFILE", undefined);
       vi.stubEnv("PRISM_ACCESS_TOKEN", undefined);
       vi.stubEnv("PRISM_REFRESH_TOKEN", undefined);
       vi.stubEnv("PRISMATIC_TENANT_ID", undefined);
@@ -62,8 +49,9 @@ describe("getEnv", () => {
     it("returns defaults / undefined when nothing is set", () => {
       clearAll();
       expect(getEnv()).toEqual({
-        PRISMATIC_URL: DEFAULT_PRISMATIC_URL,
+        PRISMATIC_URL: undefined,
         PRISM_CONFIG_FILE: getDefaultConfigFilePath(),
+        PRISM_PROFILE: undefined,
         PRISM_ACCESS_TOKEN: undefined,
         PRISM_REFRESH_TOKEN: undefined,
         PRISMATIC_TENANT_ID: undefined,
@@ -77,6 +65,7 @@ describe("getEnv", () => {
       expect(getEnv()).toEqual({
         PRISMATIC_URL: "https://custom.example.com",
         PRISM_CONFIG_FILE: getDefaultConfigFilePath(),
+        PRISM_PROFILE: undefined,
         PRISM_ACCESS_TOKEN: undefined,
         PRISM_REFRESH_TOKEN: "rt-123",
         PRISMATIC_TENANT_ID: undefined,
@@ -92,6 +81,7 @@ describe("getEnv", () => {
       expect(getEnv()).toEqual({
         PRISMATIC_URL: "https://custom.example.com",
         PRISM_CONFIG_FILE: getDefaultConfigFilePath(),
+        PRISM_PROFILE: undefined,
         PRISM_ACCESS_TOKEN: undefined,
         PRISM_REFRESH_TOKEN: "rt-123",
         PRISMATIC_TENANT_ID: undefined,

--- a/src/env.ts
+++ b/src/env.ts
@@ -2,12 +2,7 @@ import { homedir } from "os";
 import path from "path";
 import { z } from "zod";
 
-/**
- * Normalizes empty or whitespace-only strings to undefined before validation.
- * CI systems such as GitHub Actions forward unset action inputs as empty
- * strings rather than omitting the env var, and we want those to behave the
- * same as the variable being unset.
- */
+// Treat empty action inputs as unset.
 const normalizeEmpty = (val: unknown) =>
   typeof val === "string" && val.trim() === "" ? undefined : val;
 
@@ -19,11 +14,12 @@ export const getDefaultConfigFilePath = (): string =>
   path.join(homedir(), ".config", "prism", "config.yml");
 
 const envSchema = z.object({
-  PRISMATIC_URL: z.preprocess(normalizeEmpty, z.string().min(1).default(DEFAULT_PRISMATIC_URL)),
+  PRISMATIC_URL: optionalEnvString,
   PRISM_CONFIG_FILE: z.preprocess(
     normalizeEmpty,
     z.string().min(1).default(getDefaultConfigFilePath),
   ),
+  PRISM_PROFILE: optionalEnvString,
   PRISM_ACCESS_TOKEN: optionalEnvString,
   PRISM_REFRESH_TOKEN: optionalEnvString,
   PRISMATIC_TENANT_ID: optionalEnvString,

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -39,7 +39,7 @@ describe("processError", () => {
       { query: "query { me { id } }" },
     );
     const out = processError(err);
-    expect(out.message).toMatch(/not logged/i);
+    expect(out.message).toMatch(/not authenticated/i);
   });
 
   it("preserves the message on a plain Error", () => {

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -18,7 +18,7 @@ const getStatusMessage = (status: number): string | undefined => {
     return;
   }
   return status === StatusCodes.UNAUTHORIZED
-    ? "You are not logged to the Prismatic platform at the specified endpoint URL. Check the value for PRISMATIC_URL."
+    ? "Not authenticated. Run 'prism login' or select another profile."
     : getReasonPhrase(status);
 };
 
@@ -47,14 +47,11 @@ const extractResponseError = ({ response: { errors = [], status } }: ClientError
 
 type ErrorToHandle = Parameters<typeof handle>[0];
 
-/** Accept arbitrary errors and convert them to something oclif handles. */
 export const processError = (error: unknown): ErrorToHandle => {
-  // Pass OclifErrors through unchanged
   if (isOclifError(error)) {
     return error;
   }
 
-  // Try to process GraphQL errors into more user-friendly forms
   if (isClientError(error)) {
     return {
       ...error,
@@ -63,8 +60,7 @@ export const processError = (error: unknown): ErrorToHandle => {
     };
   }
 
-  // Error.name is usually non-enumerable, so preserve it explicitly. Oclif's formatter requires
-  // both name and message and otherwise renders an empty string.
+  // Oclif needs the non-enumerable error name copied explicitly.
   if (isError(error)) {
     return {
       ...error,
@@ -73,7 +69,6 @@ export const processError = (error: unknown): ErrorToHandle => {
     };
   }
 
-  // Last ditch best effort
   return {
     name: "Error",
     message: fallbackMessage(String(error), "Unknown error"),

--- a/src/generate/formats/writer/index.ts
+++ b/src/generate/formats/writer/index.ts
@@ -18,6 +18,10 @@ const writeComponentIndex = (
   isPublic: boolean,
   { display: { label, description, iconPath } }: Component,
 ): SourceFile => {
+  const documentationUrl = new URL(
+    `/docs/components/${encodeURIComponent(key)}/`,
+    "https://prismatic.io",
+  );
   const file = project.createSourceFile(path.join("src", "index.ts"), undefined, {
     scriptKind: ScriptKind.TS,
   });
@@ -45,10 +49,7 @@ const writeComponentIndex = (
         .writeLine("component({")
         .writeLine(`key: "${key}",`)
         .conditionalWriteLine(isPublic, "public: true,")
-        .conditionalWriteLine(
-          isPublic,
-          `documentationUrl: "https://prismatic.io/docs/components/${key}/",`,
-        )
+        .conditionalWriteLine(isPublic, `documentationUrl: "${documentationUrl}",`)
         .writeLine("display: {")
         .writeLine(`label: "${label}",`)
         .writeLine(`description: "${createDescription(description)}",`)

--- a/src/generate/util.ts
+++ b/src/generate/util.ts
@@ -70,7 +70,9 @@ const updateDependencies = async (dependencies: Record<string, string>) => {
   const promises = Object.entries(dependencies).map(async ([name, version]) => {
     try {
       if (version === "*" && !name.includes("@component-manifests")) {
-        const response = await fetch(`https://registry.npmjs.org/${name}/latest`);
+        const packageUrl = new URL("https://registry.npmjs.org");
+        packageUrl.pathname = `/${name}/latest`;
+        const response = await fetch(packageUrl.toString());
         const data = (await response.json()) as any;
         return [name, data.version];
       }

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,5 +1,6 @@
 import { URL } from "url";
-import { getAccessToken, prismaticUrl } from "./auth.js";
+import { getAccessToken } from "./auth.js";
+import { getPrismaticUrl } from "./context.js";
 import { fetch } from "./utils/http.js";
 
 interface GQLRequest<TVariables = Record<string, unknown>> {
@@ -77,7 +78,7 @@ export const gqlRequest = async <T = any, TVariables = Record<string, unknown>>(
   variables,
 }: GQLRequest<TVariables>): Promise<T> => {
   const accessToken = await getAccessToken();
-  const url = new URL("/api", prismaticUrl).toString();
+  const url = new URL("/api", await getPrismaticUrl()).toString();
 
   const query = document;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,6 +83,9 @@ import OrganizationUsersDeleteCommand from "./commands/organization/users/delete
 import OrganizationUsersListCommand from "./commands/organization/users/list.js";
 import OrganizationUsersRolesCommand from "./commands/organization/users/roles.js";
 import OrganizationUsersUpdateCommand from "./commands/organization/users/update.js";
+import ProfilesDeleteCommand from "./commands/profiles/delete.js";
+import ProfilesListCommand from "./commands/profiles/list.js";
+import ProfilesUseCommand from "./commands/profiles/use.js";
 import TranslationsListCommand from "./commands/translations/list.js";
 import WorkflowsExportCommand from "./commands/workflows/export.js";
 import WorkflowsImportCommand from "./commands/workflows/import.js";
@@ -120,6 +123,9 @@ export const Commands = {
   "integrations:validate-yaml": IntegrationsValidateYamlCommand,
   me: MeCommand,
   "me:token": MeTokenCommand,
+  "profiles:list": ProfilesListCommand,
+  "profiles:use": ProfilesUseCommand,
+  "profiles:delete": ProfilesDeleteCommand,
   "on-prem-resources:delete": OnPremResourcesDeleteCommand,
   "on-prem-resources:list": OnPremResourcesListCommand,
   "on-prem-resources:registration-jwt": OnPremResourcesRegistrationCommand,

--- a/src/utils/integration/metadata.test.ts
+++ b/src/utils/integration/metadata.test.ts
@@ -92,7 +92,7 @@ describe("metadata utils", () => {
     it("should not warn when file already exists", async () => {
       mockExists.mockResolvedValue(true);
       mockWriteFile.mockResolvedValue(undefined);
-      process.env.PRISM_QUIET = undefined;
+      delete process.env.PRISM_QUIET;
 
       await writePrismMetadata({ integrationId: "int-123" });
 

--- a/src/utils/integration/open.ts
+++ b/src/utils/integration/open.ts
@@ -1,9 +1,8 @@
 import open from "open";
-import * as path from "path";
-import { prismaticUrl } from "../../auth.js";
+import { getPrismaticUrl } from "../../context.js";
 
 export const openIntegration = async (integrationId: string) => {
-  const url = new URL(path.join("designer", integrationId), prismaticUrl);
+  const url = new URL(`/designer/${encodeURIComponent(integrationId)}`, await getPrismaticUrl());
 
   await open(url.href);
 };

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -4,11 +4,21 @@ export const TEST_PRISMATIC_URL = "https://example.com";
 
 vi.mock(import("./src/auth.js"), () => ({
   getAccessToken: vi.fn(() => Promise.resolve("test-token")),
-  prismaticUrl: TEST_PRISMATIC_URL,
+  logout: vi.fn(() => Promise.resolve()),
   createRequestParams: (data: Record<string, string | undefined>): string =>
     new URLSearchParams(
       Object.entries(data).filter(([, v]) => v !== undefined) as [string, string][],
     ).toString(),
+}));
+
+vi.mock(import("./src/context.js"), () => ({
+  getAuthContext: vi.fn(),
+  getPrismaticUrl: vi.fn(() => Promise.resolve(TEST_PRISMATIC_URL)),
+  hasEnvironmentCredentials: vi.fn(() =>
+    Boolean(process.env.PRISM_ACCESS_TOKEN || process.env.PRISM_REFRESH_TOKEN),
+  ),
+  useDefaultAuthContext: vi.fn(),
+  useProfileAuthContext: vi.fn(),
 }));
 
 vi.mock(import("./src/utils/http.js"), () => ({


### PR DESCRIPTION
Add the ability to authenticate against multiple tenants across one or many stacks at the same time via named profiles.  

All prism commands now support `--profile NAME` which will use that named profile for that command.

This new behavior is completely opt-in since all existing prism sessions will be upgraded to be the default profile the first time the credentials file is written after upgrading to this prism version which means that any commands that are not provided a profile will use the default profile to mimic the current experience.