### PR TITLE
Use tinyexec for process execution

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,3 +17,12 @@ jobs:
       - run: bun install --frozen-lockfile
       - run: mise exec node@${{ matrix.node-version }} -- npm install --dry-run --engine-strict
       - run: mise run validate:node${{ matrix.node-version }}
+
+  test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7.0.0
+      - uses: jdx/mise-action@v4.2.0
+      - run: mise exec -- bun install --frozen-lockfile
+      - run: mise exec -- bun run clean-test-temp
+      - run: mise exec -- node node_modules/vitest/vitest.mjs run

--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
         "striptags": "^3.2.0",
         "tempy": "^3.2.0",
         "terminal-link": "^5.0.0",
+        "tinyexec": "^1.1.2",
         "tinyglobby": "^0.2.16",
         "ts-morph": "^28.0.0",
         "undici": "^7.25.0",
@@ -1193,7 +1194,7 @@
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
-    "tinyexec": ["tinyexec@1.1.1", "", {}, "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg=="],
+    "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
 
@@ -1518,6 +1519,8 @@
     "terminal-link/ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
     "vite/tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
+
+    "vitest/tinyexec": ["tinyexec@1.1.1", "", {}, "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg=="],
 
     "wsdl-tsclient/chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "striptags": "^3.2.0",
     "tempy": "^3.2.0",
     "terminal-link": "^5.0.0",
+    "tinyexec": "^1.1.2",
     "tinyglobby": "^0.2.16",
     "ts-morph": "^28.0.0",
     "undici": "^7.25.0",

--- a/src/commands/components/init/index.test.ts
+++ b/src/commands/components/init/index.test.ts
@@ -62,7 +62,7 @@ describe("component generation tests", () => {
           const targets = await walkDir(projectName, [".png", "webpack.config.js", "package.json"]);
           for (const target of targets) {
             const contents = await readFile(target, "utf-8");
-            expect(contents).toMatchSnapshot(target);
+            expect(contents).toMatchSnapshot(target.split(path.sep).join("/"));
           }
 
           process.chdir(basePath);

--- a/src/commands/integrations/init/index.test.ts
+++ b/src/commands/integrations/init/index.test.ts
@@ -18,7 +18,7 @@ expect.addSnapshotSerializer({
         /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi,
         "00000000-0000-0000-0000-000000000000",
       )
-      .replace(/"@prismatic-io\/spectral": "\d+\.\d+\.\d+"/, '"@prismatic-io/spectral": "VERSION"');
+      .replace(/"@prismatic-io\/spectral": "[^"]+"/, '"@prismatic-io/spectral": "VERSION"');
     return normalized;
   },
 });
