### PR TITLE
Rename "Code-Native" to "Code-First"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ The codebase follows oclif's explicit command strategy:
 - All API requests go through GraphQL to `https://app.prismatic.io/api` (or `PRISMATIC_URL` env var)
 
 **Key Utilities**:
-- `src/utils/integration/` - Integration import/export, YAML processing, code-native integration handling
+- `src/utils/integration/` - Integration import/export, YAML processing, code-first integration handling
 - `src/utils/component/` - Component publishing and signature generation
 - `src/generate/` - Code generation for components from OpenAPI/WSDL specs
 - `src/templates/` - EJS templates for generating components, integrations, and formats (copied to lib/ during build)
@@ -78,7 +78,7 @@ Templates are processed with EJS and must be copied to `lib/templates/` during b
 ### Two Integration Types
 
 1. **YAML Integrations**: Defined in YAML files, use pre-built components
-2. **Code-Native Integrations**: Written in TypeScript, imported as npm packages
+2. **Code-First Integrations**: Written in TypeScript, imported as npm packages
 
 Commands handle both types with different code paths (check for YAML vs package.json).
 

--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ There, you will find information about the various subcommands you can run, trou
 
 ## What is Prismatic?
 
-Prismatic is the leading embedded iPaaS, enabling B2B SaaS teams to ship product integrations faster and with less dev time. The only embedded iPaaS that empowers both developers and non-developers with tools for the complete integration lifecycle, Prismatic includes low-code and code-native building options, deployment and management tooling, and self-serve customer tools.
+Prismatic is the leading embedded iPaaS, enabling B2B SaaS teams to ship product integrations faster and with less dev time. The only embedded iPaaS that empowers both developers and non-developers with tools for the complete integration lifecycle, Prismatic includes low-code and code-first building options, deployment and management tooling, and self-serve customer tools.
 
 Prismatic's unparalleled versatility lets teams deliver any integration from simple to complex in one powerful platform. SaaS companies worldwide, from startups to Fortune 500s, trust Prismatic to help connect their products to the other products their customers use.
 
 With Prismatic, you can:
 
