### PR TITLE
fix(auth): isolate environment credentials from config

### DIFF
--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -1,7 +1,13 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import inquirer from "inquirer";
-import { Authenticate, createRequestParams, selectTenant, type Tenant } from "./auth.js";
-import { deleteConfig } from "./config.js";
+import {
+  Authenticate,
+  createRequestParams,
+  getAccessToken,
+  selectTenant,
+  type Tenant,
+} from "./auth.js";
+import { deleteConfig, readConfig, writeConfig } from "./config.js";
 import { fetch } from "./utils/http.js";
 
 vi.unmock("./auth.js");
@@ -58,11 +64,6 @@ describe("createRequestParams", () => {
 });
 
 describe("selectTenant", () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-    vi.clearAllMocks();
-  });
-
   it("logs an error and returns undefined when every tenant is suspended", async () => {
     const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const tenants = [
@@ -137,6 +138,76 @@ describe("selectTenant", () => {
     await selectTenant(tenants, { currentTenantId: "a" });
 
     expect(capturedDefault).toBe("a");
+  });
+});
+
+describe("getAccessToken", () => {
+  it("does not use the config tenant when both tokens are supplied via environment variables", async () => {
+    const expiredAccessToken = [
+      Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url"),
+      Buffer.from(JSON.stringify({ exp: 0 })).toString("base64url"),
+      "signature",
+    ].join(".");
+    vi.stubEnv("PRISM_ACCESS_TOKEN", expiredAccessToken);
+    vi.stubEnv("PRISM_REFRESH_TOKEN", "env-refresh-token");
+    vi.stubEnv("PRISMATIC_TENANT_ID", undefined);
+    vi.mocked(readConfig).mockResolvedValue({
+      accessToken: "config-access-token",
+      expiresIn: 3600,
+      refreshToken: "config-refresh-token",
+      scopes: "openid",
+      tokenType: "Bearer",
+      tenantId: "config-tenant",
+    });
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        Response.json({ domain: "auth.example.com", clientId: "client", audience: "audience" }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          access_token: "refreshed-access-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+      );
+
+    await expect(getAccessToken()).resolves.toBe("refreshed-access-token");
+
+    const refreshRequest = fetchSpy.mock.calls[1];
+    expect(refreshRequest[0]).toBe("https://auth.example.com/oauth/token");
+    expect(refreshRequest[1]?.body).toBe(
+      "grant_type=refresh_token&client_id=client&refresh_token=env-refresh-token",
+    );
+    expect(writeConfig).not.toHaveBeenCalled();
+  });
+
+  it("does not persist a session obtained from an environment refresh token", async () => {
+    vi.stubEnv("PRISM_ACCESS_TOKEN", undefined);
+    vi.stubEnv("PRISM_REFRESH_TOKEN", "env-refresh-token");
+    vi.stubEnv("PRISMATIC_TENANT_ID", "env-tenant");
+
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        Response.json({ domain: "auth.example.com", clientId: "client", audience: "audience" }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          access_token: "refreshed-access-token",
+          expires_in: 3600,
+          token_type: "Bearer",
+        }),
+      );
+
+    await expect(getAccessToken()).resolves.toBe("refreshed-access-token");
+
+    expect(readConfig).not.toHaveBeenCalled();
+    expect(fetchSpy.mock.calls[1][1]?.body).toBe(
+      "grant_type=refresh_token&client_id=client&refresh_token=env-refresh-token&tenant_id=env-tenant",
+    );
+    expect(writeConfig).not.toHaveBeenCalled();
   });
 });
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -440,11 +440,15 @@ export const login = async (props?: { url: boolean }) => {
   return;
 };
 
-export const refresh = async (refreshToken: string, tenantId?: string) => {
+const refreshAuthentication = async (refreshToken: string, tenantId?: string) => {
   const authOptions = await getAuthOptions();
   const auth = new Authenticate(authOptions);
 
-  const response = await auth.refresh(refreshToken, tenantId);
+  return auth.refresh(refreshToken, tenantId);
+};
+
+export const refresh = async (refreshToken: string, tenantId?: string) => {
+  const response = await refreshAuthentication(refreshToken, tenantId);
   await writeConfig(response);
   return response;
 };
@@ -469,7 +473,10 @@ export const getAccessToken = async (): Promise<string | undefined> => {
   } = getEnv();
 
   if (envRefreshToken && !envAccessToken) {
-    const { accessToken: refreshedAccessToken } = await refresh(envRefreshToken, envTenantId);
+    const { accessToken: refreshedAccessToken } = await refreshAuthentication(
+      envRefreshToken,
+      envTenantId,
+    );
     return refreshedAccessToken;
   }
 
@@ -479,7 +486,8 @@ export const getAccessToken = async (): Promise<string | undefined> => {
 
   const accessToken = envAccessToken ?? configAccessToken;
   const refreshToken = envRefreshToken ?? configRefreshToken;
-  const tenantId = envTenantId ?? configTenantId;
+  const hasEnvTokenPair = envAccessToken !== undefined && envRefreshToken !== undefined;
+  const tenantId = envTenantId ?? (hasEnvTokenPair ? undefined : configTenantId);
 
   if (accessToken && refreshToken) {
     // biome-ignore lint/complexity/useDateNow: TODO
@@ -488,7 +496,8 @@ export const getAccessToken = async (): Promise<string | undefined> => {
 
     // Refresh if expired or expiring in 5 minutes or less
     if (exp - now < 5 * 60) {
-      const { accessToken: refreshedAccessToken } = await refresh(refreshToken, tenantId);
+      const refreshTokenPair = envRefreshToken ? refreshAuthentication : refresh;
+      const { accessToken: refreshedAccessToken } = await refreshTokenPair(refreshToken, tenantId);
       return refreshedAccessToken;
     }
   }

--- a/src/utils/integration/metadata.test.ts
+++ b/src/utils/integration/metadata.test.ts
@@ -15,10 +15,10 @@ vi.mock(import("../../fs.js"), () => ({
 
 describe("metadata utils", () => {
   const originalEnv = { ...process.env };
-  const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  let consoleWarnSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     process.env.PRISM_QUIET = "true";
   });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,6 +17,10 @@ const graphqlPlugin = (): Plugin => ({
 export default defineConfig({
   plugins: [graphqlPlugin()],
   test: {
+    clearMocks: true,
+    restoreMocks: true,
+    unstubEnvs: true,
+    unstubGlobals: true,
     include: ["src/**/*.test.ts"],
     exclude: ["**/node_modules/**"],
     environment: "node",


### PR DESCRIPTION
Previously a partial collection of environment variables would have the rest of the set populated from the config file leading to likely incorrect configurations.

This also fixes tokens through env vars being refreshed and the config being written from those env vars which isn't expected on a stateful machine (inconsequential on stateless machines, such as CI runners).