@@ -63,7 +63,7 @@ describe("integrations:init", () => {
             const targets = await walkDir(integrationName, [".png", "webpack.config.js"]);
             for (const target of targets) {
               const contents = await readFile(target, "utf-8");
-              expect(contents).toMatchSnapshot(target);
+              expect(contents).toMatchSnapshot(target.split(path.sep).join("/"));
             }
           },
           GENERATION_TIMEOUT_SECONDS,
@@ -99,7 +99,8 @@ describe("integrations:init", () => {
             const targets = await walkDir(cleanIntegrationName, [".png", "webpack.config.js"]);
             for (const target of targets) {
               const contents = await readFile(target, "utf-8");
-              expect(contents).toMatchSnapshot(`clean-${target}`);
+              const snapshotName = `clean-${target}`.split(path.sep).join("/");
+              expect(contents).toMatchSnapshot(snapshotName);
             }
           },
           GENERATION_TIMEOUT_SECONDS,

--- a/src/commands/integrations/init/index.ts
+++ b/src/commands/integrations/init/index.ts
@@ -107,7 +107,8 @@ export default class InitializeIntegration extends PrismaticBaseCommand {
       if (file.endsWith("icon.png")) {
         return file;
       }
-      if (CLEANABLE_TEMPLATES.includes(file)) {
+      const normalizedFile = file.split(path.sep).join("/");
+      if (CLEANABLE_TEMPLATES.includes(normalizedFile)) {
         return `${file}${templateSuffix}.ejs`;
       }
       return `${file}.ejs`;

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,5 +1,5 @@
 import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { devNull, tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -91,7 +91,7 @@ describe("config with PRISM_CONFIG_FILE override", () => {
   });
 });
 
-describe("config with PRISM_CONFIG_FILE=/dev/null", () => {
+describe("config with PRISM_CONFIG_FILE set to the null device", () => {
   let tmpDir: string;
 
   beforeAll(async () => {
@@ -104,7 +104,7 @@ describe("config with PRISM_CONFIG_FILE=/dev/null", () => {
 
   beforeEach(() => {
     stubFakeHome(tmpDir);
-    vi.stubEnv("PRISM_CONFIG_FILE", "/dev/null");
+    vi.stubEnv("PRISM_CONFIG_FILE", devNull);
   });
 
   afterEach(() => {
@@ -118,7 +118,7 @@ describe("config with PRISM_CONFIG_FILE=/dev/null", () => {
     await expect(Promise.all(writers)).resolves.toBeDefined();
   });
 
-  it("returns null on read since /dev/null is empty", async () => {
+  it("returns null on read since the null device is empty", async () => {
     await writeActiveProfile(makeConfig({ accessToken: "ignored" }));
     const result = await readProfile();
     expect(result).toBeNull();

--- a/src/utils/fixtures/npm-package/package.json
+++ b/src/utils/fixtures/npm-package/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "prism-process-test-fixture",
+  "private": true,
+  "scripts": {
+    "process-smoke": "node process-smoke.mjs",
+    "process-failure": "node process-smoke.mjs --fail"
+  }
+}

--- a/src/utils/fixtures/npm-package/process-smoke.mjs
+++ b/src/utils/fixtures/npm-package/process-smoke.mjs
@@ -1,0 +1,13 @@
+import { writeFileSync } from "node:fs";
+
+if (process.argv[2] === "--fail") {
+  process.exit(19);
+}
+
+writeFileSync(
+  process.env.PRISM_PROCESS_TEST_OUTPUT,
+  JSON.stringify({
+    argument: process.argv[2],
+    environment: process.env.PRISM_PROCESS_TEST_ENV,
+  }),
+);

--- a/src/utils/fixtures/prism-process-smoke.cmd
+++ b/src/utils/fixtures/prism-process-smoke.cmd
@@ -1,0 +1,3 @@
+@echo off
+if not "%~1"=="expected" exit /b 23
+exit /b 0

--- a/src/utils/process.test.ts
+++ b/src/utils/process.test.ts
@@ -1,0 +1,106 @@
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { spawnProcess } from "./process.js";
+
+const temporaryDirectories: string[] = [];
+
+const createTemporaryDirectory = async (): Promise<string> => {
+  const directory = await mkdtemp(path.join(tmpdir(), "prism-process-test-"));
+  temporaryDirectories.push(directory);
+  return directory;
+};
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) => rm(directory, { recursive: true })),
+  );
+});
+
+describe("spawnProcess", () => {
+  it("resolves when the process exits successfully", async () => {
+    await expect(spawnProcess([process.execPath, "--version"], {})).resolves.toBeUndefined();
+  });
+
+  it("runs an npm package script by its bare executable name", async () => {
+    const directory = await createTemporaryDirectory();
+    const outputPath = path.join(directory, "npm-result.json");
+    const fixtureDirectory = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "fixtures",
+      "npm-package",
+    );
+    const originalDirectory = process.cwd();
+
+    try {
+      process.chdir(fixtureDirectory);
+      await spawnProcess(
+        ["npm", "run", "process-smoke", "--", "value with spaces & shell | metacharacters"],
+        {
+          PRISM_PROCESS_TEST_ENV: "expected environment value",
+          PRISM_PROCESS_TEST_OUTPUT: outputPath,
+        },
+      );
+    } finally {
+      process.chdir(originalDirectory);
+    }
+
+    await expect(readFile(outputPath, "utf8")).resolves.toBe(
+      JSON.stringify({
+        argument: "value with spaces & shell | metacharacters",
+        environment: "expected environment value",
+      }),
+    );
+  });
+
+  it("reports a failing npm package script's exit code", async () => {
+    const fixtureDirectory = path.join(
+      path.dirname(fileURLToPath(import.meta.url)),
+      "fixtures",
+      "npm-package",
+    );
+    const originalDirectory = process.cwd();
+
+    try {
+      process.chdir(fixtureDirectory);
+      await expect(spawnProcess(["npm", "run", "process-failure"], {})).rejects.toThrow(
+        /failed with exit code 19/,
+      );
+    } finally {
+      process.chdir(originalDirectory);
+    }
+  });
+
+  it("rejects with the command and exit code for a non-zero exit", async () => {
+    await expect(spawnProcess([process.execPath, "-e", "process.exit(17)"], {})).rejects.toThrow(
+      /failed with exit code 17/,
+    );
+  });
+
+  it("rejects with a readable error when the executable cannot be started", async () => {
+    await expect(spawnProcess(["prism-command-that-does-not-exist"], {})).rejects.toThrowError(
+      "prism-command-that-does-not-exist",
+    );
+  });
+
+  it("rejects an empty command", async () => {
+    await expect(spawnProcess([], {})).rejects.toThrow("No command was provided.");
+  });
+
+  it.runIf(process.platform === "win32")(
+    "runs a .cmd executable discovered through PATH",
+    async () => {
+      const fixtureDirectory = path.join(path.dirname(fileURLToPath(import.meta.url)), "fixtures");
+      const pathKey =
+        Object.keys(process.env).find((key) => key.toLowerCase() === "path") ?? "PATH";
+
+      await expect(
+        spawnProcess(["prism-process-smoke", "expected"], {
+          [pathKey]: `${fixtureDirectory}${path.delimiter}${process.env[pathKey] ?? ""}`,
+        }),
+      ).resolves.toBeUndefined();
+    },
+  );
+});

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -1,17 +1,33 @@
-import { spawn } from "child_process";
+import { type Output, x } from "tinyexec";
 
-export const spawnProcess = (
+export const spawnProcess = async (
   [command, ...args]: string[],
   env: Record<string, string>,
 ): Promise<void> => {
-  return new Promise((resolve, reject) => {
-    const child = spawn(command, args, {
-      env: { ...process.env, ...env },
+  if (!command) {
+    throw new Error("No command was provided.");
+  }
+
+  let result: Output;
+  try {
+    result = await x(command, args, {
+      nodeOptions: {
+        env: { ...process.env, ...env },
+        stdio: "inherit",
+      },
     });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to start ${JSON.stringify(command)}: ${message}`, {
+      cause: error,
+    });
+  }
 
-    child.stdout.pipe(process.stdout);
-    child.stderr.pipe(process.stderr);
-
-    child.on("close", (code) => (code === 0 ? resolve() : reject()));
-  });
+  if (result.exitCode !== 0) {
+    const status =
+      result.exitCode !== undefined
+        ? `exit code ${result.exitCode}`
+        : "termination before reporting an exit code";
+    throw new Error(`Command failed with ${status}: ${command} ${args.join(" ")}`);
+  }
 };


### PR DESCRIPTION
Switch to tinyexec for improved cross-platform process execution, particularly for dealing with Windows' various configurations (WSL, cmd, etc).