-- Build [integrations](https://prismatic.io/docs/integrations/) using our [intuitive low-code designer](https://prismatic.io/docs/integrations/low-code-integration-designer/) or [code-native](https://prismatic.io/docs/integrations/code-native/) approach in your preferred IDE
+- Build [integrations](https://prismatic.io/docs/integrations/) using our [intuitive low-code designer](https://prismatic.io/docs/integrations/low-code-integration-designer/) or [code-first](https://prismatic.io/docs/integrations/code-native/) approach in your preferred IDE
 - Leverage pre-built [connectors](https://prismatic.io/docs/components/) for common integration tasks, or develop custom connectors using our TypeScript SDK
 - Embed a native [integration marketplace](https://prismatic.io/docs/embed/) in your product for customer self-service
 - Configure and deploy customer-specific integration instances with powerful configuration tools

--- a/oclif.manifest.json
+++ b/oclif.manifest.json
@@ -1563,7 +1563,7 @@
     "integrations:import": {
       "aliases": [],
       "args": {},
-      "description": "Import an Integration using a YAML definition file or a Code Native Integration",
+      "description": "Import an Integration using a YAML definition file or a Code-First Integration",
       "flags": {
         "print-requests": {
           "description": "Print all GraphQL requests that are issued",
@@ -1591,7 +1591,7 @@
         },
         "path": {
           "char": "p",
-          "description": "If supplied, the path to the YAML definition of the integration to import. Not applicable for Code Native Integrations.",
+          "description": "If supplied, the path to the YAML definition of the integration to import. Not applicable for Code-First Integrations.",
           "name": "path",
           "required": false,
           "hasDynamicHelp": false,
@@ -1608,7 +1608,7 @@
           "type": "option"
         },
         "icon-path": {
-          "description": "If supplied, the path to the PNG icon for the integration. Not applicable for Code Native Integrations.",
+          "description": "If supplied, the path to the PNG icon for the integration. Not applicable for Code-First Integrations.",
           "name": "icon-path",
           "required": false,
           "hasDynamicHelp": false,
@@ -1625,7 +1625,7 @@
         },
         "replace": {
           "char": "r",
-          "description": "If supplied, allows replacing an existing integration regardless of code-native status. Requires integrationId.",
+          "description": "If supplied, allows replacing an existing integration regardless of code-first status. Requires integrationId.",
           "name": "replace",
           "required": false,
           "allowNo": false,
@@ -5594,7 +5594,7 @@
           "required": true
         }
       },
-      "description": "Convert a Low-Code Integration's YAML file into a Code Native Integration",
+      "description": "Convert a Low-Code Integration's YAML file into a Code-First Integration",
       "flags": {
         "print-requests": {
           "description": "Print all GraphQL requests that are issued",
@@ -6052,10 +6052,10 @@
           "required": true
         }
       },
-      "description": "Initialize a new Code Native Integration",
+      "description": "Initialize a new Code-First Integration",
       "examples": [
         {
-          "description": "Initialize a new directory for a Code Native Integration:",
+          "description": "Initialize a new directory for a Code-First Integration:",
           "command": "<%= config.bin %> <%= command.id %> acme-integration"
         },
         {

--- a/src/commands/integrations/convert/index.ts
+++ b/src/commands/integrations/convert/index.ts
@@ -23,7 +23,7 @@ interface ConvertLowCodeIntegrationResult {
 }
 
 export default class ConvertIntegrationCommand extends PrismaticBaseCommand {
-  static description = "Convert a Low-Code Integration's YAML file into a Code Native Integration";
+  static description = "Convert a Low-Code Integration's YAML file into a Code-First Integration";
   static args = {
     integration: Args.string({
       required: true,
@@ -56,7 +56,7 @@ export default class ConvertIntegrationCommand extends PrismaticBaseCommand {
       flags: { registryPrefix, registryUrl, includeComments },
     } = await this.parse(ConvertIntegrationCommand);
 
-    ux.action.start("Converting low-code integration to code-native integration");
+    ux.action.start("Converting low-code integration to code-first integration");
 
     try {
       const result = await gqlRequest<ConvertLowCodeIntegrationResult>({
@@ -109,7 +109,7 @@ Next steps:
   3. Run: npm install && npm update --save && npm run format
 
 If installation issues occur during step 3, double check your package.json file and component registry set-up.
-For documentation on code-native integrations, visit https://prismatic.io/docs/integrations/code-native/`);
+For documentation on code-first integrations, visit https://prismatic.io/docs/integrations/code-native/`);
     } catch (error) {
       ux.action.stop("failed");
       throw error;

--- a/src/commands/integrations/flows/test.test.ts
+++ b/src/commands/integrations/flows/test.test.ts
@@ -173,7 +173,7 @@ describe("buildFlagString", () => {
   });
 });
 
-describe("--cni-auto-end flag on non-code-native integrations", () => {
+describe("--cni-auto-end flag on non-code-first integrations", () => {
   const integrationId = "SW50ZWdyYXRpb246dGVzdC1pZA==";
   const flowId = "flow-123";
   const testFlowUrl = "https://hooks.example.com/trigger/test-flow";
@@ -224,7 +224,7 @@ describe("--cni-auto-end flag on non-code-native integrations", () => {
     );
   };
 
-  it("should warn when --cni-auto-end is used with a non-code-native integration", async () => {
+  it("should warn when --cni-auto-end is used with a non-code-first integration", async () => {
     setupMocks(false);
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -238,12 +238,12 @@ describe("--cni-auto-end flag on non-code-native integrations", () => {
     ]);
 
     expect(warnSpy).toHaveBeenCalledWith(
-      "The given integration is not code-native but the --cni-auto-end flag was configured.",
+      "The given integration is not code-first but the --cni-auto-end flag was configured.",
       "\nThis process will continue but ignore the --cni-auto-end flag.",
     );
   });
 
-  it("should not warn when --cni-auto-end is used with a code-native integration", async () => {
+  it("should not warn when --cni-auto-end is used with a code-first integration", async () => {
     setupMocks(true);
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -257,7 +257,7 @@ describe("--cni-auto-end flag on non-code-native integrations", () => {
     ]);
 
     expect(warnSpy).not.toHaveBeenCalledWith(
-      "The given integration is not code-native but the --cni-auto-end flag was configured.",
+      "The given integration is not code-first but the --cni-auto-end flag was configured.",
       "\nThis process will continue but ignore the --cni-auto-end flag.",
     );
   });

--- a/src/commands/integrations/flows/test.ts
+++ b/src/commands/integrations/flows/test.ts
@@ -323,7 +323,7 @@ export default class TestFlowCommand extends PrismaticBaseCommand {
 
       if (!isCodeNative && autoEndPoll) {
         console.warn(
-          "The given integration is not code-native but the --cni-auto-end flag was configured.",
+          "The given integration is not code-first but the --cni-auto-end flag was configured.",
           "\nThis process will continue but ignore the --cni-auto-end flag.",
         );
         autoEndPoll = false;

--- a/src/commands/integrations/import.test.ts
+++ b/src/commands/integrations/import.test.ts
@@ -89,8 +89,8 @@ configPages:
     });
   });
 
-  describe("Code Native import", () => {
-    it("should import Code Native integration when no path is provided", async () => {
+  describe("Code-First import", () => {
+    it("should import Code-First integration when no path is provided", async () => {
       const { importCodeNativeIntegration } = await import("../../utils/integration/import.js");
       const logSpy = vi.spyOn(ImportCommand.prototype, "log").mockImplementation(() => {});
 
@@ -100,7 +100,7 @@ configPages:
       expect(logSpy).toHaveBeenCalledWith("imported-cni-id");
     });
 
-    it("should pass test API keys to Code Native import", async () => {
+    it("should pass test API keys to Code-First import", async () => {
       const { importCodeNativeIntegration } = await import("../../utils/integration/import.js");
       vi.spyOn(ImportCommand.prototype, "log").mockImplementation(() => {});
 

--- a/src/commands/integrations/import.ts
+++ b/src/commands/integrations/import.ts
@@ -14,13 +14,13 @@ import { ux } from "../../utils/ux.js";
 
 export default class ImportCommand extends PrismaticBaseCommand {
   static description =
-    "Import an Integration using a YAML definition file or a Code Native Integration";
+    "Import an Integration using a YAML definition file or a Code-First Integration";
   static flags = {
     path: Flags.string({
       char: "p",
       required: false,
       description:
-        "If supplied, the path to the YAML definition of the integration to import. Not applicable for Code Native Integrations.",
+        "If supplied, the path to the YAML definition of the integration to import. Not applicable for Code-First Integrations.",
     }),
     integrationId: Flags.string({
       char: "i",
@@ -30,7 +30,7 @@ export default class ImportCommand extends PrismaticBaseCommand {
     "icon-path": Flags.string({
       required: false,
       description:
-        "If supplied, the path to the PNG icon for the integration. Not applicable for Code Native Integrations.",
+        "If supplied, the path to the PNG icon for the integration. Not applicable for Code-First Integrations.",
     }),
     open: Flags.boolean({
       char: "o",
@@ -43,7 +43,7 @@ export default class ImportCommand extends PrismaticBaseCommand {
       required: false,
       default: false,
       description:
-        "If supplied, allows replacing an existing integration regardless of code-native status. Requires integrationId.",
+        "If supplied, allows replacing an existing integration regardless of code-first status. Requires integrationId.",
     }),
     "test-api-key": Flags.string({
       description:
@@ -129,7 +129,7 @@ There will be no way to restore the existing draft. If you wish to save it, eith
     const integrationImportId = path
       ? // A path was specified, so assume we're importing a YAML Integration.
         await importYamlIntegration(path, integrationId, iconPath, replace)
-      : // No path was specified, so assume the current directory is a Code Native Integration and import it.
+      : // No path was specified, so assume the current directory is a Code-First Integration and import it.
         await importCodeNativeIntegration(integrationId, replace, testApiKey);
 
     this.log(integrationImportId);

--- a/src/commands/integrations/init/__snapshots__/index.test.ts.snap
+++ b/src/commands/integrations/init/__snapshots__/index.test.ts.snap
@@ -155,8 +155,8 @@ export function createApiClient(connection: Connection) {
 
 exports[`integrations:init > legacy toolchain > clean scaffold generation > should match scaffolding snapshots for clean template > clean-clean-test-integration-legacy/src/componentRegistry.ts 1`] = `
 /**
- * Your code-native integration can invoke existing connectors.
- * This is where you declare which connectors your code-native
+ * Your code-first integration can invoke existing connectors.
+ * This is where you declare which connectors your code-first
  * integration uses. For more information, see
  * https://prismatic.io/docs/integrations/code-native/existing-components/
  */
@@ -175,7 +175,7 @@ exports[`integrations:init > legacy toolchain > clean scaffold generation > shou
  * they will walk through a configuration wizard. Define your
  * configuration pages here.
  *
- * For more information on the code-native config wizards, see
+ * For more information on the code-first config wizards, see
  * https://prismatic.io/docs/integrations/code-native/config-wizard/
  */
 
@@ -199,11 +199,11 @@ export const configPages = {
 exports[`integrations:init > legacy toolchain > clean scaffold generation > should match scaffolding snapshots for clean template > clean-clean-test-integration-legacy/src/flows.test.ts 1`] = `
 /**
  * Your flows can be tested locally prior to publishing your
- * code-native integration. Add your tests here.
+ * code-first integration. Add your tests here.
  *
  * You can run this test with "npm run test"
  *
- * For more information on unit testing code-native integrations, see
+ * For more information on unit testing code-first integrations, see
  * https://prismatic.io/docs/integrations/code-native/testing/
  */
 
@@ -246,7 +246,7 @@ export default [exampleFlow];
 
 exports[`integrations:init > legacy toolchain > clean scaffold generation > should match scaffolding snapshots for clean template > clean-clean-test-integration-legacy/src/index.ts 1`] = `
 /**
- * This project represents a code-native integration. A customer
+ * This project represents a code-first integration. A customer
  * user will walk through a config wizard (defined in configPages.ts),
  * and flows for that customer (defined in flows.ts) will run.
  *
@@ -462,8 +462,8 @@ export function createAcmeClient(acmeConnection: Connection) {
 
 exports[`integrations:init > legacy toolchain > scaffold generation > should match scaffolding snapshots for default template > test-integration-legacy/src/componentRegistry.ts 1`] = `
 /**
- * Your code-native integration can invoke existing connectors.
- * This is where you declare which connectors your code-native
+ * Your code-first integration can invoke existing connectors.
+ * This is where you declare which connectors your code-first
  * integration uses. For more information, see
  * https://prismatic.io/docs/integrations/code-native/existing-components/
  */
@@ -484,7 +484,7 @@ exports[`integrations:init > legacy toolchain > scaffold generation > should mat
  * their authentication information, and then use that
  * information to fetch data for a dropdown menu.
  *
- * For more information on the code-native config wizards, see
+ * For more information on the code-first config wizards, see
  * https://prismatic.io/docs/integrations/code-native/config-wizard/
  */
 
@@ -558,12 +558,12 @@ export const configPages = {
 exports[`integrations:init > legacy toolchain > scaffold generation > should match scaffolding snapshots for default template > test-integration-legacy/src/flows.test.ts 1`] = `
 /**
  * Your flows can be tested locally prior to publishing your
- * code-native integration. In this file, we invoke our flow
+ * code-first integration. In this file, we invoke our flow
  * twice and describe the results we expect to see.
  *
  * You can run this test with "npm run test"
  *
- * For more information on unit testing code-native integrations, see
+ * For more information on unit testing code-first integrations, see
  * https://prismatic.io/docs/integrations/code-native/testing/
  */
 
@@ -656,7 +656,7 @@ export default [listItems];
 
 exports[`integrations:init > legacy toolchain > scaffold generation > should match scaffolding snapshots for default template > test-integration-legacy/src/index.ts 1`] = `
 /**
- * This project represents a code-native integration. A customer
+ * This project represents a code-first integration. A customer
  * user will walk through a config wizard (defined in configPages.ts),
  * and flows for that customer (defined in flows.ts) will run.
  *
@@ -884,8 +884,8 @@ export function createApiClient(connection: Connection) {
 
 exports[`integrations:init > modern toolchain > clean scaffold generation > should match scaffolding snapshots for clean template > clean-clean-test-integration-modern/src/componentRegistry.ts 1`] = `
 /**
- * Your code-native integration can invoke existing connectors.
- * This is where you declare which connectors your code-native
+ * Your code-first integration can invoke existing connectors.
+ * This is where you declare which connectors your code-first
  * integration uses. For more information, see
  * https://prismatic.io/docs/integrations/code-native/existing-components/
  */
@@ -904,7 +904,7 @@ exports[`integrations:init > modern toolchain > clean scaffold generation > shou
  * they will walk through a configuration wizard. Define your
  * configuration pages here.
  *
- * For more information on the code-native config wizards, see
+ * For more information on the code-first config wizards, see
  * https://prismatic.io/docs/integrations/code-native/config-wizard/
  */
 
@@ -928,11 +928,11 @@ export const configPages = {
 exports[`integrations:init > modern toolchain > clean scaffold generation > should match scaffolding snapshots for clean template > clean-clean-test-integration-modern/src/flows.test.ts 1`] = `
 /**
  * Your flows can be tested locally prior to publishing your
- * code-native integration. Add your tests here.
+ * code-first integration. Add your tests here.
  *
  * You can run this test with "npm run test"
  *
- * For more information on unit testing code-native integrations, see
+ * For more information on unit testing code-first integrations, see
  * https://prismatic.io/docs/integrations/code-native/testing/
  */
 
@@ -975,7 +975,7 @@ export default [exampleFlow];
 
 exports[`integrations:init > modern toolchain > clean scaffold generation > should match scaffolding snapshots for clean template > clean-clean-test-integration-modern/src/index.ts 1`] = `
 /**
- * This project represents a code-native integration. A customer
+ * This project represents a code-first integration. A customer
  * user will walk through a config wizard (defined in configPages.ts),
  * and flows for that customer (defined in flows.ts) will run.
  *
@@ -1246,8 +1246,8 @@ export function createAcmeClient(acmeConnection: Connection) {
 
 exports[`integrations:init > modern toolchain > scaffold generation > should match scaffolding snapshots for default template > test-integration-modern/src/componentRegistry.ts 1`] = `
 /**
- * Your code-native integration can invoke existing connectors.
- * This is where you declare which connectors your code-native
+ * Your code-first integration can invoke existing connectors.
+ * This is where you declare which connectors your code-first
  * integration uses. For more information, see
  * https://prismatic.io/docs/integrations/code-native/existing-components/
  */
@@ -1268,7 +1268,7 @@ exports[`integrations:init > modern toolchain > scaffold generation > should mat
  * their authentication information, and then use that
  * information to fetch data for a dropdown menu.
  *
- * For more information on the code-native config wizards, see
+ * For more information on the code-first config wizards, see
  * https://prismatic.io/docs/integrations/code-native/config-wizard/
  */
 
@@ -1342,12 +1342,12 @@ export const configPages = {
 exports[`integrations:init > modern toolchain > scaffold generation > should match scaffolding snapshots for default template > test-integration-modern/src/flows.test.ts 1`] = `
 /**
  * Your flows can be tested locally prior to publishing your
- * code-native integration. In this file, we invoke our flow
+ * code-first integration. In this file, we invoke our flow
  * twice and describe the results we expect to see.
  *
  * You can run this test with "npm run test"
  *
- * For more information on unit testing code-native integrations, see
+ * For more information on unit testing code-first integrations, see
  * https://prismatic.io/docs/integrations/code-native/testing/
  */
 
@@ -1440,7 +1440,7 @@ export default [listItems];
 
 exports[`integrations:init > modern toolchain > scaffold generation > should match scaffolding snapshots for default template > test-integration-modern/src/index.ts 1`] = `
 /**
- * This project represents a code-native integration. A customer
+ * This project represents a code-first integration. A customer
  * user will walk through a config wizard (defined in configPages.ts),
  * and flows for that customer (defined in flows.ts) will run.
  *

--- a/src/commands/integrations/init/index.ts
+++ b/src/commands/integrations/init/index.ts
@@ -21,11 +21,11 @@ const CLEANABLE_TEMPLATES = [
 ];
 
 export default class InitializeIntegration extends PrismaticBaseCommand {
-  static description = "Initialize a new Code Native Integration";
+  static description = "Initialize a new Code-First Integration";
 
   static examples = [
     {
-      description: "Initialize a new directory for a Code Native Integration:",
+      description: "Initialize a new directory for a Code-First Integration:",
       command: "<%= config.bin %> <%= command.id %> acme-integration",
     },
     {
@@ -160,7 +160,7 @@ To run unit tests for the integration, run "npm run test" or "yarn test"
 To build the integration, run "npm run build" or "yarn build"
 To import the integration, run "prism integrations:import"
 
-For documentation on writing code-native integrations, visit https://prismatic.io/docs/integrations/code-native/
+For documentation on writing code-first integrations, visit https://prismatic.io/docs/integrations/code-native/
     `);
   }
 }

--- a/src/graphql/schema.generated.ts
+++ b/src/graphql/schema.generated.ts
@@ -345,7 +345,7 @@ export type ComponentDefinitionInput = {
   display: ComponentDisplayDefinition;
   /** The URL that specifies where the Component documentation exists. */
   documentationUrl?: InputMaybe<Scalars["String"]["input"]>;
-  /** Specifies whether the Component is for a Code Native Integration. */
+  /** Specifies whether the Component is for a Code-First Integration. */
   forCodeNativeIntegration?: InputMaybe<Scalars["Boolean"]["input"]>;
   /** A string that uniquely identifies the Component. */
   key: Scalars["String"]["input"];

--- a/src/utils/component/index.ts
+++ b/src/utils/component/index.ts
@@ -105,7 +105,7 @@ export const validateDefinition = async (
   // Check for mistaken invocations, though an invoke from an actual CNI build context is valid.
   if (codeNativeIntegrationYAML && !options.forCodeNativeIntegration) {
     ux.error(
-      "You are running a component command on what appears to be a Code Native Integration. Please check the current path.",
+      "You are running a component command on what appears to be a Code-First Integration. Please check the current path.",
       {
         exit: 1,
       },

--- a/src/utils/integration/import.test.ts
+++ b/src/utils/integration/import.test.ts
@@ -26,14 +26,14 @@ describe("importDefinition", () => {
 });
 
 describe("loadCodeNativeIntegrationEntryPoint", () => {
-  it("should error when the entrypoint lacks a Code Native Integration definition", async () => {
+  it("should error when the entrypoint lacks a Code-First Integration definition", async () => {
     const originalCwd = process.cwd();
     await temporaryDirectoryTask(async (tmpDir) => {
       await writeFile(path.join(tmpDir, "index.js"), "module.exports = { default: {} };");
       process.chdir(tmpDir);
       try {
         await expect(loadCodeNativeIntegrationEntryPoint()).rejects.toThrow(
-          /Failed to find Code Native Integration definition/,
+          /Failed to find Code-First Integration definition/,
         );
       } finally {
         process.chdir(originalCwd);

--- a/src/utils/integration/import.ts
+++ b/src/utils/integration/import.ts
@@ -234,7 +234,7 @@ export const importCodeNativeIntegration = async (
       forCodeNativeIntegration: true,
     });
 
-  ux.action.start("Uploading package for Code Native Integration");
+  ux.action.start("Uploading package for Code-First Integration");
   await uploadFile(packagePath, packageUploadUrl);
   const uploaded = await waitForCodeNativeComponentAvailable(
     componentDefinition.key,
@@ -244,11 +244,11 @@ export const importCodeNativeIntegration = async (
     ux.action.stop();
   } else {
     ux.action.stop(
-      "Package still processing for Code Native Integration, it will likely be available in a few minutes.",
+      "Package still processing for Code-First Integration, it will likely be available in a few minutes.",
     );
   }
 
-  ux.action.start("Importing definition for Code Native Integration into Prismatic");
+  ux.action.start("Importing definition for Code-First Integration into Prismatic");
   const { integrationId: integrationImportId, systemInstance } = await importDefinition(
     integrationDefinition,
     integrationId,
@@ -474,15 +474,15 @@ export const loadCodeNativeIntegrationEntryPoint = async (): Promise<{
   componentDefinition: ComponentDefinition;
   publishingMetadata?: PublishingMetadata;
 }> => {
-  // If we don't have an index.js in cwd seek directories to find package.json of Code Native Integration
+  // If we don't have an index.js in cwd seek directories to find package.json of Code-First Integration
   if (!(await exists("index.js"))) {
-    await seekPackageDistDirectory("Code Native Integration");
+    await seekPackageDistDirectory("Code-First Integration");
   }
 
   // If we still didn't find index.js error out
   if (!(await exists("index.js"))) {
     ux.error(
-      "Failed to find 'index.js' entrypoint file. Is the current path a Code Native Integration?",
+      "Failed to find 'index.js' entrypoint file. Is the current path a Code-First Integration?",
       { exit: 1 },
     );
   }
@@ -494,7 +494,7 @@ export const loadCodeNativeIntegrationEntryPoint = async (): Promise<{
 
   if (!componentDefinition?.codeNativeIntegrationYAML) {
     ux.error(
-      "Failed to find Code Native Integration definition in 'index.js' entrypoint file. Is the current path a Code Native Integration?",
+      "Failed to find Code-First Integration definition in 'index.js' entrypoint file. Is the current path a Code-First Integration?",
       { exit: 1 },
     );
   }

--- a/src/utils/toolchain/types.ts
+++ b/src/utils/toolchain/types.ts
@@ -4,7 +4,7 @@ export type ToolchainName = "modern" | "legacy";
 
 /**
  * A scaffolding toolchain owns everything that differs between the build/test/lint
- * stacks a generated component or code-native integration can use.
+ * stacks a generated component or code-first integration can use.
  *
  * Subclasses supply the package.json contributions below as data; the toolchain's
  * template files live under `templates/<name>/` and are rendered by `renderTemplates`.

--- a/templates/integration/src/componentRegistry.ts.ejs
+++ b/templates/integration/src/componentRegistry.ts.ejs
@@ -1,6 +1,6 @@
 /**
- * Your code-native integration can invoke existing connectors.
- * This is where you declare which connectors your code-native
+ * Your code-first integration can invoke existing connectors.
+ * This is where you declare which connectors your code-first
  * integration uses. For more information, see
  * https://prismatic.io/docs/integrations/code-native/existing-components/
  */

--- a/templates/integration/src/configPages.ts.clean.ejs
+++ b/templates/integration/src/configPages.ts.clean.ejs
@@ -3,7 +3,7 @@
  * they will walk through a configuration wizard. Define your
  * configuration pages here.
  *
- * For more information on the code-native config wizards, see
+ * For more information on the code-first config wizards, see
  * https://prismatic.io/docs/integrations/code-native/config-wizard/
  */
 

--- a/templates/integration/src/configPages.ts.ejs
+++ b/templates/integration/src/configPages.ts.ejs
@@ -5,7 +5,7 @@
  * their authentication information, and then use that
  * information to fetch data for a dropdown menu.
  *
- * For more information on the code-native config wizards, see
+ * For more information on the code-first config wizards, see
  * https://prismatic.io/docs/integrations/code-native/config-wizard/
  */
 

--- a/templates/integration/src/flows.test.ts.clean.ejs
+++ b/templates/integration/src/flows.test.ts.clean.ejs
@@ -1,10 +1,10 @@
 /**
  * Your flows can be tested locally prior to publishing your
- * code-native integration. Add your tests here.
+ * code-first integration. Add your tests here.
  *
  * You can run this test with "npm run test"
  *
- * For more information on unit testing code-native integrations, see
+ * For more information on unit testing code-first integrations, see
  * https://prismatic.io/docs/integrations/code-native/testing/
  */
 

--- a/templates/integration/src/flows.test.ts.ejs
+++ b/templates/integration/src/flows.test.ts.ejs
@@ -1,11 +1,11 @@
 /**
  * Your flows can be tested locally prior to publishing your
- * code-native integration. In this file, we invoke our flow
+ * code-first integration. In this file, we invoke our flow
  * twice and describe the results we expect to see.
  *
  * You can run this test with "npm run test"
  *
- * For more information on unit testing code-native integrations, see
+ * For more information on unit testing code-first integrations, see
  * https://prismatic.io/docs/integrations/code-native/testing/
  */
 

--- a/templates/integration/src/index.ts.ejs
+++ b/templates/integration/src/index.ts.ejs
@@ -1,5 +1,5 @@
 /**
- * This project represents a code-native integration. A customer
+ * This project represents a code-first integration. A customer
  * user will walk through a config wizard (defined in configPages.ts),
  * and flows for that customer (defined in flows.ts) will run.
  *


### PR DESCRIPTION
We've historically called integrations written using this SDK "Code-Native Integrations". It turns out, "Code-First" is a more commonly recognized industry-standard term. This updates some READMEs and CLI help text to say "Code-First Integration" rather than "Code-Native Integration".