### PR TITLE
[incur 02/24] Generate typed GraphQL operation artifacts

### DIFF
--- a/codegen.ts
+++ b/codegen.ts
@@ -1,6 +1,19 @@
 import type { CodegenConfig } from "@graphql-codegen/cli";
 
 const schemaUrl = new URL("/api", process.env.PRISMATIC_URL).toString();
+const scalarConfig = {
+  defaultScalarType: "unknown",
+  strictScalars: true,
+  scalars: {
+    BigInt: { input: "string | number", output: "string" },
+    Date: "string",
+    DateTime: "string",
+    GenericScalar: "unknown",
+    JSONOrString: "unknown",
+    JSONString: "unknown",
+    UUID: "string",
+  },
+};
 
 const config: CodegenConfig = {
   overwrite: true,
@@ -21,6 +34,7 @@ const config: CodegenConfig = {
     "src/graphql/schema.generated.ts": {
       plugins: ["typescript"],
       config: {
+        ...scalarConfig,
         onlyOperationTypes: true,
       },
     },
@@ -31,7 +45,8 @@ const config: CodegenConfig = {
         extension: ".generated.ts",
         baseTypesPath: "schema.generated.js",
       },
-      plugins: ["typescript-operations"],
+      plugins: ["typescript-operations", "typed-document-node"],
+      config: scalarConfig,
     },
   },
 };

--- a/src/graphql.contract.test.ts
+++ b/src/graphql.contract.test.ts
@@ -1,0 +1,36 @@
+import { readFile } from "node:fs/promises";
+import { parse } from "graphql";
+import { glob } from "tinyglobby";
+import { describe, expect, it } from "vitest";
+
+const readFiles = async (patterns: string[], ignore: string[] = []) =>
+  Promise.all(
+    (await glob(patterns, { ignore: ["**/temp/**", ...ignore] })).map(async (path) => ({
+      path,
+      source: await readFile(path, "utf8"),
+    })),
+  );
+
+describe("GraphQL document generation", () => {
+  it("gives every document one uniquely named operation and generated typed node", async () => {
+    const documents = await readFiles(["src/graphql/**/*.graphql"]);
+    const names = new Map<string, string>();
+
+    for (const { path, source } of documents) {
+      const operations = parse(source).definitions.filter(
+        (definition) => definition.kind === "OperationDefinition",
+      );
+      expect(operations, path).toHaveLength(1);
+      const name = operations[0]?.name?.value;
+      expect(name, `${path} has an anonymous operation`).toBeTruthy();
+      expect(names.get(name ?? ""), `${name} is also declared in ${names.get(name ?? "")}`).toBe(
+        undefined,
+      );
+      names.set(name ?? "", path);
+
+      const generated = await readFile(path.replace(/\.graphql$/, ".generated.ts"), "utf8");
+      expect(generated, `${path} has no typed document node`).toContain("TypedDocumentNode");
+      expect(generated, `${path} leaks the legacy Scalars lookup`).not.toContain("Scalars[");
+    }
+  });
+});

--- a/src/graphql/alerts/listAlertGroups.generated.ts
+++ b/src/graphql/alerts/listAlertGroups.generated.ts
@@ -1,0 +1,90 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ListAlertGroupsQueryVariables = Exact<{
+  after?: string | null | undefined;
+  first?: number | null | undefined;
+}>;
+
+export type ListAlertGroupsQuery = {
+  alertGroups: {
+    nodes: Array<{ id: string; name: string }>;
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  };
+};
+
+export const ListAlertGroupsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "listAlertGroups" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "after" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "alertGroups" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "after" },
+                value: { kind: "Variable", name: { kind: "Name", value: "after" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "first" },
+                value: { kind: "Variable", name: { kind: "Name", value: "first" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      { kind: "Field", name: { kind: "Name", value: "name" } },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "pageInfo" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "hasNextPage" } },
+                      { kind: "Field", name: { kind: "Name", value: "endCursor" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ListAlertGroupsQuery, ListAlertGroupsQueryVariables>;

--- a/src/graphql/alerts/listAlertGroups.graphql
+++ b/src/graphql/alerts/listAlertGroups.graphql
@@ -1,0 +1,12 @@
+query listAlertGroups($after: String, $first: Int) {
+  alertGroups(after: $after, first: $first) {
+    nodes {
+      id
+      name
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}

--- a/src/graphql/alerts/listAlertMonitors.generated.ts
+++ b/src/graphql/alerts/listAlertMonitors.generated.ts
@@ -1,0 +1,118 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ListAlertMonitorsQueryVariables = Exact<{
+  after?: string | null | undefined;
+  first?: number | null | undefined;
+}>;
+
+export type ListAlertMonitorsQuery = {
+  alertMonitors: {
+    nodes: Array<{
+      id: string;
+      name: string;
+      triggered: boolean;
+      instance: { id: string; name: string; customer: { id: string; name: string } } | null;
+    }>;
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  };
+};
+
+export const ListAlertMonitorsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "listAlertMonitors" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "after" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "alertMonitors" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "after" },
+                value: { kind: "Variable", name: { kind: "Name", value: "after" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "first" },
+                value: { kind: "Variable", name: { kind: "Name", value: "first" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      { kind: "Field", name: { kind: "Name", value: "name" } },
+                      { kind: "Field", name: { kind: "Name", value: "triggered" } },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "instance" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "id" } },
+                            { kind: "Field", name: { kind: "Name", value: "name" } },
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "customer" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "id" } },
+                                  { kind: "Field", name: { kind: "Name", value: "name" } },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "pageInfo" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "hasNextPage" } },
+                      { kind: "Field", name: { kind: "Name", value: "endCursor" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ListAlertMonitorsQuery, ListAlertMonitorsQueryVariables>;

--- a/src/graphql/alerts/listAlertMonitors.graphql
+++ b/src/graphql/alerts/listAlertMonitors.graphql
@@ -1,0 +1,21 @@
+query listAlertMonitors($after: String, $first: Int) {
+  alertMonitors(after: $after, first: $first) {
+    nodes {
+      id
+      name
+      triggered
+      instance {
+        id
+        name
+        customer {
+          id
+          name
+        }
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}

--- a/src/graphql/alerts/listAlertWebhooks.generated.ts
+++ b/src/graphql/alerts/listAlertWebhooks.generated.ts
@@ -1,0 +1,99 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ListAlertWebhooksQueryVariables = Exact<{
+  after?: string | null | undefined;
+  first?: number | null | undefined;
+}>;
+
+export type ListAlertWebhooksQuery = {
+  alertWebhooks: {
+    nodes: Array<{
+      id: string;
+      name: string;
+      payloadTemplate: string;
+      url: string;
+      headers: unknown;
+    }>;
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  };
+};
+
+export const ListAlertWebhooksDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "listAlertWebhooks" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "after" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "alertWebhooks" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "after" },
+                value: { kind: "Variable", name: { kind: "Name", value: "after" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "first" },
+                value: { kind: "Variable", name: { kind: "Name", value: "first" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      { kind: "Field", name: { kind: "Name", value: "name" } },
+                      { kind: "Field", name: { kind: "Name", value: "payloadTemplate" } },
+                      { kind: "Field", name: { kind: "Name", value: "url" } },
+                      { kind: "Field", name: { kind: "Name", value: "headers" } },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "pageInfo" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "hasNextPage" } },
+                      { kind: "Field", name: { kind: "Name", value: "endCursor" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ListAlertWebhooksQuery, ListAlertWebhooksQueryVariables>;

--- a/src/graphql/alerts/listAlertWebhooks.graphql
+++ b/src/graphql/alerts/listAlertWebhooks.graphql
@@ -1,0 +1,15 @@
+query listAlertWebhooks($after: String, $first: Int) {
+  alertWebhooks(after: $after, first: $first) {
+    nodes {
+      id
+      name
+      payloadTemplate
+      url
+      headers
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}

--- a/src/graphql/customers/listCustomerUsers.generated.ts
+++ b/src/graphql/customers/listCustomerUsers.generated.ts
@@ -1,0 +1,135 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ListCustomerUsersQueryVariables = Exact<{
+  id: string | number;
+  after?: string | null | undefined;
+  first?: number | null | undefined;
+}>;
+
+export type ListCustomerUsersQuery = {
+  customer: {
+    users: {
+      nodes: Array<{
+        id: string;
+        name: string;
+        email: string;
+        externalId: string | null;
+        role: { name: string };
+      }>;
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+    };
+  } | null;
+};
+
+export const ListCustomerUsersDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "listCustomerUsers" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "after" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "customer" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "users" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "after" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "after" } },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "first" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "first" } },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "id" } },
+                            { kind: "Field", name: { kind: "Name", value: "name" } },
+                            { kind: "Field", name: { kind: "Name", value: "email" } },
+                            { kind: "Field", name: { kind: "Name", value: "externalId" } },
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "role" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "name" } },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "pageInfo" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "hasNextPage" } },
+                            { kind: "Field", name: { kind: "Name", value: "endCursor" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ListCustomerUsersQuery, ListCustomerUsersQueryVariables>;

--- a/src/graphql/customers/listCustomerUsers.graphql
+++ b/src/graphql/customers/listCustomerUsers.graphql
@@ -1,0 +1,19 @@
+query listCustomerUsers($id: ID!, $after: String, $first: Int) {
+  customer(id: $id) {
+    users(after: $after, first: $first) {
+      nodes {
+        id
+        name
+        email
+        externalId
+        role {
+          name
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}

--- a/src/graphql/customers/listCustomers.generated.ts
+++ b/src/graphql/customers/listCustomers.generated.ts
@@ -1,0 +1,97 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ListCustomersQueryVariables = Exact<{
+  after?: string | null | undefined;
+  first?: number | null | undefined;
+}>;
+
+export type ListCustomersQuery = {
+  customers: {
+    nodes: Array<{ id: string; name: string; externalId: string | null; description: string }>;
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  };
+};
+
+export const ListCustomersDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "listCustomers" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "after" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "customers" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "isSystem" },
+                value: { kind: "BooleanValue", value: false },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "after" },
+                value: { kind: "Variable", name: { kind: "Name", value: "after" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "first" },
+                value: { kind: "Variable", name: { kind: "Name", value: "first" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      { kind: "Field", name: { kind: "Name", value: "name" } },
+                      { kind: "Field", name: { kind: "Name", value: "externalId" } },
+                      { kind: "Field", name: { kind: "Name", value: "description" } },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "pageInfo" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "hasNextPage" } },
+                      { kind: "Field", name: { kind: "Name", value: "endCursor" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ListCustomersQuery, ListCustomersQueryVariables>;

--- a/src/graphql/customers/listCustomers.graphql
+++ b/src/graphql/customers/listCustomers.graphql
@@ -1,0 +1,14 @@
+query listCustomers($after: String, $first: Int) {
+  customers(isSystem: false, after: $after, first: $first) {
+    nodes {
+      id
+      name
+      externalId
+      description
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}

--- a/src/graphql/executions/getExecutionLogs.generated.ts
+++ b/src/graphql/executions/getExecutionLogs.generated.ts
@@ -1,23 +1,118 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
 import type * as Types from "../schema.generated.js";
 
-export type GetExecutionLogsQueryVariables = Types.Exact<{
-  executionId: Types.Scalars["ID"]["input"];
-  nextCursor?: Types.InputMaybe<Types.Scalars["String"]["input"]>;
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+/** Indicates the severity level of a log message. */
+export type LogSeverityLevel = "DEBUG" | "ERROR" | "FATAL" | "INFO" | "METRIC" | "TRACE" | "WARN";
+
+export type GetExecutionLogsQueryVariables = Exact<{
+  executionId: string | number;
+  nextCursor?: string | null | undefined;
 }>;
 
 export type GetExecutionLogsQuery = {
-  __typename?: "RootQuery";
   logs: {
-    __typename?: "LogConnection";
     edges: Array<{
-      __typename?: "LogEdge";
       cursor: string;
-      node?: {
-        __typename?: "Log";
-        timestamp: any;
-        severity: Types.LogSeverityLevel;
-        message: string;
-      } | null;
-    } | null>;
+      node: { timestamp: string; severity: Types.LogSeverityLevel; message: string };
+    }>;
   };
 };
+
+export const GetExecutionLogsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "GetExecutionLogs" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "executionId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "nextCursor" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "logs" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "executionResult" },
+                value: { kind: "Variable", name: { kind: "Name", value: "executionId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "after" },
+                value: { kind: "Variable", name: { kind: "Name", value: "nextCursor" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "orderBy" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "field" },
+                      value: { kind: "EnumValue", value: "TIMESTAMP" },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "direction" },
+                      value: { kind: "EnumValue", value: "ASC" },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "edges" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "node" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "timestamp" } },
+                            { kind: "Field", name: { kind: "Name", value: "severity" } },
+                            { kind: "Field", name: { kind: "Name", value: "message" } },
+                          ],
+                        },
+                      },
+                      { kind: "Field", name: { kind: "Name", value: "cursor" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<GetExecutionLogsQuery, GetExecutionLogsQueryVariables>;

--- a/src/graphql/executions/getExecutionStepResults.generated.ts
+++ b/src/graphql/executions/getExecutionStepResults.generated.ts
@@ -1,27 +1,129 @@
-import type * as Types from "../schema.generated.js";
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
 
-export type GetExecutionStepResultsQueryVariables = Types.Exact<{
-  executionId: Types.Scalars["ID"]["input"];
-  nextCursor?: Types.InputMaybe<Types.Scalars["String"]["input"]>;
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type GetExecutionStepResultsQueryVariables = Exact<{
+  executionId: string | number;
+  nextCursor?: string | null | undefined;
 }>;
 
 export type GetExecutionStepResultsQuery = {
-  __typename?: "RootQuery";
-  executionResult?: {
-    __typename?: "InstanceExecutionResult";
+  executionResult: {
     stepResults: {
-      __typename?: "InstanceStepResultConnection";
       totalCount: number;
       edges: Array<{
-        __typename?: "InstanceStepResultEdge";
         cursor: string;
-        node?: {
-          __typename?: "InstanceStepResult";
-          stepName?: string | null;
-          endedAt?: any | null;
-          resultsUrl: string;
-        } | null;
-      } | null>;
+        node: { stepName: string | null; endedAt: string | null; resultsUrl: string };
+      }>;
     };
   } | null;
 };
+
+export const GetExecutionStepResultsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "GetExecutionStepResults" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "executionId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "nextCursor" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "executionResult" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "executionId" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "stepResults" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "after" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "nextCursor" } },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "orderBy" },
+                      value: {
+                        kind: "ObjectValue",
+                        fields: [
+                          {
+                            kind: "ObjectField",
+                            name: { kind: "Name", value: "field" },
+                            value: { kind: "EnumValue", value: "ENDED_AT" },
+                          },
+                          {
+                            kind: "ObjectField",
+                            name: { kind: "Name", value: "direction" },
+                            value: { kind: "EnumValue", value: "ASC" },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "edges" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "node" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "stepName" } },
+                                  { kind: "Field", name: { kind: "Name", value: "endedAt" } },
+                                  { kind: "Field", name: { kind: "Name", value: "resultsUrl" } },
+                                ],
+                              },
+                            },
+                            { kind: "Field", name: { kind: "Name", value: "cursor" } },
+                          ],
+                        },
+                      },
+                      { kind: "Field", name: { kind: "Name", value: "totalCount" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<GetExecutionStepResultsQuery, GetExecutionStepResultsQueryVariables>;

--- a/src/graphql/executions/getExecutions.generated.ts
+++ b/src/graphql/executions/getExecutions.generated.ts
@@ -1,22 +1,107 @@
-import type * as Types from "../schema.generated.js";
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
 
-export type GetExecutionsQueryVariables = Types.Exact<{
-  flowId?: Types.InputMaybe<Types.Scalars["ID"]["input"]>;
-  isTestExecution?: Types.InputMaybe<Types.Scalars["Boolean"]["input"]>;
-  limit?: Types.InputMaybe<Types.Scalars["Int"]["input"]>;
-  startDate?: Types.InputMaybe<Types.Scalars["DateTime"]["input"]>;
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type GetExecutionsQueryVariables = Exact<{
+  flowId?: string | number | null | undefined;
+  isTestExecution?: boolean | null | undefined;
+  limit?: number | null | undefined;
+  startDate?: string | null | undefined;
 }>;
 
 export type GetExecutionsQuery = {
-  __typename?: "RootQuery";
   executionResults: {
-    __typename?: "InstanceExecutionResultConnection";
     nodes: Array<{
-      __typename?: "InstanceExecutionResult";
       id: string;
-      endedAt?: any | null;
+      endedAt: string | null;
       requestPayloadUrl: string;
       responsePayloadUrl: string;
-    } | null>;
+    }>;
   };
 };
+
+export const GetExecutionsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "GetExecutions" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "flowId" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "isTestExecution" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "limit" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "startDate" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "DateTime" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "executionResults" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "first" },
+                value: { kind: "Variable", name: { kind: "Name", value: "limit" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "isTestExecution" },
+                value: { kind: "Variable", name: { kind: "Name", value: "isTestExecution" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "startedAt_Gte" },
+                value: { kind: "Variable", name: { kind: "Name", value: "startDate" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "flowConfig_Flow" },
+                value: { kind: "Variable", name: { kind: "Name", value: "flowId" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      { kind: "Field", name: { kind: "Name", value: "endedAt" } },
+                      { kind: "Field", name: { kind: "Name", value: "requestPayloadUrl" } },
+                      { kind: "Field", name: { kind: "Name", value: "responsePayloadUrl" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<GetExecutionsQuery, GetExecutionsQueryVariables>;

--- a/src/graphql/executions/getPolledExecution.generated.ts
+++ b/src/graphql/executions/getPolledExecution.generated.ts
@@ -1,23 +1,110 @@
-import type * as Types from "../schema.generated.js";
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
 
-export type GetPolledExecutionQueryVariables = Types.Exact<{
-  executionId: Types.Scalars["ID"]["input"];
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type GetPolledExecutionQueryVariables = Exact<{
+  executionId: string | number;
 }>;
 
 export type GetPolledExecutionQuery = {
-  __typename?: "RootQuery";
-  executionResult?: {
-    __typename?: "InstanceExecutionResult";
+  executionResult: {
     id: string;
-    endedAt?: any | null;
-    stepResults: {
-      __typename?: "InstanceStepResultConnection";
-      nodes: Array<{
-        __typename?: "InstanceStepResult";
-        id: string;
-        stepName?: string | null;
-        resultsUrl: string;
-      } | null>;
-    };
+    endedAt: string | null;
+    stepResults: { nodes: Array<{ id: string; stepName: string | null; resultsUrl: string }> };
   } | null;
 };
+
+export const GetPolledExecutionDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "GetPolledExecution" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "executionId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "executionResult" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "executionId" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "id" } },
+                { kind: "Field", name: { kind: "Name", value: "endedAt" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "stepResults" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "orderBy" },
+                      value: {
+                        kind: "ObjectValue",
+                        fields: [
+                          {
+                            kind: "ObjectField",
+                            name: { kind: "Name", value: "direction" },
+                            value: { kind: "EnumValue", value: "ASC" },
+                          },
+                          {
+                            kind: "ObjectField",
+                            name: { kind: "Name", value: "field" },
+                            value: { kind: "EnumValue", value: "STARTED_AT" },
+                          },
+                        ],
+                      },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "first" },
+                      value: { kind: "IntValue", value: "1" },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "id" } },
+                            { kind: "Field", name: { kind: "Name", value: "stepName" } },
+                            { kind: "Field", name: { kind: "Name", value: "resultsUrl" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<GetPolledExecutionQuery, GetPolledExecutionQueryVariables>;

--- a/src/graphql/executions/isCniExecutionComplete.generated.ts
+++ b/src/graphql/executions/isCniExecutionComplete.generated.ts
@@ -1,13 +1,65 @@
-import type * as Types from "../schema.generated.js";
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
 
-export type IsCniExecutionCompleteQueryVariables = Types.Exact<{
-  executionId: Types.Scalars["ID"]["input"];
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type IsCniExecutionCompleteQueryVariables = Exact<{
+  executionId: string | number;
 }>;
 
 export type IsCniExecutionCompleteQuery = {
-  __typename?: "RootQuery";
-  executionResult?: {
-    __typename?: "InstanceExecutionResult";
-    stepResults: { __typename?: "InstanceStepResultConnection"; totalCount: number };
-  } | null;
+  executionResult: { stepResults: { totalCount: number } } | null;
 };
+
+export const IsCniExecutionCompleteDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "IsCniExecutionComplete" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "executionId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "executionResult" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "executionId" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "stepResults" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "totalCount" } }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<IsCniExecutionCompleteQuery, IsCniExecutionCompleteQueryVariables>;

--- a/src/graphql/instances/listInstanceConfigVariables.generated.ts
+++ b/src/graphql/instances/listInstanceConfigVariables.generated.ts
@@ -1,0 +1,204 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+import type * as Types from "../schema.generated.js";
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type InstanceConfigVariableStatus =
+  /** active */
+  | "ACTIVE"
+  /** error */
+  | "ERROR"
+  /** failed */
+  | "FAILED"
+  /** pending */
+  | "PENDING";
+
+export type RequiredConfigVariableDataType =
+  /** Boolean */
+  | "BOOLEAN"
+  /** Code */
+  | "CODE"
+  /** Connection */
+  | "CONNECTION"
+  /** Credential */
+  | "CREDENTIAL"
+  /** Date */
+  | "DATE"
+  /** Jsonform */
+  | "JSONFORM"
+  /** Number */
+  | "NUMBER"
+  /** Objectfieldmap */
+  | "OBJECTFIELDMAP"
+  /** Objectselection */
+  | "OBJECTSELECTION"
+  /** Picklist */
+  | "PICKLIST"
+  /** Schedule */
+  | "SCHEDULE"
+  /** String */
+  | "STRING"
+  /** Timestamp */
+  | "TIMESTAMP";
+
+export type ListInstanceConfigVariablesQueryVariables = Exact<{
+  id: string | number;
+  after?: string | null | undefined;
+  first?: number | null | undefined;
+}>;
+
+export type ListInstanceConfigVariablesQuery = {
+  instance: {
+    configVariables: {
+      nodes: Array<{
+        id: string;
+        value: string | null;
+        status: Types.InstanceConfigVariableStatus | null;
+        inputs: { nodes: Array<{ name: string; value: string }> } | null;
+        requiredConfigVariable: {
+          id: string;
+          key: string;
+          defaultValue: string | null;
+          dataType: Types.RequiredConfigVariableDataType;
+        };
+      }>;
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+    };
+  } | null;
+};
+
+export const ListInstanceConfigVariablesDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "listInstanceConfigVariables" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "after" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "instance" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "configVariables" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "after" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "after" } },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "first" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "first" } },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "id" } },
+                            { kind: "Field", name: { kind: "Name", value: "value" } },
+                            { kind: "Field", name: { kind: "Name", value: "status" } },
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "inputs" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  {
+                                    kind: "Field",
+                                    name: { kind: "Name", value: "nodes" },
+                                    selectionSet: {
+                                      kind: "SelectionSet",
+                                      selections: [
+                                        { kind: "Field", name: { kind: "Name", value: "name" } },
+                                        { kind: "Field", name: { kind: "Name", value: "value" } },
+                                      ],
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "requiredConfigVariable" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "id" } },
+                                  { kind: "Field", name: { kind: "Name", value: "key" } },
+                                  { kind: "Field", name: { kind: "Name", value: "defaultValue" } },
+                                  { kind: "Field", name: { kind: "Name", value: "dataType" } },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "pageInfo" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "hasNextPage" } },
+                            { kind: "Field", name: { kind: "Name", value: "endCursor" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  ListInstanceConfigVariablesQuery,
+  ListInstanceConfigVariablesQueryVariables
+>;

--- a/src/graphql/instances/listInstanceConfigVariables.graphql
+++ b/src/graphql/instances/listInstanceConfigVariables.graphql
@@ -1,0 +1,27 @@
+query listInstanceConfigVariables($id: ID!, $after: String, $first: Int) {
+  instance(id: $id) {
+    configVariables(after: $after, first: $first) {
+      nodes {
+        id
+        value
+        status
+        inputs {
+          nodes {
+            name
+            value
+          }
+        }
+        requiredConfigVariable {
+          id
+          key
+          defaultValue
+          dataType
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}

--- a/src/graphql/instances/listInstanceFlowConfigs.generated.ts
+++ b/src/graphql/instances/listInstanceFlowConfigs.generated.ts
@@ -1,0 +1,127 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ListInstanceFlowConfigsQueryVariables = Exact<{
+  id: string | number;
+  after?: string | null | undefined;
+  first?: number | null | undefined;
+}>;
+
+export type ListInstanceFlowConfigsQuery = {
+  instance: {
+    flowConfigs: {
+      nodes: Array<{ id: string; webhookUrl: string; flow: { name: string } }>;
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+    };
+  } | null;
+};
+
+export const ListInstanceFlowConfigsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "listInstanceFlowConfigs" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "after" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "instance" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "flowConfigs" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "after" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "after" } },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "first" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "first" } },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "id" } },
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "flow" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "name" } },
+                                ],
+                              },
+                            },
+                            { kind: "Field", name: { kind: "Name", value: "webhookUrl" } },
+                          ],
+                        },
+                      },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "pageInfo" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "hasNextPage" } },
+                            { kind: "Field", name: { kind: "Name", value: "endCursor" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ListInstanceFlowConfigsQuery, ListInstanceFlowConfigsQueryVariables>;

--- a/src/graphql/instances/listInstanceFlowConfigs.graphql
+++ b/src/graphql/instances/listInstanceFlowConfigs.graphql
@@ -1,0 +1,17 @@
+query listInstanceFlowConfigs($id: ID!, $after: String, $first: Int) {
+  instance(id: $id) {
+    flowConfigs(after: $after, first: $first) {
+      nodes {
+        id
+        flow {
+          name
+        }
+        webhookUrl
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}

--- a/src/graphql/instances/listInstances.generated.ts
+++ b/src/graphql/instances/listInstances.generated.ts
@@ -1,0 +1,137 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ListInstancesQueryVariables = Exact<{
+  customer?: string | number | null | undefined;
+  integration?: string | number | null | undefined;
+  after?: string | null | undefined;
+  first?: number | null | undefined;
+}>;
+
+export type ListInstancesQuery = {
+  instances: {
+    nodes: Array<{
+      id: string;
+      name: string;
+      description: string;
+      enabled: boolean;
+      customer: { id: string; name: string; externalId: string | null };
+    }>;
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  };
+};
+
+export const ListInstancesDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "listInstances" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "customer" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "integration" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "after" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "instances" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "customer" },
+                value: { kind: "Variable", name: { kind: "Name", value: "customer" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "integration" },
+                value: { kind: "Variable", name: { kind: "Name", value: "integration" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "isSystem" },
+                value: { kind: "BooleanValue", value: false },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "after" },
+                value: { kind: "Variable", name: { kind: "Name", value: "after" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "first" },
+                value: { kind: "Variable", name: { kind: "Name", value: "first" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      { kind: "Field", name: { kind: "Name", value: "name" } },
+                      { kind: "Field", name: { kind: "Name", value: "description" } },
+                      { kind: "Field", name: { kind: "Name", value: "enabled" } },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "customer" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "id" } },
+                            { kind: "Field", name: { kind: "Name", value: "name" } },
+                            { kind: "Field", name: { kind: "Name", value: "externalId" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "pageInfo" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "hasNextPage" } },
+                      { kind: "Field", name: { kind: "Name", value: "endCursor" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ListInstancesQuery, ListInstancesQueryVariables>;

--- a/src/graphql/instances/listInstances.graphql
+++ b/src/graphql/instances/listInstances.graphql
@@ -1,0 +1,25 @@
+query listInstances($customer: ID, $integration: ID, $after: String, $first: Int) {
+  instances(
+    customer: $customer
+    integration: $integration
+    isSystem: false
+    after: $after
+    first: $first
+  ) {
+    nodes {
+      id
+      name
+      description
+      enabled
+      customer {
+        id
+        name
+        externalId
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}

--- a/src/graphql/integrations/deleteIntegration.generated.ts
+++ b/src/graphql/integrations/deleteIntegration.generated.ts
@@ -1,13 +1,77 @@
-import type * as Types from "../schema.generated.js";
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
 
-export type DeleteIntegrationMutationVariables = Types.Exact<{
-  id: Types.Scalars["ID"]["input"];
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type DeleteIntegrationMutationVariables = Exact<{
+  id: string | number;
 }>;
 
 export type DeleteIntegrationMutation = {
-  __typename?: "RootMutation";
-  deleteIntegration?: {
-    __typename?: "DeleteIntegrationPayload";
-    errors: Array<{ __typename?: "ErrorType"; field: string; messages: Array<string> }>;
-  } | null;
+  deleteIntegration: { errors: Array<{ field: string; messages: Array<string> }> } | null;
 };
+
+export const DeleteIntegrationDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "DeleteIntegration" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "deleteIntegration" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DeleteIntegrationMutation, DeleteIntegrationMutationVariables>;

--- a/src/graphql/integrations/getIntegrationFlow.generated.ts
+++ b/src/graphql/integrations/getIntegrationFlow.generated.ts
@@ -1,16 +1,77 @@
-import type * as Types from "../schema.generated.js";
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
 
-export type GetIntegrationFlowQueryVariables = Types.Exact<{
-  id: Types.Scalars["ID"]["input"];
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type GetIntegrationFlowQueryVariables = Exact<{
+  id: string | number;
 }>;
 
 export type GetIntegrationFlowQuery = {
-  __typename?: "RootQuery";
-  integration?: {
-    __typename?: "Integration";
-    flows: {
-      __typename?: "IntegrationFlowConnection";
-      nodes: Array<{ __typename?: "IntegrationFlow"; id: string; name: string } | null>;
-    };
-  } | null;
+  integration: { flows: { nodes: Array<{ id: string; name: string }> } } | null;
 };
+
+export const GetIntegrationFlowDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "GetIntegrationFlow" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integration" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "flows" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "id" } },
+                            { kind: "Field", name: { kind: "Name", value: "name" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<GetIntegrationFlowQuery, GetIntegrationFlowQueryVariables>;

--- a/src/graphql/integrations/getIntegrationFlows.generated.ts
+++ b/src/graphql/integrations/getIntegrationFlows.generated.ts
@@ -1,34 +1,181 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
 import type * as Types from "../schema.generated.js";
 
-export type GetIntegrationFlowsQueryVariables = Types.Exact<{
-  id: Types.Scalars["ID"]["input"];
-  after?: Types.InputMaybe<Types.Scalars["String"]["input"]>;
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ActionScheduleSupport =
+  /** Invalid */
+  | "INVALID"
+  /** Required */
+  | "REQUIRED"
+  /** Valid */
+  | "VALID";
+
+export type GetIntegrationFlowsQueryVariables = Exact<{
+  id: string | number;
+  after?: string | null | undefined;
+  first?: number | null | undefined;
 }>;
 
 export type GetIntegrationFlowsQuery = {
-  __typename?: "RootQuery";
-  integration?: {
-    __typename?: "Integration";
+  integration: {
     flows: {
-      __typename?: "IntegrationFlowConnection";
       nodes: Array<{
-        __typename?: "IntegrationFlow";
         id: string;
-        stableKey?: string | null;
+        stableKey: string | null;
         name: string;
-        description?: string | null;
+        description: string | null;
         testUrl: string;
         trigger: {
-          __typename?: "IntegrationAction";
           action: {
-            __typename?: "Action";
-            isPollingTrigger?: boolean | null;
-            scheduleSupport?: Types.ActionScheduleSupport | null;
-            component?: { __typename?: "Component"; key: string } | null;
+            isPollingTrigger: boolean | null;
+            scheduleSupport: Types.ActionScheduleSupport | null;
+            component: { key: string } | null;
           };
         };
-      } | null>;
-      pageInfo: { __typename?: "PageInfo"; hasNextPage: boolean; endCursor?: string | null };
+      }>;
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
     };
   } | null;
 };
+
+export const GetIntegrationFlowsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "GetIntegrationFlows" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "after" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integration" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "flows" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "after" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "after" } },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "first" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "first" } },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "id" } },
+                            { kind: "Field", name: { kind: "Name", value: "stableKey" } },
+                            { kind: "Field", name: { kind: "Name", value: "name" } },
+                            { kind: "Field", name: { kind: "Name", value: "description" } },
+                            { kind: "Field", name: { kind: "Name", value: "testUrl" } },
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "trigger" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  {
+                                    kind: "Field",
+                                    name: { kind: "Name", value: "action" },
+                                    selectionSet: {
+                                      kind: "SelectionSet",
+                                      selections: [
+                                        {
+                                          kind: "Field",
+                                          name: { kind: "Name", value: "component" },
+                                          selectionSet: {
+                                            kind: "SelectionSet",
+                                            selections: [
+                                              {
+                                                kind: "Field",
+                                                name: { kind: "Name", value: "key" },
+                                              },
+                                            ],
+                                          },
+                                        },
+                                        {
+                                          kind: "Field",
+                                          name: { kind: "Name", value: "isPollingTrigger" },
+                                        },
+                                        {
+                                          kind: "Field",
+                                          name: { kind: "Name", value: "scheduleSupport" },
+                                        },
+                                      ],
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "pageInfo" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "hasNextPage" } },
+                            { kind: "Field", name: { kind: "Name", value: "endCursor" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<GetIntegrationFlowsQuery, GetIntegrationFlowsQueryVariables>;

--- a/src/graphql/integrations/getIntegrationFlows.graphql
+++ b/src/graphql/integrations/getIntegrationFlows.graphql
@@ -1,6 +1,6 @@
-query GetIntegrationFlows($id: ID!, $after: String) {
+query GetIntegrationFlows($id: ID!, $after: String, $first: Int) {
   integration(id: $id) {
-    flows(after: $after) {
+    flows(after: $after, first: $first) {
       nodes {
         id
         stableKey

--- a/src/graphql/integrations/getIntegrationSystemInstance.generated.ts
+++ b/src/graphql/integrations/getIntegrationSystemInstance.generated.ts
@@ -1,18 +1,81 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
 import type * as Types from "../schema.generated.js";
 
-export type GetIntegrationSystemInstanceQueryVariables = Types.Exact<{
-  integrationId: Types.Scalars["ID"]["input"];
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type InstanceConfigState =
+  | "FULLY_CONFIGURED"
+  | "NEEDS_INSTANCE_CONFIGURATION"
+  | "NEEDS_USER_LEVEL_CONFIGURATION";
+
+export type GetIntegrationSystemInstanceQueryVariables = Exact<{
+  integrationId: string | number;
 }>;
 
 export type GetIntegrationSystemInstanceQuery = {
-  __typename?: "RootQuery";
-  integration?: {
-    __typename?: "Integration";
+  integration: {
     isCodeNative: boolean;
-    systemInstance: {
-      __typename?: "Instance";
-      id: string;
-      configState?: Types.InstanceConfigState | null;
-    };
+    systemInstance: { id: string; configState: Types.InstanceConfigState | null };
   } | null;
 };
+
+export const GetIntegrationSystemInstanceDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "GetIntegrationSystemInstance" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "integrationId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integration" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "integrationId" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "isCodeNative" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "systemInstance" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      { kind: "Field", name: { kind: "Name", value: "configState" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  GetIntegrationSystemInstanceQuery,
+  GetIntegrationSystemInstanceQueryVariables
+>;

--- a/src/graphql/integrations/listIntegrations.generated.ts
+++ b/src/graphql/integrations/listIntegrations.generated.ts
@@ -1,0 +1,158 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ListIntegrationsQueryVariables = Exact<{
+  showAllVersions?: boolean | null | undefined;
+  after?: string | null | undefined;
+  first?: number | null | undefined;
+  customer?: string | number | null | undefined;
+  customerIsnull?: boolean | null | undefined;
+  search?: string | null | undefined;
+}>;
+
+export type ListIntegrationsQuery = {
+  integrations: {
+    nodes: Array<{
+      id: string;
+      name: string;
+      description: string | null;
+      versionNumber: number;
+      labels: Array<string> | null;
+      category: string | null;
+      customer: { id: string; name: string; externalId: string | null } | null;
+    }>;
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  };
+};
+
+export const ListIntegrationsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "listIntegrations" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "showAllVersions" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "after" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "customer" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "customerIsnull" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "search" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrations" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "allVersions" },
+                value: { kind: "Variable", name: { kind: "Name", value: "showAllVersions" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "after" },
+                value: { kind: "Variable", name: { kind: "Name", value: "after" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "first" },
+                value: { kind: "Variable", name: { kind: "Name", value: "first" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "customer" },
+                value: { kind: "Variable", name: { kind: "Name", value: "customer" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "customer_Isnull" },
+                value: { kind: "Variable", name: { kind: "Name", value: "customerIsnull" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "name_Icontains" },
+                value: { kind: "Variable", name: { kind: "Name", value: "search" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      { kind: "Field", name: { kind: "Name", value: "name" } },
+                      { kind: "Field", name: { kind: "Name", value: "description" } },
+                      { kind: "Field", name: { kind: "Name", value: "versionNumber" } },
+                      { kind: "Field", name: { kind: "Name", value: "labels" } },
+                      { kind: "Field", name: { kind: "Name", value: "category" } },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "customer" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "id" } },
+                            { kind: "Field", name: { kind: "Name", value: "name" } },
+                            { kind: "Field", name: { kind: "Name", value: "externalId" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "pageInfo" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "hasNextPage" } },
+                      { kind: "Field", name: { kind: "Name", value: "endCursor" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ListIntegrationsQuery, ListIntegrationsQueryVariables>;

--- a/src/graphql/integrations/listIntegrations.graphql
+++ b/src/graphql/integrations/listIntegrations.graphql
@@ -1,0 +1,35 @@
+query listIntegrations(
+  $showAllVersions: Boolean
+  $after: String
+  $first: Int
+  $customer: ID
+  $customerIsnull: Boolean
+  $search: String
+) {
+  integrations(
+    allVersions: $showAllVersions
+    after: $after
+    first: $first
+    customer: $customer
+    customer_Isnull: $customerIsnull
+    name_Icontains: $search
+  ) {
+    nodes {
+      id
+      name
+      description
+      versionNumber
+      labels
+      category
+      customer {
+        id
+        name
+        externalId
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}

--- a/src/graphql/integrations/testIntegrationFlow.generated.ts
+++ b/src/graphql/integrations/testIntegrationFlow.generated.ts
@@ -1,17 +1,97 @@
-import type * as Types from "../schema.generated.js";
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
 
-export type TestIntegrationFlowMutationVariables = Types.Exact<{
-  id: Types.Scalars["ID"]["input"];
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type TestIntegrationFlowMutationVariables = Exact<{
+  id: string | number;
 }>;
 
 export type TestIntegrationFlowMutation = {
-  __typename?: "RootMutation";
-  testIntegrationFlow?: {
-    __typename?: "TestIntegrationFlowPayload";
-    testIntegrationFlowResult?: {
-      __typename?: "TestIntegrationFlowResult";
-      execution?: { __typename?: "InstanceExecutionResult"; id: string } | null;
-    } | null;
-    errors: Array<{ __typename?: "ErrorType"; field: string; messages: Array<string> }>;
+  testIntegrationFlow: {
+    testIntegrationFlowResult: { execution: { id: string } | null } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
   } | null;
 };
+
+export const TestIntegrationFlowDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "TestIntegrationFlow" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "testIntegrationFlow" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "testIntegrationFlowResult" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "execution" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<TestIntegrationFlowMutation, TestIntegrationFlowMutationVariables>;

--- a/src/graphql/integrations/updateIntegrationFlowListeningMode.generated.ts
+++ b/src/graphql/integrations/updateIntegrationFlowListeningMode.generated.ts
@@ -1,14 +1,93 @@
-import type * as Types from "../schema.generated.js";
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
 
-export type UpdateIntegrationFlowListeningModeMutationVariables = Types.Exact<{
-  integrationId: Types.Scalars["ID"]["input"];
-  isListening?: Types.InputMaybe<Types.Scalars["Boolean"]["input"]>;
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type UpdateIntegrationFlowListeningModeMutationVariables = Exact<{
+  integrationId: string | number;
+  isListening?: boolean | null | undefined;
 }>;
 
 export type UpdateIntegrationFlowListeningModeMutation = {
-  __typename?: "RootMutation";
-  updateWorkflowTestConfiguration?: {
-    __typename?: "UpdateWorkflowTestConfigurationPayload";
-    errors: Array<{ __typename?: "ErrorType"; field: string; messages: Array<string> }>;
+  updateWorkflowTestConfiguration: {
+    errors: Array<{ field: string; messages: Array<string> }>;
   } | null;
 };
+
+export const UpdateIntegrationFlowListeningModeDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "UpdateIntegrationFlowListeningMode" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "integrationId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "isListening" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "updateWorkflowTestConfiguration" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "integrationId" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "listeningMode" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "isListening" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  UpdateIntegrationFlowListeningModeMutation,
+  UpdateIntegrationFlowListeningModeMutationVariables
+>;

--- a/src/graphql/onPremResources/listOnPremiseResources.generated.ts
+++ b/src/graphql/onPremResources/listOnPremiseResources.generated.ts
@@ -1,0 +1,130 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+import type * as Types from "../schema.generated.js";
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type OnPremiseResourceStatus =
+  /** Available */
+  | "AVAILABLE"
+  /** Pending */
+  | "PENDING"
+  /** Unavailable */
+  | "UNAVAILABLE"
+  /** Unknown */
+  | "UNKNOWN";
+
+export type ListOnPremiseResourcesQueryVariables = Exact<{
+  after?: string | null | undefined;
+  customer?: string | number | null | undefined;
+  first?: number | null | undefined;
+}>;
+
+export type ListOnPremiseResourcesQuery = {
+  onPremiseResources: {
+    nodes: Array<{
+      id: string;
+      name: string;
+      status: Types.OnPremiseResourceStatus;
+      customer: { id: string; name: string; externalId: string | null } | null;
+    }>;
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  };
+};
+
+export const ListOnPremiseResourcesDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "listOnPremiseResources" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "after" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "customer" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "onPremiseResources" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "after" },
+                value: { kind: "Variable", name: { kind: "Name", value: "after" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "customer" },
+                value: { kind: "Variable", name: { kind: "Name", value: "customer" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "first" },
+                value: { kind: "Variable", name: { kind: "Name", value: "first" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      { kind: "Field", name: { kind: "Name", value: "name" } },
+                      { kind: "Field", name: { kind: "Name", value: "status" } },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "customer" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "id" } },
+                            { kind: "Field", name: { kind: "Name", value: "name" } },
+                            { kind: "Field", name: { kind: "Name", value: "externalId" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "pageInfo" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "hasNextPage" } },
+                      { kind: "Field", name: { kind: "Name", value: "endCursor" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ListOnPremiseResourcesQuery, ListOnPremiseResourcesQueryVariables>;

--- a/src/graphql/onPremResources/listOnPremiseResources.graphql
+++ b/src/graphql/onPremResources/listOnPremiseResources.graphql
@@ -1,0 +1,18 @@
+query listOnPremiseResources($after: String, $customer: ID, $first: Int) {
+  onPremiseResources(after: $after, customer: $customer, first: $first) {
+    nodes {
+      id
+      name
+      status
+      customer {
+        id
+        name
+        externalId
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}

--- a/src/graphql/operations/AuthenticatedUserQuery.generated.ts
+++ b/src/graphql/operations/AuthenticatedUserQuery.generated.ts
@@ -1,0 +1,35 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type AuthenticatedUserQueryQueryVariables = Exact<{ [key: string]: never }>;
+
+export type AuthenticatedUserQueryQuery = { authenticatedUser: { id: string } };
+
+export const AuthenticatedUserQueryDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "AuthenticatedUserQuery" },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "authenticatedUser" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<AuthenticatedUserQueryQuery, AuthenticatedUserQueryQueryVariables>;

--- a/src/graphql/operations/AuthenticatedUserQuery.graphql
+++ b/src/graphql/operations/AuthenticatedUserQuery.graphql
@@ -1,0 +1,5 @@
+query AuthenticatedUserQuery {
+  authenticatedUser {
+    id
+  }
+}

--- a/src/graphql/operations/ConvertToCNI.generated.ts
+++ b/src/graphql/operations/ConvertToCNI.generated.ts
@@ -1,0 +1,142 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ConvertToCniMutationVariables = Exact<{
+  id: string | number;
+  registryPrefix?: string | null | undefined;
+  registryUrl?: string | null | undefined;
+  includeComments?: boolean | null | undefined;
+}>;
+
+export type ConvertToCniMutation = {
+  convertLowCodeIntegration: {
+    convertLowCodeIntegrationFormResult: {
+      url: string | null;
+      conversionErrors: Array<{
+        path: string | null;
+        error: string;
+        errorType: string;
+      } | null> | null;
+    } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const ConvertToCniDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "ConvertToCNI" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "registryPrefix" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "registryUrl" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "includeComments" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "convertLowCodeIntegration" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "registryPrefix" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "registryPrefix" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "registryUrl" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "registryUrl" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "includeComments" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "includeComments" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "convertLowCodeIntegrationFormResult" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "url" } },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "conversionErrors" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "path" } },
+                            { kind: "Field", name: { kind: "Name", value: "error" } },
+                            { kind: "Field", name: { kind: "Name", value: "errorType" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ConvertToCniMutation, ConvertToCniMutationVariables>;

--- a/src/graphql/operations/ConvertToCNI.graphql
+++ b/src/graphql/operations/ConvertToCNI.graphql
@@ -1,0 +1,28 @@
+mutation ConvertToCNI(
+  $id: ID!
+  $registryPrefix: String
+  $registryUrl: String
+  $includeComments: Boolean
+) {
+  convertLowCodeIntegration(
+    input: {
+      id: $id
+      registryPrefix: $registryPrefix
+      registryUrl: $registryUrl
+      includeComments: $includeComments
+    }
+  ) {
+    convertLowCodeIntegrationFormResult {
+      url
+      conversionErrors {
+        path
+        error
+        errorType
+      }
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/DeleteOrganizationSigningKeyMutation.generated.ts
+++ b/src/graphql/operations/DeleteOrganizationSigningKeyMutation.generated.ts
@@ -1,0 +1,91 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type DeleteOrganizationSigningKeyMutationMutationVariables = Exact<{
+  id: string | number;
+}>;
+
+export type DeleteOrganizationSigningKeyMutationMutation = {
+  deleteOrganizationSigningKey: {
+    organizationSigningKey: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const DeleteOrganizationSigningKeyMutationDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "DeleteOrganizationSigningKeyMutation" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "deleteOrganizationSigningKey" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "organizationSigningKey" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  DeleteOrganizationSigningKeyMutationMutation,
+  DeleteOrganizationSigningKeyMutationMutationVariables
+>;

--- a/src/graphql/operations/DeleteOrganizationSigningKeyMutation.graphql
+++ b/src/graphql/operations/DeleteOrganizationSigningKeyMutation.graphql
@@ -1,0 +1,11 @@
+mutation DeleteOrganizationSigningKeyMutation($id: ID!) {
+  deleteOrganizationSigningKey(input: { id: $id }) {
+    organizationSigningKey {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/ListUserTenants.generated.ts
+++ b/src/graphql/operations/ListUserTenants.generated.ts
@@ -1,0 +1,60 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ListUserTenantsQueryVariables = Exact<{ [key: string]: never }>;
+
+export type ListUserTenantsQuery = {
+  listUserTenants: {
+    nodes: Array<{
+      tenantId: string;
+      url: string;
+      orgName: string;
+      awsRegion: string;
+      systemSuspended: boolean | null;
+    }>;
+  };
+};
+
+export const ListUserTenantsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "ListUserTenants" },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "listUserTenants" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "tenantId" } },
+                      { kind: "Field", name: { kind: "Name", value: "url" } },
+                      { kind: "Field", name: { kind: "Name", value: "orgName" } },
+                      { kind: "Field", name: { kind: "Name", value: "awsRegion" } },
+                      { kind: "Field", name: { kind: "Name", value: "systemSuspended" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ListUserTenantsQuery, ListUserTenantsQueryVariables>;

--- a/src/graphql/operations/ListUserTenants.graphql
+++ b/src/graphql/operations/ListUserTenants.graphql
@@ -1,0 +1,11 @@
+query ListUserTenants {
+  listUserTenants {
+    nodes {
+      tenantId
+      url
+      orgName
+      awsRegion
+      systemSuspended
+    }
+  }
+}

--- a/src/graphql/operations/availableConnections.generated.ts
+++ b/src/graphql/operations/availableConnections.generated.ts
@@ -1,0 +1,115 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+import type * as Types from "../schema.generated.js";
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ScopedConfigVariableManagedBy =
+  /** Customer */
+  | "CUSTOMER"
+  /** Org */
+  | "ORG"
+  /** System */
+  | "SYSTEM"
+  /** User */
+  | "USER";
+
+export type AvailableConnectionsQueryVariables = Exact<{
+  managedBy?: string | null | undefined;
+}>;
+
+export type AvailableConnectionsQuery = {
+  scopedConfigVariables: {
+    nodes: Array<{
+      stableKey: string;
+      description: string | null;
+      managedBy: Types.ScopedConfigVariableManagedBy;
+      customer: { externalId: string | null; name: string } | null;
+      connection: { component: { key: string } } | null;
+    }>;
+  };
+};
+
+export const AvailableConnectionsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "availableConnections" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "managedBy" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "scopedConfigVariables" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "managedBy" },
+                value: { kind: "Variable", name: { kind: "Name", value: "managedBy" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "stableKey" } },
+                      { kind: "Field", name: { kind: "Name", value: "description" } },
+                      { kind: "Field", name: { kind: "Name", value: "managedBy" } },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "customer" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "externalId" } },
+                            { kind: "Field", name: { kind: "Name", value: "name" } },
+                          ],
+                        },
+                      },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "connection" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "component" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "key" } },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<AvailableConnectionsQuery, AvailableConnectionsQueryVariables>;

--- a/src/graphql/operations/availableConnections.graphql
+++ b/src/graphql/operations/availableConnections.graphql
@@ -1,0 +1,18 @@
+query availableConnections($managedBy: String) {
+  scopedConfigVariables(managedBy: $managedBy) {
+    nodes {
+      stableKey
+      description
+      managedBy
+      customer {
+        externalId
+        name
+      }
+      connection {
+        component {
+          key
+        }
+      }
+    }
+  }
+}

--- a/src/graphql/operations/clearAlertMonitor.generated.ts
+++ b/src/graphql/operations/clearAlertMonitor.generated.ts
@@ -1,0 +1,88 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ClearAlertMonitorMutationVariables = Exact<{
+  id: string | number;
+}>;
+
+export type ClearAlertMonitorMutation = {
+  clearAlertMonitor: {
+    alertMonitor: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const ClearAlertMonitorDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "clearAlertMonitor" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "clearAlertMonitor" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "alertMonitor" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ClearAlertMonitorMutation, ClearAlertMonitorMutationVariables>;

--- a/src/graphql/operations/clearAlertMonitor.graphql
+++ b/src/graphql/operations/clearAlertMonitor.graphql
@@ -1,0 +1,11 @@
+mutation clearAlertMonitor($id: ID!) {
+  clearAlertMonitor(input: { id: $id }) {
+    alertMonitor {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/commitAvatarUpload.generated.ts
+++ b/src/graphql/operations/commitAvatarUpload.generated.ts
@@ -1,0 +1,105 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type CommitAvatarUploadMutationVariables = Exact<{
+  organizationId: string | number;
+  avatarUrl: string;
+}>;
+
+export type CommitAvatarUploadMutation = {
+  updateOrganization: {
+    organization: { id: string; avatarUrl: string | null } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const CommitAvatarUploadDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "commitAvatarUpload" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "organizationId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "avatarUrl" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "updateOrganization" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "organizationId" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "avatarUrl" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "avatarUrl" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "organization" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      { kind: "Field", name: { kind: "Name", value: "avatarUrl" } },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<CommitAvatarUploadMutation, CommitAvatarUploadMutationVariables>;

--- a/src/graphql/operations/commitAvatarUpload.graphql
+++ b/src/graphql/operations/commitAvatarUpload.graphql
@@ -1,0 +1,12 @@
+mutation commitAvatarUpload($organizationId: ID!, $avatarUrl: String!) {
+  updateOrganization(input: { id: $organizationId, avatarUrl: $avatarUrl }) {
+    organization {
+      id
+      avatarUrl
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/commitAvatarUpload2.generated.ts
+++ b/src/graphql/operations/commitAvatarUpload2.generated.ts
@@ -1,0 +1,102 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type CommitAvatarUpload2MutationVariables = Exact<{
+  integrationId: string | number;
+  avatarUrl: string;
+}>;
+
+export type CommitAvatarUpload2Mutation = {
+  updateIntegration: {
+    integration: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const CommitAvatarUpload2Document = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "commitAvatarUpload2" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "integrationId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "avatarUrl" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "updateIntegration" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "integrationId" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "avatarUrl" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "avatarUrl" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "integration" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<CommitAvatarUpload2Mutation, CommitAvatarUpload2MutationVariables>;

--- a/src/graphql/operations/commitAvatarUpload2.graphql
+++ b/src/graphql/operations/commitAvatarUpload2.graphql
@@ -1,0 +1,11 @@
+mutation commitAvatarUpload2($integrationId: ID!, $avatarUrl: String!) {
+  updateIntegration(input: { id: $integrationId, avatarUrl: $avatarUrl }) {
+    integration {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/component.generated.ts
+++ b/src/graphql/operations/component.generated.ts
@@ -1,0 +1,68 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ComponentQueryVariables = Exact<{
+  key: string;
+}>;
+
+export type ComponentQuery = { components: { nodes: Array<{ id: string }> } };
+
+export const ComponentDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "component" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "key" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "components" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "key" },
+                value: { kind: "Variable", name: { kind: "Name", value: "key" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "public" },
+                value: { kind: "BooleanValue", value: false },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ComponentQuery, ComponentQueryVariables>;

--- a/src/graphql/operations/component.graphql
+++ b/src/graphql/operations/component.graphql
@@ -1,0 +1,7 @@
+query component($key: String!) {
+  components(key: $key, public: false) {
+    nodes {
+      id
+    }
+  }
+}

--- a/src/graphql/operations/component2.generated.ts
+++ b/src/graphql/operations/component2.generated.ts
@@ -1,0 +1,77 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type Component2QueryVariables = Exact<{
+  key: string;
+  public: boolean;
+}>;
+
+export type Component2Query = { components: { nodes: Array<{ signature: string }> } };
+
+export const Component2Document = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "component2" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "key" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "public" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "components" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "key" },
+                value: { kind: "Variable", name: { kind: "Name", value: "key" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "public" },
+                value: { kind: "Variable", name: { kind: "Name", value: "public" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "signature" } }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<Component2Query, Component2QueryVariables>;

--- a/src/graphql/operations/component2.graphql
+++ b/src/graphql/operations/component2.graphql
@@ -1,0 +1,7 @@
+query component2($key: String!, $public: Boolean!) {
+  components(key: $key, public: $public) {
+    nodes {
+      signature
+    }
+  }
+}

--- a/src/graphql/operations/component3.generated.ts
+++ b/src/graphql/operations/component3.generated.ts
@@ -1,0 +1,77 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type Component3QueryVariables = Exact<{
+  key: string;
+  public: boolean;
+}>;
+
+export type Component3Query = { components: { nodes: Array<{ signature: string }> } };
+
+export const Component3Document = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "component3" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "key" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "public" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "components" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "key" },
+                value: { kind: "Variable", name: { kind: "Name", value: "key" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "public" },
+                value: { kind: "Variable", name: { kind: "Name", value: "public" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "signature" } }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<Component3Query, Component3QueryVariables>;

--- a/src/graphql/operations/component3.graphql
+++ b/src/graphql/operations/component3.graphql
@@ -1,0 +1,7 @@
+query component3($key: String!, $public: Boolean!) {
+  components(key: $key, public: $public) {
+    nodes {
+      signature
+    }
+  }
+}

--- a/src/graphql/operations/component4.generated.ts
+++ b/src/graphql/operations/component4.generated.ts
@@ -1,0 +1,87 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type Component4QueryVariables = Exact<{
+  componentKey: string;
+  versionNumber: number;
+}>;
+
+export type Component4Query = { components: { nodes: Array<{ id: string }> } };
+
+export const Component4Document = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "component4" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "componentKey" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "versionNumber" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "components" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "key" },
+                value: { kind: "Variable", name: { kind: "Name", value: "componentKey" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "versionNumber" },
+                value: { kind: "Variable", name: { kind: "Name", value: "versionNumber" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "public" },
+                value: { kind: "BooleanValue", value: false },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "includeComponentsForCodeNativeIntegrations" },
+                value: { kind: "BooleanValue", value: true },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<Component4Query, Component4QueryVariables>;

--- a/src/graphql/operations/component4.graphql
+++ b/src/graphql/operations/component4.graphql
@@ -1,0 +1,12 @@
+query component4($componentKey: String!, $versionNumber: Int!) {
+  components(
+    key: $componentKey
+    versionNumber: $versionNumber
+    public: false
+    includeComponentsForCodeNativeIntegrations: true
+  ) {
+    nodes {
+      id
+    }
+  }
+}

--- a/src/graphql/operations/components.generated.ts
+++ b/src/graphql/operations/components.generated.ts
@@ -1,0 +1,73 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ComponentsQueryVariables = Exact<{
+  keys: Array<string | null | undefined> | string;
+}>;
+
+export type ComponentsQuery = {
+  components: { nodes: Array<{ id: string; key: string; versionNumber: number; public: boolean }> };
+};
+
+export const ComponentsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "components" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "keys" } },
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "ListType",
+              type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+            },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "components" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "key_In" },
+                value: { kind: "Variable", name: { kind: "Name", value: "keys" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      { kind: "Field", name: { kind: "Name", value: "key" } },
+                      { kind: "Field", name: { kind: "Name", value: "versionNumber" } },
+                      { kind: "Field", name: { kind: "Name", value: "public" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ComponentsQuery, ComponentsQueryVariables>;

--- a/src/graphql/operations/components.graphql
+++ b/src/graphql/operations/components.graphql
@@ -1,0 +1,10 @@
+query components($keys: [String]!) {
+  components(key_In: $keys) {
+    nodes {
+      id
+      key
+      versionNumber
+      public
+    }
+  }
+}

--- a/src/graphql/operations/createAlertGroup.generated.ts
+++ b/src/graphql/operations/createAlertGroup.generated.ts
@@ -1,0 +1,116 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type CreateAlertGroupMutationVariables = Exact<{
+  name: string;
+  users?: Array<string | number | null | undefined> | string | number | null | undefined;
+  webhooks?: Array<string | number | null | undefined> | string | number | null | undefined;
+}>;
+
+export type CreateAlertGroupMutation = {
+  createAlertGroup: {
+    alertGroup: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const CreateAlertGroupDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createAlertGroup" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "name" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "users" } },
+          type: {
+            kind: "ListType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "webhooks" } },
+          type: {
+            kind: "ListType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "createAlertGroup" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "name" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "name" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "users" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "users" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "webhooks" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "webhooks" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "alertGroup" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<CreateAlertGroupMutation, CreateAlertGroupMutationVariables>;

--- a/src/graphql/operations/createAlertGroup.graphql
+++ b/src/graphql/operations/createAlertGroup.graphql
@@ -1,0 +1,11 @@
+mutation createAlertGroup($name: String!, $users: [ID], $webhooks: [ID]) {
+  createAlertGroup(input: { name: $name, users: $users, webhooks: $webhooks }) {
+    alertGroup {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/createAlertMonitor.generated.ts
+++ b/src/graphql/operations/createAlertMonitor.generated.ts
@@ -1,0 +1,169 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type CreateAlertMonitorMutationVariables = Exact<{
+  name: string;
+  instance: string | number;
+  triggers: Array<string | number | null | undefined> | string | number;
+  logSeverity?: number | null | undefined;
+  duration?: number | null | undefined;
+  groups?: Array<string | number | null | undefined> | string | number | null | undefined;
+  users?: Array<string | number | null | undefined> | string | number | null | undefined;
+}>;
+
+export type CreateAlertMonitorMutation = {
+  createAlertMonitor: {
+    alertMonitor: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const CreateAlertMonitorDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createAlertMonitor" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "name" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "instance" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "triggers" } },
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "ListType",
+              type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+            },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "logSeverity" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "duration" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "groups" } },
+          type: {
+            kind: "ListType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "users" } },
+          type: {
+            kind: "ListType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "createAlertMonitor" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "name" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "name" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "instance" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "instance" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "triggers" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "triggers" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "logSeverityLevelCondition" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "logSeverity" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "durationSecondsCondition" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "duration" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "groups" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "groups" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "users" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "users" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "alertMonitor" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<CreateAlertMonitorMutation, CreateAlertMonitorMutationVariables>;

--- a/src/graphql/operations/createAlertMonitor.graphql
+++ b/src/graphql/operations/createAlertMonitor.graphql
@@ -1,0 +1,29 @@
+mutation createAlertMonitor(
+  $name: String!
+  $instance: ID!
+  $triggers: [ID]!
+  $logSeverity: Int
+  $duration: Int
+  $groups: [ID]
+  $users: [ID]
+) {
+  createAlertMonitor(
+    input: {
+      name: $name
+      instance: $instance
+      triggers: $triggers
+      logSeverityLevelCondition: $logSeverity
+      durationSecondsCondition: $duration
+      groups: $groups
+      users: $users
+    }
+  ) {
+    alertMonitor {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/createAlertWebhook.generated.ts
+++ b/src/graphql/operations/createAlertWebhook.generated.ts
@@ -1,0 +1,127 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type CreateAlertWebhookMutationVariables = Exact<{
+  name: string;
+  url: string;
+  headers?: string | null | undefined;
+  payloadTemplate: string;
+}>;
+
+export type CreateAlertWebhookMutation = {
+  createAlertWebhook: {
+    alertWebhook: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const CreateAlertWebhookDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createAlertWebhook" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "name" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "url" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "headers" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "payloadTemplate" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "createAlertWebhook" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "name" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "name" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "url" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "url" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "headers" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "headers" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "payloadTemplate" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "payloadTemplate" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "alertWebhook" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<CreateAlertWebhookMutation, CreateAlertWebhookMutationVariables>;

--- a/src/graphql/operations/createAlertWebhook.graphql
+++ b/src/graphql/operations/createAlertWebhook.graphql
@@ -1,0 +1,18 @@
+mutation createAlertWebhook(
+  $name: String!
+  $url: String!
+  $headers: String
+  $payloadTemplate: String!
+) {
+  createAlertWebhook(
+    input: { name: $name, url: $url, headers: $headers, payloadTemplate: $payloadTemplate }
+  ) {
+    alertWebhook {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/createCustomer.generated.ts
+++ b/src/graphql/operations/createCustomer.generated.ts
@@ -1,0 +1,124 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type CreateCustomerMutationVariables = Exact<{
+  name: string;
+  description?: string | null | undefined;
+  externalId?: string | null | undefined;
+  labels?: Array<string | null | undefined> | string | null | undefined;
+}>;
+
+export type CreateCustomerMutation = {
+  createCustomer: {
+    customer: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const CreateCustomerDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createCustomer" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "name" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "description" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "externalId" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "labels" } },
+          type: {
+            kind: "ListType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "createCustomer" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "name" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "name" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "description" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "description" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "externalId" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "externalId" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "labels" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "labels" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "customer" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<CreateCustomerMutation, CreateCustomerMutationVariables>;

--- a/src/graphql/operations/createCustomer.graphql
+++ b/src/graphql/operations/createCustomer.graphql
@@ -1,0 +1,18 @@
+mutation createCustomer(
+  $name: String!
+  $description: String
+  $externalId: String
+  $labels: [String]
+) {
+  createCustomer(
+    input: { name: $name, description: $description, externalId: $externalId, labels: $labels }
+  ) {
+    customer {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/createCustomerUser.generated.ts
+++ b/src/graphql/operations/createCustomerUser.generated.ts
@@ -1,0 +1,127 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type CreateCustomerUserMutationVariables = Exact<{
+  name?: string | null | undefined;
+  email: string;
+  role: string | number;
+  customer: string | number;
+}>;
+
+export type CreateCustomerUserMutation = {
+  createCustomerUser: {
+    user: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const CreateCustomerUserDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createCustomerUser" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "name" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "email" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "role" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "customer" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "createCustomerUser" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "name" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "name" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "email" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "email" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "role" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "role" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "customer" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "customer" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "user" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<CreateCustomerUserMutation, CreateCustomerUserMutationVariables>;

--- a/src/graphql/operations/createCustomerUser.graphql
+++ b/src/graphql/operations/createCustomerUser.graphql
@@ -1,0 +1,11 @@
+mutation createCustomerUser($name: String, $email: String!, $role: ID!, $customer: ID!) {
+  createCustomerUser(input: { name: $name, email: $email, role: $role, customer: $customer }) {
+    user {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/createInstance.generated.ts
+++ b/src/graphql/operations/createInstance.generated.ts
@@ -1,0 +1,179 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+import type * as Types from "../schema.generated.js";
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type InputInstanceConfigVariable = {
+  customerConfigVariableId?: string | number | null | undefined;
+  /** The key of the Required Config Var of the Integration for which a value is being provided. */
+  key: string;
+  onPremiseResourceId?: string | number | null | undefined;
+  /** The schedule type for the specified Required Config Var of the Integration. */
+  scheduleType?: string | null | undefined;
+  scopedConfigVariableId?: string | number | null | undefined;
+  /** The timezone for the specified Required Config Var of the Integration. */
+  timeZone?: string | null | undefined;
+  /** The value to provide for the specified Required Config Var of the Integration. */
+  value?: string | null | undefined;
+  /** The values for nested inputs of the specified Required Config Var of the Integration. */
+  values?: unknown;
+};
+
+export type CreateInstanceMutationVariables = Exact<{
+  name: string;
+  description?: string | null | undefined;
+  integration: string | number;
+  customer: string | number;
+  configVariables?:
+    | Array<Types.InputInstanceConfigVariable | null | undefined>
+    | Types.InputInstanceConfigVariable
+    | null
+    | undefined;
+  labels?: Array<string | null | undefined> | string | null | undefined;
+}>;
+
+export type CreateInstanceMutation = {
+  createInstance: {
+    instance: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const CreateInstanceDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createInstance" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "name" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "description" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "integration" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "customer" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "configVariables" } },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NamedType",
+              name: { kind: "Name", value: "InputInstanceConfigVariable" },
+            },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "labels" } },
+          type: {
+            kind: "ListType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "createInstance" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "name" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "name" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "description" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "description" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "integration" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "integration" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "customer" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "customer" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "configVariables" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "configVariables" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "labels" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "labels" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "instance" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<CreateInstanceMutation, CreateInstanceMutationVariables>;

--- a/src/graphql/operations/createInstance.graphql
+++ b/src/graphql/operations/createInstance.graphql
@@ -1,0 +1,27 @@
+mutation createInstance(
+  $name: String!
+  $description: String
+  $integration: ID!
+  $customer: ID!
+  $configVariables: [InputInstanceConfigVariable]
+  $labels: [String]
+) {
+  createInstance(
+    input: {
+      name: $name
+      description: $description
+      integration: $integration
+      customer: $customer
+      configVariables: $configVariables
+      labels: $labels
+    }
+  ) {
+    instance {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/createIntegration.generated.ts
+++ b/src/graphql/operations/createIntegration.generated.ts
@@ -1,0 +1,113 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type CreateIntegrationMutationVariables = Exact<{
+  name: string;
+  description: string;
+  customer?: string | number | null | undefined;
+}>;
+
+export type CreateIntegrationMutation = {
+  createIntegration: {
+    integration: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const CreateIntegrationDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createIntegration" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "name" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "description" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "customer" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "createIntegration" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "name" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "name" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "description" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "description" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "customer" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "customer" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "integration" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<CreateIntegrationMutation, CreateIntegrationMutationVariables>;

--- a/src/graphql/operations/createIntegration.graphql
+++ b/src/graphql/operations/createIntegration.graphql
@@ -1,0 +1,11 @@
+mutation createIntegration($name: String!, $description: String!, $customer: ID) {
+  createIntegration(input: { name: $name, description: $description, customer: $customer }) {
+    integration {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/createOnPremiseResourceJWT.generated.ts
+++ b/src/graphql/operations/createOnPremiseResourceJWT.generated.ts
@@ -1,0 +1,110 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type CreateOnPremiseResourceJwtMutationVariables = Exact<{
+  customerId?: string | number | null | undefined;
+  resourceId?: string | number | null | undefined;
+  orgOnly?: boolean | null | undefined;
+}>;
+
+export type CreateOnPremiseResourceJwtMutation = {
+  createOnPremiseResourceJWT: {
+    result: { jwt: string | null } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const CreateOnPremiseResourceJwtDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createOnPremiseResourceJWT" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "customerId" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "resourceId" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "orgOnly" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "createOnPremiseResourceJWT" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "customerId" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "customerId" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "orgOnly" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "orgOnly" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "resourceId" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "resourceId" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "result" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "jwt" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  CreateOnPremiseResourceJwtMutation,
+  CreateOnPremiseResourceJwtMutationVariables
+>;

--- a/src/graphql/operations/createOnPremiseResourceJWT.graphql
+++ b/src/graphql/operations/createOnPremiseResourceJWT.graphql
@@ -1,0 +1,13 @@
+mutation createOnPremiseResourceJWT($customerId: ID, $resourceId: ID, $orgOnly: Boolean) {
+  createOnPremiseResourceJWT(
+    input: { customerId: $customerId, orgOnly: $orgOnly, resourceId: $resourceId }
+  ) {
+    result {
+      jwt
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/createOrganizationUser.generated.ts
+++ b/src/graphql/operations/createOrganizationUser.generated.ts
@@ -1,0 +1,116 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type CreateOrganizationUserMutationVariables = Exact<{
+  name?: string | null | undefined;
+  email: string;
+  role: string | number;
+}>;
+
+export type CreateOrganizationUserMutation = {
+  createOrganizationUser: {
+    user: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const CreateOrganizationUserDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "createOrganizationUser" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "name" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "email" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "role" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "createOrganizationUser" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "name" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "name" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "email" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "email" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "role" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "role" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "user" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  CreateOrganizationUserMutation,
+  CreateOrganizationUserMutationVariables
+>;

--- a/src/graphql/operations/createOrganizationUser.graphql
+++ b/src/graphql/operations/createOrganizationUser.graphql
@@ -1,0 +1,11 @@
+mutation createOrganizationUser($name: String, $email: String!, $role: ID!) {
+  createOrganizationUser(input: { name: $name, email: $email, role: $role }) {
+    user {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/deleteAlertGroup.generated.ts
+++ b/src/graphql/operations/deleteAlertGroup.generated.ts
@@ -1,0 +1,88 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type DeleteAlertGroupMutationVariables = Exact<{
+  id: string | number;
+}>;
+
+export type DeleteAlertGroupMutation = {
+  deleteAlertGroup: {
+    alertGroup: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const DeleteAlertGroupDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteAlertGroup" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "deleteAlertGroup" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "alertGroup" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DeleteAlertGroupMutation, DeleteAlertGroupMutationVariables>;

--- a/src/graphql/operations/deleteAlertGroup.graphql
+++ b/src/graphql/operations/deleteAlertGroup.graphql
@@ -1,0 +1,11 @@
+mutation deleteAlertGroup($id: ID!) {
+  deleteAlertGroup(input: { id: $id }) {
+    alertGroup {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/deleteAlertMonitor.generated.ts
+++ b/src/graphql/operations/deleteAlertMonitor.generated.ts
@@ -1,0 +1,88 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type DeleteAlertMonitorMutationVariables = Exact<{
+  id: string | number;
+}>;
+
+export type DeleteAlertMonitorMutation = {
+  deleteAlertMonitor: {
+    alertMonitor: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const DeleteAlertMonitorDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteAlertMonitor" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "deleteAlertMonitor" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "alertMonitor" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DeleteAlertMonitorMutation, DeleteAlertMonitorMutationVariables>;

--- a/src/graphql/operations/deleteAlertMonitor.graphql
+++ b/src/graphql/operations/deleteAlertMonitor.graphql
@@ -1,0 +1,11 @@
+mutation deleteAlertMonitor($id: ID!) {
+  deleteAlertMonitor(input: { id: $id }) {
+    alertMonitor {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/deleteAlertWebhook.generated.ts
+++ b/src/graphql/operations/deleteAlertWebhook.generated.ts
@@ -1,0 +1,88 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type DeleteAlertWebhookMutationVariables = Exact<{
+  id: string | number;
+}>;
+
+export type DeleteAlertWebhookMutation = {
+  deleteAlertWebhook: {
+    alertWebhook: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const DeleteAlertWebhookDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteAlertWebhook" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "deleteAlertWebhook" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "alertWebhook" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DeleteAlertWebhookMutation, DeleteAlertWebhookMutationVariables>;

--- a/src/graphql/operations/deleteAlertWebhook.graphql
+++ b/src/graphql/operations/deleteAlertWebhook.graphql
@@ -1,0 +1,11 @@
+mutation deleteAlertWebhook($id: ID!) {
+  deleteAlertWebhook(input: { id: $id }) {
+    alertWebhook {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/deleteComponent.generated.ts
+++ b/src/graphql/operations/deleteComponent.generated.ts
@@ -1,0 +1,88 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type DeleteComponentMutationVariables = Exact<{
+  id: string | number;
+}>;
+
+export type DeleteComponentMutation = {
+  deleteComponent: {
+    component: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const DeleteComponentDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteComponent" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "deleteComponent" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "component" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DeleteComponentMutation, DeleteComponentMutationVariables>;

--- a/src/graphql/operations/deleteComponent.graphql
+++ b/src/graphql/operations/deleteComponent.graphql
@@ -1,0 +1,11 @@
+mutation deleteComponent($id: ID!) {
+  deleteComponent(input: { id: $id }) {
+    component {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/deleteComponent2.generated.ts
+++ b/src/graphql/operations/deleteComponent2.generated.ts
@@ -1,0 +1,77 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type DeleteComponent2MutationVariables = Exact<{
+  id: string | number;
+}>;
+
+export type DeleteComponent2Mutation = {
+  deleteComponent: { errors: Array<{ field: string; messages: Array<string> }> } | null;
+};
+
+export const DeleteComponent2Document = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteComponent2" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "deleteComponent" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DeleteComponent2Mutation, DeleteComponent2MutationVariables>;

--- a/src/graphql/operations/deleteComponent2.graphql
+++ b/src/graphql/operations/deleteComponent2.graphql
@@ -1,0 +1,8 @@
+mutation deleteComponent2($id: ID!) {
+  deleteComponent(input: { id: $id }) {
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/deleteCustomer.generated.ts
+++ b/src/graphql/operations/deleteCustomer.generated.ts
@@ -1,0 +1,88 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type DeleteCustomerMutationVariables = Exact<{
+  id: string | number;
+}>;
+
+export type DeleteCustomerMutation = {
+  deleteCustomer: {
+    customer: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const DeleteCustomerDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteCustomer" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "deleteCustomer" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "customer" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DeleteCustomerMutation, DeleteCustomerMutationVariables>;

--- a/src/graphql/operations/deleteCustomer.graphql
+++ b/src/graphql/operations/deleteCustomer.graphql
@@ -1,0 +1,11 @@
+mutation deleteCustomer($id: ID!) {
+  deleteCustomer(input: { id: $id }) {
+    customer {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/deleteInstance.generated.ts
+++ b/src/graphql/operations/deleteInstance.generated.ts
@@ -1,0 +1,88 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type DeleteInstanceMutationVariables = Exact<{
+  id: string | number;
+}>;
+
+export type DeleteInstanceMutation = {
+  deleteInstance: {
+    instance: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const DeleteInstanceDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteInstance" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "deleteInstance" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "instance" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DeleteInstanceMutation, DeleteInstanceMutationVariables>;

--- a/src/graphql/operations/deleteInstance.graphql
+++ b/src/graphql/operations/deleteInstance.graphql
@@ -1,0 +1,11 @@
+mutation deleteInstance($id: ID!) {
+  deleteInstance(input: { id: $id }) {
+    instance {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/deleteIntegration.generated.ts
+++ b/src/graphql/operations/deleteIntegration.generated.ts
@@ -1,0 +1,88 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type DeleteIntegrationMutationVariables = Exact<{
+  id: string | number;
+}>;
+
+export type DeleteIntegrationMutation = {
+  deleteIntegration: {
+    integration: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const DeleteIntegrationDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteIntegration" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "deleteIntegration" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "integration" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DeleteIntegrationMutation, DeleteIntegrationMutationVariables>;

--- a/src/graphql/operations/deleteIntegration.graphql
+++ b/src/graphql/operations/deleteIntegration.graphql
@@ -1,0 +1,11 @@
+mutation deleteIntegration($id: ID!) {
+  deleteIntegration(input: { id: $id }) {
+    integration {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/deleteOnPremiseResource.generated.ts
+++ b/src/graphql/operations/deleteOnPremiseResource.generated.ts
@@ -1,0 +1,91 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type DeleteOnPremiseResourceMutationVariables = Exact<{
+  id: string | number;
+}>;
+
+export type DeleteOnPremiseResourceMutation = {
+  deleteOnPremiseResource: {
+    onPremiseResource: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const DeleteOnPremiseResourceDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteOnPremiseResource" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "deleteOnPremiseResource" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "onPremiseResource" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  DeleteOnPremiseResourceMutation,
+  DeleteOnPremiseResourceMutationVariables
+>;

--- a/src/graphql/operations/deleteOnPremiseResource.graphql
+++ b/src/graphql/operations/deleteOnPremiseResource.graphql
@@ -1,0 +1,11 @@
+mutation deleteOnPremiseResource($id: ID!) {
+  deleteOnPremiseResource(input: { id: $id }) {
+    onPremiseResource {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/deleteUser.generated.ts
+++ b/src/graphql/operations/deleteUser.generated.ts
@@ -1,0 +1,88 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type DeleteUserMutationVariables = Exact<{
+  id: string | number;
+}>;
+
+export type DeleteUserMutation = {
+  deleteUser: {
+    user: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const DeleteUserDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deleteUser" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "deleteUser" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "user" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DeleteUserMutation, DeleteUserMutationVariables>;

--- a/src/graphql/operations/deleteUser.graphql
+++ b/src/graphql/operations/deleteUser.graphql
@@ -1,0 +1,11 @@
+mutation deleteUser($id: ID!) {
+  deleteUser(input: { id: $id }) {
+    user {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/deployInstance.generated.ts
+++ b/src/graphql/operations/deployInstance.generated.ts
@@ -1,0 +1,99 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type DeployInstanceMutationVariables = Exact<{
+  id: string | number;
+  force?: boolean | null | undefined;
+}>;
+
+export type DeployInstanceMutation = {
+  deployInstance: {
+    instance: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const DeployInstanceDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deployInstance" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "force" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "deployInstance" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "force" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "force" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "instance" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DeployInstanceMutation, DeployInstanceMutationVariables>;

--- a/src/graphql/operations/deployInstance.graphql
+++ b/src/graphql/operations/deployInstance.graphql
@@ -1,0 +1,11 @@
+mutation deployInstance($id: ID!, $force: Boolean) {
+  deployInstance(input: { id: $id, force: $force }) {
+    instance {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/deployInstance2.generated.ts
+++ b/src/graphql/operations/deployInstance2.generated.ts
@@ -1,0 +1,88 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type DeployInstance2MutationVariables = Exact<{
+  id: string | number;
+}>;
+
+export type DeployInstance2Mutation = {
+  deployInstance: {
+    instance: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const DeployInstance2Document = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "deployInstance2" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "deployInstance" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "instance" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DeployInstance2Mutation, DeployInstance2MutationVariables>;

--- a/src/graphql/operations/deployInstance2.graphql
+++ b/src/graphql/operations/deployInstance2.graphql
@@ -1,0 +1,11 @@
+mutation deployInstance2($id: ID!) {
+  deployInstance(input: { id: $id }) {
+    instance {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/disableInstance.generated.ts
+++ b/src/graphql/operations/disableInstance.generated.ts
@@ -1,0 +1,93 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type DisableInstanceMutationVariables = Exact<{
+  id: string | number;
+}>;
+
+export type DisableInstanceMutation = {
+  updateInstance: {
+    instance: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const DisableInstanceDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "disableInstance" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "updateInstance" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "enabled" },
+                      value: { kind: "BooleanValue", value: false },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "instance" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<DisableInstanceMutation, DisableInstanceMutationVariables>;

--- a/src/graphql/operations/disableInstance.graphql
+++ b/src/graphql/operations/disableInstance.graphql
@@ -1,0 +1,11 @@
+mutation disableInstance($id: ID!) {
+  updateInstance(input: { id: $id, enabled: false }) {
+    instance {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/enableInstance.generated.ts
+++ b/src/graphql/operations/enableInstance.generated.ts
@@ -1,0 +1,93 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type EnableInstanceMutationVariables = Exact<{
+  id: string | number;
+}>;
+
+export type EnableInstanceMutation = {
+  updateInstance: {
+    instance: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const EnableInstanceDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "enableInstance" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "updateInstance" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "enabled" },
+                      value: { kind: "BooleanValue", value: true },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "instance" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<EnableInstanceMutation, EnableInstanceMutationVariables>;

--- a/src/graphql/operations/enableInstance.graphql
+++ b/src/graphql/operations/enableInstance.graphql
@@ -1,0 +1,11 @@
+mutation enableInstance($id: ID!) {
+  updateInstance(input: { id: $id, enabled: true }) {
+    instance {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/executionResults.generated.ts
+++ b/src/graphql/operations/executionResults.generated.ts
@@ -1,0 +1,87 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ExecutionResultsQueryVariables = Exact<{
+  executionId: string | number;
+}>;
+
+export type ExecutionResultsQuery = {
+  executionResult: {
+    stepResults: { nodes: Array<{ id: string; stepName: string | null; resultsUrl: string }> };
+  } | null;
+};
+
+export const ExecutionResultsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "executionResults" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "executionId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "executionResult" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "executionId" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "stepResults" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "last" },
+                      value: { kind: "IntValue", value: "1" },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "id" } },
+                            { kind: "Field", name: { kind: "Name", value: "stepName" } },
+                            { kind: "Field", name: { kind: "Name", value: "resultsUrl" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ExecutionResultsQuery, ExecutionResultsQueryVariables>;

--- a/src/graphql/operations/executionResults.graphql
+++ b/src/graphql/operations/executionResults.graphql
@@ -1,0 +1,11 @@
+query executionResults($executionId: ID!) {
+  executionResult(id: $executionId) {
+    stepResults(last: 1) {
+      nodes {
+        id
+        stepName
+        resultsUrl
+      }
+    }
+  }
+}

--- a/src/graphql/operations/export.generated.ts
+++ b/src/graphql/operations/export.generated.ts
@@ -1,0 +1,95 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ExportQueryVariables = Exact<{
+  id: string | number;
+  version: number;
+  useLatestComponentVersions: boolean;
+}>;
+
+export type ExportQuery = { integration: { definition: string | null } | null };
+
+export const ExportDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "export" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "version" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: {
+            kind: "Variable",
+            name: { kind: "Name", value: "useLatestComponentVersions" },
+          },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integration" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "definition" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "version" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "version" } },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "useLatestComponentVersions" },
+                      value: {
+                        kind: "Variable",
+                        name: { kind: "Name", value: "useLatestComponentVersions" },
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ExportQuery, ExportQueryVariables>;

--- a/src/graphql/operations/export.graphql
+++ b/src/graphql/operations/export.graphql
@@ -1,0 +1,5 @@
+query export($id: ID!, $version: Int!, $useLatestComponentVersions: Boolean!) {
+  integration(id: $id) {
+    definition(version: $version, useLatestComponentVersions: $useLatestComponentVersions)
+  }
+}

--- a/src/graphql/operations/exportWorkflow.generated.ts
+++ b/src/graphql/operations/exportWorkflow.generated.ts
@@ -1,0 +1,83 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ExportWorkflowQueryVariables = Exact<{
+  workflow: string | number;
+  useLatestComponentVersions?: boolean | null | undefined;
+}>;
+
+export type ExportWorkflowQuery = { workflow: { definition: string | null } | null };
+
+export const ExportWorkflowDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "exportWorkflow" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "workflow" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: {
+            kind: "Variable",
+            name: { kind: "Name", value: "useLatestComponentVersions" },
+          },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "workflow" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "workflow" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "definition" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "definitionType" },
+                      value: { kind: "EnumValue", value: "WORKFLOW" },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "useLatestComponentVersions" },
+                      value: {
+                        kind: "Variable",
+                        name: { kind: "Name", value: "useLatestComponentVersions" },
+                      },
+                    },
+                  ],
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ExportWorkflowQuery, ExportWorkflowQueryVariables>;

--- a/src/graphql/operations/exportWorkflow.graphql
+++ b/src/graphql/operations/exportWorkflow.graphql
@@ -1,0 +1,5 @@
+query exportWorkflow($workflow: ID!, $useLatestComponentVersions: Boolean) {
+  workflow(id: $workflow) {
+    definition(definitionType: WORKFLOW, useLatestComponentVersions: $useLatestComponentVersions)
+  }
+}

--- a/src/graphql/operations/forkIntegration.generated.ts
+++ b/src/graphql/operations/forkIntegration.generated.ts
@@ -1,0 +1,116 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ForkIntegrationMutationVariables = Exact<{
+  parentID: string | number;
+  name: string;
+  description: string;
+}>;
+
+export type ForkIntegrationMutation = {
+  forkIntegration: {
+    integration: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const ForkIntegrationDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "forkIntegration" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "parentID" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "name" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "description" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "forkIntegration" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "parent" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "parentID" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "name" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "name" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "description" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "description" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "integration" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ForkIntegrationMutation, ForkIntegrationMutationVariables>;

--- a/src/graphql/operations/forkIntegration.graphql
+++ b/src/graphql/operations/forkIntegration.graphql
@@ -1,0 +1,11 @@
+mutation forkIntegration($parentID: ID!, $name: String!, $description: String!) {
+  forkIntegration(input: { parent: $parentID, name: $name, description: $description }) {
+    integration {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/generateSigningKey.generated.ts
+++ b/src/graphql/operations/generateSigningKey.generated.ts
@@ -1,0 +1,53 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type GenerateSigningKeyMutationVariables = Exact<{ [key: string]: never }>;
+
+export type GenerateSigningKeyMutation = {
+  createOrganizationSigningKey: { result: { privateKey: string | null } | null } | null;
+};
+
+export const GenerateSigningKeyDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "generateSigningKey" },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "createOrganizationSigningKey" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: { kind: "ObjectValue", fields: [] },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "result" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "privateKey" } }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<GenerateSigningKeyMutation, GenerateSigningKeyMutationVariables>;

--- a/src/graphql/operations/generateSigningKey.graphql
+++ b/src/graphql/operations/generateSigningKey.graphql
@@ -1,0 +1,7 @@
+mutation generateSigningKey {
+  createOrganizationSigningKey(input: {}) {
+    result {
+      privateKey
+    }
+  }
+}

--- a/src/graphql/operations/getPresignedUrl.generated.ts
+++ b/src/graphql/operations/getPresignedUrl.generated.ts
@@ -1,0 +1,91 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+import type * as Types from "../schema.generated.js";
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type MediaType = "ATTACHMENT" | "AVATAR";
+
+export type GetPresignedUrlQueryVariables = Exact<{
+  objectId: string | number;
+  fileName: string;
+  mediaType: Types.MediaType;
+}>;
+
+export type GetPresignedUrlQuery = {
+  uploadMedia: { uploadUrl: string | null; objectUrl: string | null; error: string | null };
+};
+
+export const GetPresignedUrlDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "getPresignedUrl" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "objectId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "fileName" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "mediaType" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "MediaType" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "uploadMedia" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "objectId" },
+                value: { kind: "Variable", name: { kind: "Name", value: "objectId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "fileName" },
+                value: { kind: "Variable", name: { kind: "Name", value: "fileName" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "mediaType" },
+                value: { kind: "Variable", name: { kind: "Name", value: "mediaType" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "uploadUrl" } },
+                { kind: "Field", name: { kind: "Name", value: "objectUrl" } },
+                { kind: "Field", name: { kind: "Name", value: "error" } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<GetPresignedUrlQuery, GetPresignedUrlQueryVariables>;

--- a/src/graphql/operations/getPresignedUrl.graphql
+++ b/src/graphql/operations/getPresignedUrl.graphql
@@ -1,0 +1,7 @@
+query getPresignedUrl($objectId: ID!, $fileName: String!, $mediaType: MediaType!) {
+  uploadMedia(objectId: $objectId, fileName: $fileName, mediaType: $mediaType) {
+    uploadUrl
+    objectUrl
+    error
+  }
+}

--- a/src/graphql/operations/getStepOutputDetails.generated.ts
+++ b/src/graphql/operations/getStepOutputDetails.generated.ts
@@ -1,0 +1,97 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type GetStepOutputDetailsQueryVariables = Exact<{
+  executionId: string | number;
+  stepName: string;
+}>;
+
+export type GetStepOutputDetailsQuery = {
+  executionResult: {
+    id: string;
+    stepResults: { nodes: Array<{ displayStepName: string | null; resultsUrl: string }> };
+  } | null;
+};
+
+export const GetStepOutputDetailsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "getStepOutputDetails" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "executionId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "stepName" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "executionResult" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "executionId" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "id" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "stepResults" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "displayStepName" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "stepName" } },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "displayStepName" } },
+                            { kind: "Field", name: { kind: "Name", value: "resultsUrl" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<GetStepOutputDetailsQuery, GetStepOutputDetailsQueryVariables>;

--- a/src/graphql/operations/getStepOutputDetails.graphql
+++ b/src/graphql/operations/getStepOutputDetails.graphql
@@ -1,0 +1,11 @@
+query getStepOutputDetails($executionId: ID!, $stepName: String!) {
+  executionResult(id: $executionId) {
+    id
+    stepResults(displayStepName: $stepName) {
+      nodes {
+        displayStepName
+        resultsUrl
+      }
+    }
+  }
+}

--- a/src/graphql/operations/getSystemInstanceId.generated.ts
+++ b/src/graphql/operations/getSystemInstanceId.generated.ts
@@ -1,0 +1,63 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type GetSystemInstanceIdQueryVariables = Exact<{
+  integrationId: string | number;
+}>;
+
+export type GetSystemInstanceIdQuery = { integration: { systemInstance: { id: string } } | null };
+
+export const GetSystemInstanceIdDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "getSystemInstanceId" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "integrationId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integration" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "integrationId" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "systemInstance" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<GetSystemInstanceIdQuery, GetSystemInstanceIdQueryVariables>;

--- a/src/graphql/operations/getSystemInstanceId.graphql
+++ b/src/graphql/operations/getSystemInstanceId.graphql
@@ -1,0 +1,7 @@
+query getSystemInstanceId($integrationId: ID!) {
+  integration(id: $integrationId) {
+    systemInstance {
+      id
+    }
+  }
+}

--- a/src/graphql/operations/importIntegration.generated.ts
+++ b/src/graphql/operations/importIntegration.generated.ts
@@ -1,0 +1,220 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ImportIntegrationMutationVariables = Exact<{
+  definition: string;
+  integrationId?: string | number | null | undefined;
+  replace?: boolean | null | undefined;
+}>;
+
+export type ImportIntegrationMutation = {
+  importIntegration: {
+    integration: {
+      id: string;
+      flows: { nodes: Array<{ id: string; name: string }> };
+      testConfigVariables: { nodes: Array<{ id: string; authorizeUrl: string | null }> };
+      systemInstance: {
+        id: string;
+        flowConfigs: {
+          nodes: Array<{
+            id: string;
+            apiKeys: Array<string | null> | null;
+            flow: { id: string; name: string };
+          }>;
+        };
+      };
+    } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const ImportIntegrationDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "importIntegration" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "definition" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "integrationId" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "replace" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "importIntegration" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "definition" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "definition" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "integrationId" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "integrationId" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "replace" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "replace" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "integration" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "flows" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "nodes" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "id" } },
+                                  { kind: "Field", name: { kind: "Name", value: "name" } },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "testConfigVariables" },
+                        arguments: [
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "status" },
+                            value: { kind: "StringValue", value: "pending", block: false },
+                          },
+                        ],
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "nodes" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "id" } },
+                                  { kind: "Field", name: { kind: "Name", value: "authorizeUrl" } },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "systemInstance" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "id" } },
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "flowConfigs" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  {
+                                    kind: "Field",
+                                    name: { kind: "Name", value: "nodes" },
+                                    selectionSet: {
+                                      kind: "SelectionSet",
+                                      selections: [
+                                        { kind: "Field", name: { kind: "Name", value: "id" } },
+                                        {
+                                          kind: "Field",
+                                          name: { kind: "Name", value: "flow" },
+                                          selectionSet: {
+                                            kind: "SelectionSet",
+                                            selections: [
+                                              {
+                                                kind: "Field",
+                                                name: { kind: "Name", value: "id" },
+                                              },
+                                              {
+                                                kind: "Field",
+                                                name: { kind: "Name", value: "name" },
+                                              },
+                                            ],
+                                          },
+                                        },
+                                        { kind: "Field", name: { kind: "Name", value: "apiKeys" } },
+                                      ],
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ImportIntegrationMutation, ImportIntegrationMutationVariables>;

--- a/src/graphql/operations/importIntegration.graphql
+++ b/src/graphql/operations/importIntegration.graphql
@@ -1,0 +1,38 @@
+mutation importIntegration($definition: String!, $integrationId: ID, $replace: Boolean) {
+  importIntegration(
+    input: { definition: $definition, integrationId: $integrationId, replace: $replace }
+  ) {
+    integration {
+      id
+      flows {
+        nodes {
+          id
+          name
+        }
+      }
+      testConfigVariables(status: "pending") {
+        nodes {
+          id
+          authorizeUrl
+        }
+      }
+      systemInstance {
+        id
+        flowConfigs {
+          nodes {
+            id
+            flow {
+              id
+              name
+            }
+            apiKeys
+          }
+        }
+      }
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/importPublicKey.generated.ts
+++ b/src/graphql/operations/importPublicKey.generated.ts
@@ -1,0 +1,88 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ImportPublicKeyMutationVariables = Exact<{
+  publicKey: string;
+}>;
+
+export type ImportPublicKeyMutation = {
+  importOrganizationSigningKey: {
+    organizationSigningKey: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const ImportPublicKeyDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "importPublicKey" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "publicKey" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "importOrganizationSigningKey" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "publicKey" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "publicKey" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "organizationSigningKey" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ImportPublicKeyMutation, ImportPublicKeyMutationVariables>;

--- a/src/graphql/operations/importPublicKey.graphql
+++ b/src/graphql/operations/importPublicKey.graphql
@@ -1,0 +1,11 @@
+mutation importPublicKey($publicKey: String!) {
+  importOrganizationSigningKey(input: { publicKey: $publicKey }) {
+    organizationSigningKey {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/importWorkflow.generated.ts
+++ b/src/graphql/operations/importWorkflow.generated.ts
@@ -1,0 +1,110 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ImportWorkflowMutationVariables = Exact<{
+  workflow?: string | number | null | undefined;
+  customer?: string | number | null | undefined;
+  definition: string;
+}>;
+
+export type ImportWorkflowMutation = {
+  importWorkflow: {
+    workflow: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const ImportWorkflowDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "importWorkflow" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "workflow" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "customer" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "definition" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "importWorkflow" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "workflow" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "definition" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "definition" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "customer" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "customer" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "workflow" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ImportWorkflowMutation, ImportWorkflowMutationVariables>;

--- a/src/graphql/operations/importWorkflow.graphql
+++ b/src/graphql/operations/importWorkflow.graphql
@@ -1,0 +1,11 @@
+mutation importWorkflow($workflow: ID, $customer: ID, $definition: String!) {
+  importWorkflow(input: { id: $workflow, definition: $definition, customer: $customer }) {
+    workflow {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/instance.generated.ts
+++ b/src/graphql/operations/instance.generated.ts
@@ -1,0 +1,165 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type InstanceQueryVariables = Exact<{
+  id: string | number;
+}>;
+
+export type InstanceQuery = {
+  instance: {
+    configVariables: {
+      nodes: Array<{
+        meta: unknown;
+        requiredConfigVariable: {
+          key: string;
+          connectionTemplate: {
+            inputFieldTemplates: {
+              nodes: Array<{ value: string | null; inputField: { key: string } }>;
+            };
+          } | null;
+        };
+        inputs: { nodes: Array<{ name: string; value: string }> } | null;
+      }>;
+    };
+  } | null;
+};
+
+export const InstanceDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "instance" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "instance" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "configVariables" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "requiredConfigVariable" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "key" } },
+                                  {
+                                    kind: "Field",
+                                    name: { kind: "Name", value: "connectionTemplate" },
+                                    selectionSet: {
+                                      kind: "SelectionSet",
+                                      selections: [
+                                        {
+                                          kind: "Field",
+                                          name: { kind: "Name", value: "inputFieldTemplates" },
+                                          selectionSet: {
+                                            kind: "SelectionSet",
+                                            selections: [
+                                              {
+                                                kind: "Field",
+                                                name: { kind: "Name", value: "nodes" },
+                                                selectionSet: {
+                                                  kind: "SelectionSet",
+                                                  selections: [
+                                                    {
+                                                      kind: "Field",
+                                                      name: { kind: "Name", value: "inputField" },
+                                                      selectionSet: {
+                                                        kind: "SelectionSet",
+                                                        selections: [
+                                                          {
+                                                            kind: "Field",
+                                                            name: { kind: "Name", value: "key" },
+                                                          },
+                                                        ],
+                                                      },
+                                                    },
+                                                    {
+                                                      kind: "Field",
+                                                      name: { kind: "Name", value: "value" },
+                                                    },
+                                                  ],
+                                                },
+                                              },
+                                            ],
+                                          },
+                                        },
+                                      ],
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "inputs" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  {
+                                    kind: "Field",
+                                    name: { kind: "Name", value: "nodes" },
+                                    selectionSet: {
+                                      kind: "SelectionSet",
+                                      selections: [
+                                        { kind: "Field", name: { kind: "Name", value: "name" } },
+                                        { kind: "Field", name: { kind: "Name", value: "value" } },
+                                      ],
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                            { kind: "Field", name: { kind: "Name", value: "meta" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<InstanceQuery, InstanceQueryVariables>;

--- a/src/graphql/operations/instance.graphql
+++ b/src/graphql/operations/instance.graphql
@@ -1,0 +1,28 @@
+query instance($id: ID!) {
+  instance(id: $id) {
+    configVariables {
+      nodes {
+        requiredConfigVariable {
+          key
+          connectionTemplate {
+            inputFieldTemplates {
+              nodes {
+                inputField {
+                  key
+                }
+                value
+              }
+            }
+          }
+        }
+        inputs {
+          nodes {
+            name
+            value
+          }
+        }
+        meta
+      }
+    }
+  }
+}

--- a/src/graphql/operations/integration.generated.ts
+++ b/src/graphql/operations/integration.generated.ts
@@ -1,0 +1,165 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type IntegrationQueryVariables = Exact<{
+  id: string | number;
+}>;
+
+export type IntegrationQuery = {
+  integration: {
+    testConfigVariables: {
+      nodes: Array<{
+        meta: unknown;
+        requiredConfigVariable: {
+          key: string;
+          connectionTemplate: {
+            inputFieldTemplates: {
+              nodes: Array<{ value: string | null; inputField: { key: string } }>;
+            };
+          } | null;
+        };
+        inputs: { nodes: Array<{ name: string; value: string }> } | null;
+      }>;
+    };
+  } | null;
+};
+
+export const IntegrationDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "integration" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integration" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "testConfigVariables" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "requiredConfigVariable" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "key" } },
+                                  {
+                                    kind: "Field",
+                                    name: { kind: "Name", value: "connectionTemplate" },
+                                    selectionSet: {
+                                      kind: "SelectionSet",
+                                      selections: [
+                                        {
+                                          kind: "Field",
+                                          name: { kind: "Name", value: "inputFieldTemplates" },
+                                          selectionSet: {
+                                            kind: "SelectionSet",
+                                            selections: [
+                                              {
+                                                kind: "Field",
+                                                name: { kind: "Name", value: "nodes" },
+                                                selectionSet: {
+                                                  kind: "SelectionSet",
+                                                  selections: [
+                                                    {
+                                                      kind: "Field",
+                                                      name: { kind: "Name", value: "inputField" },
+                                                      selectionSet: {
+                                                        kind: "SelectionSet",
+                                                        selections: [
+                                                          {
+                                                            kind: "Field",
+                                                            name: { kind: "Name", value: "key" },
+                                                          },
+                                                        ],
+                                                      },
+                                                    },
+                                                    {
+                                                      kind: "Field",
+                                                      name: { kind: "Name", value: "value" },
+                                                    },
+                                                  ],
+                                                },
+                                              },
+                                            ],
+                                          },
+                                        },
+                                      ],
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "inputs" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  {
+                                    kind: "Field",
+                                    name: { kind: "Name", value: "nodes" },
+                                    selectionSet: {
+                                      kind: "SelectionSet",
+                                      selections: [
+                                        { kind: "Field", name: { kind: "Name", value: "name" } },
+                                        { kind: "Field", name: { kind: "Name", value: "value" } },
+                                      ],
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                            { kind: "Field", name: { kind: "Name", value: "meta" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<IntegrationQuery, IntegrationQueryVariables>;

--- a/src/graphql/operations/integration.graphql
+++ b/src/graphql/operations/integration.graphql
@@ -1,0 +1,28 @@
+query integration($id: ID!) {
+  integration(id: $id) {
+    testConfigVariables {
+      nodes {
+        requiredConfigVariable {
+          key
+          connectionTemplate {
+            inputFieldTemplates {
+              nodes {
+                inputField {
+                  key
+                }
+                value
+              }
+            }
+          }
+        }
+        inputs {
+          nodes {
+            name
+            value
+          }
+        }
+        meta
+      }
+    }
+  }
+}

--- a/src/graphql/operations/integration2.generated.ts
+++ b/src/graphql/operations/integration2.generated.ts
@@ -1,0 +1,54 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type Integration2QueryVariables = Exact<{
+  integrationId: string | number;
+}>;
+
+export type Integration2Query = { integration: { definition: string | null } | null };
+
+export const Integration2Document = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "integration2" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "integrationId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integration" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "integrationId" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "definition" } }],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<Integration2Query, Integration2QueryVariables>;

--- a/src/graphql/operations/integration2.graphql
+++ b/src/graphql/operations/integration2.graphql
@@ -1,0 +1,5 @@
+query integration2($integrationId: ID!) {
+  integration(id: $integrationId) {
+    definition
+  }
+}

--- a/src/graphql/operations/integration3.generated.ts
+++ b/src/graphql/operations/integration3.generated.ts
@@ -1,0 +1,63 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type Integration3QueryVariables = Exact<{
+  name: string;
+}>;
+
+export type Integration3Query = { integrations: { nodes: Array<{ id: string }> } };
+
+export const Integration3Document = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "integration3" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "name" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integrations" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "name" },
+                value: { kind: "Variable", name: { kind: "Name", value: "name" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<Integration3Query, Integration3QueryVariables>;

--- a/src/graphql/operations/integration3.graphql
+++ b/src/graphql/operations/integration3.graphql
@@ -1,0 +1,7 @@
+query integration3($name: String!) {
+  integrations(name: $name) {
+    nodes {
+      id
+    }
+  }
+}

--- a/src/graphql/operations/listAlertEvents.generated.ts
+++ b/src/graphql/operations/listAlertEvents.generated.ts
@@ -1,0 +1,100 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ListAlertEventsQueryVariables = Exact<{
+  alertMonitorId?: string | number | null | undefined;
+}>;
+
+export type ListAlertEventsQuery = {
+  alertEvents: {
+    nodes: Array<{ id: string; createdAt: string; details: string; monitor: { name: string } }>;
+  };
+};
+
+export const ListAlertEventsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "listAlertEvents" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "alertMonitorId" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "alertEvents" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "monitor" },
+                value: { kind: "Variable", name: { kind: "Name", value: "alertMonitorId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "sortBy" },
+                value: {
+                  kind: "ListValue",
+                  values: [
+                    {
+                      kind: "ObjectValue",
+                      fields: [
+                        {
+                          kind: "ObjectField",
+                          name: { kind: "Name", value: "field" },
+                          value: { kind: "EnumValue", value: "CREATED_AT" },
+                        },
+                        {
+                          kind: "ObjectField",
+                          name: { kind: "Name", value: "direction" },
+                          value: { kind: "EnumValue", value: "DESC" },
+                        },
+                      ],
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "monitor" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [{ kind: "Field", name: { kind: "Name", value: "name" } }],
+                        },
+                      },
+                      { kind: "Field", name: { kind: "Name", value: "createdAt" } },
+                      { kind: "Field", name: { kind: "Name", value: "details" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ListAlertEventsQuery, ListAlertEventsQueryVariables>;

--- a/src/graphql/operations/listAlertEvents.graphql
+++ b/src/graphql/operations/listAlertEvents.graphql
@@ -1,0 +1,12 @@
+query listAlertEvents($alertMonitorId: ID) {
+  alertEvents(monitor: $alertMonitorId, sortBy: [{ field: CREATED_AT, direction: DESC }]) {
+    nodes {
+      id
+      monitor {
+        name
+      }
+      createdAt
+      details
+    }
+  }
+}

--- a/src/graphql/operations/listAlertTriggers.generated.ts
+++ b/src/graphql/operations/listAlertTriggers.generated.ts
@@ -1,0 +1,49 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ListAlertTriggersQueryVariables = Exact<{ [key: string]: never }>;
+
+export type ListAlertTriggersQuery = {
+  alertTriggers: { nodes: Array<{ id: string; name: string }> };
+};
+
+export const ListAlertTriggersDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "listAlertTriggers" },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "alertTriggers" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      { kind: "Field", name: { kind: "Name", value: "name" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ListAlertTriggersQuery, ListAlertTriggersQueryVariables>;

--- a/src/graphql/operations/listAlertTriggers.graphql
+++ b/src/graphql/operations/listAlertTriggers.graphql
@@ -1,0 +1,8 @@
+query listAlertTriggers {
+  alertTriggers {
+    nodes {
+      id
+      name
+    }
+  }
+}

--- a/src/graphql/operations/listComponentActions.generated.ts
+++ b/src/graphql/operations/listComponentActions.generated.ts
@@ -1,0 +1,152 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ListComponentActionsQueryVariables = Exact<{
+  componentKey?: string | null | undefined;
+  after?: string | null | undefined;
+  first?: number | null | undefined;
+  public?: boolean | null | undefined;
+}>;
+
+export type ListComponentActionsQuery = {
+  components: {
+    nodes: Array<{
+      id: string;
+      key: string;
+      actions: {
+        nodes: Array<{ id: string; key: string; label: string; description: string }>;
+        pageInfo: { hasNextPage: boolean; endCursor: string | null };
+      };
+    }>;
+  };
+};
+
+export const ListComponentActionsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "listComponentActions" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "componentKey" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "after" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "public" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "components" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "key" },
+                value: { kind: "Variable", name: { kind: "Name", value: "componentKey" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "public" },
+                value: { kind: "Variable", name: { kind: "Name", value: "public" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      { kind: "Field", name: { kind: "Name", value: "key" } },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "actions" },
+                        arguments: [
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "isTrigger" },
+                            value: { kind: "BooleanValue", value: false },
+                          },
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "isDataSource" },
+                            value: { kind: "BooleanValue", value: false },
+                          },
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "after" },
+                            value: { kind: "Variable", name: { kind: "Name", value: "after" } },
+                          },
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "first" },
+                            value: { kind: "Variable", name: { kind: "Name", value: "first" } },
+                          },
+                        ],
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "nodes" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "id" } },
+                                  { kind: "Field", name: { kind: "Name", value: "key" } },
+                                  { kind: "Field", name: { kind: "Name", value: "label" } },
+                                  { kind: "Field", name: { kind: "Name", value: "description" } },
+                                ],
+                              },
+                            },
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "pageInfo" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "hasNextPage" } },
+                                  { kind: "Field", name: { kind: "Name", value: "endCursor" } },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ListComponentActionsQuery, ListComponentActionsQueryVariables>;

--- a/src/graphql/operations/listComponentActions.graphql
+++ b/src/graphql/operations/listComponentActions.graphql
@@ -1,0 +1,20 @@
+query listComponentActions($componentKey: String, $after: String, $first: Int, $public: Boolean) {
+  components(key: $componentKey, public: $public) {
+    nodes {
+      id
+      key
+      actions(isTrigger: false, isDataSource: false, after: $after, first: $first) {
+        nodes {
+          id
+          key
+          label
+          description
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}

--- a/src/graphql/operations/listComponentActions2.generated.ts
+++ b/src/graphql/operations/listComponentActions2.generated.ts
@@ -1,0 +1,202 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+import type * as Types from "../schema.generated.js";
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ActionDataSourceType =
+  /** Boolean */
+  | "BOOLEAN"
+  /** Code */
+  | "CODE"
+  /** Connection */
+  | "CONNECTION"
+  /** Credential */
+  | "CREDENTIAL"
+  /** Date */
+  | "DATE"
+  /** Jsonform */
+  | "JSONFORM"
+  /** Number */
+  | "NUMBER"
+  /** Objectfieldmap */
+  | "OBJECTFIELDMAP"
+  /** Objectselection */
+  | "OBJECTSELECTION"
+  /** Picklist */
+  | "PICKLIST"
+  /** Schedule */
+  | "SCHEDULE"
+  /** String */
+  | "STRING"
+  /** Timestamp */
+  | "TIMESTAMP";
+
+export type ListComponentActions2QueryVariables = Exact<{
+  componentKey?: string | null | undefined;
+  after?: string | null | undefined;
+  first?: number | null | undefined;
+  public?: boolean | null | undefined;
+}>;
+
+export type ListComponentActions2Query = {
+  components: {
+    nodes: Array<{
+      id: string;
+      key: string;
+      actions: {
+        nodes: Array<{
+          id: string;
+          key: string;
+          label: string;
+          description: string;
+          dataSourceType: Types.ActionDataSourceType | null;
+          detailDataSource: { label: string } | null;
+        }>;
+        pageInfo: { hasNextPage: boolean; endCursor: string | null };
+      };
+    }>;
+  };
+};
+
+export const ListComponentActions2Document = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "listComponentActions2" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "componentKey" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "after" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "public" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "components" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "key" },
+                value: { kind: "Variable", name: { kind: "Name", value: "componentKey" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "public" },
+                value: { kind: "Variable", name: { kind: "Name", value: "public" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      { kind: "Field", name: { kind: "Name", value: "key" } },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "actions" },
+                        arguments: [
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "isTrigger" },
+                            value: { kind: "BooleanValue", value: false },
+                          },
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "isDataSource" },
+                            value: { kind: "BooleanValue", value: true },
+                          },
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "after" },
+                            value: { kind: "Variable", name: { kind: "Name", value: "after" } },
+                          },
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "first" },
+                            value: { kind: "Variable", name: { kind: "Name", value: "first" } },
+                          },
+                        ],
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "nodes" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "id" } },
+                                  { kind: "Field", name: { kind: "Name", value: "key" } },
+                                  { kind: "Field", name: { kind: "Name", value: "label" } },
+                                  { kind: "Field", name: { kind: "Name", value: "description" } },
+                                  {
+                                    kind: "Field",
+                                    name: { kind: "Name", value: "dataSourceType" },
+                                  },
+                                  {
+                                    kind: "Field",
+                                    name: { kind: "Name", value: "detailDataSource" },
+                                    selectionSet: {
+                                      kind: "SelectionSet",
+                                      selections: [
+                                        { kind: "Field", name: { kind: "Name", value: "label" } },
+                                      ],
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "pageInfo" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "hasNextPage" } },
+                                  { kind: "Field", name: { kind: "Name", value: "endCursor" } },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ListComponentActions2Query, ListComponentActions2QueryVariables>;

--- a/src/graphql/operations/listComponentActions2.graphql
+++ b/src/graphql/operations/listComponentActions2.graphql
@@ -1,0 +1,24 @@
+query listComponentActions2($componentKey: String, $after: String, $first: Int, $public: Boolean) {
+  components(key: $componentKey, public: $public) {
+    nodes {
+      id
+      key
+      actions(isTrigger: false, isDataSource: true, after: $after, first: $first) {
+        nodes {
+          id
+          key
+          label
+          description
+          dataSourceType
+          detailDataSource {
+            label
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}

--- a/src/graphql/operations/listComponentTriggers.generated.ts
+++ b/src/graphql/operations/listComponentTriggers.generated.ts
@@ -1,0 +1,147 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ListComponentTriggersQueryVariables = Exact<{
+  componentKey?: string | null | undefined;
+  after?: string | null | undefined;
+  first?: number | null | undefined;
+  public?: boolean | null | undefined;
+}>;
+
+export type ListComponentTriggersQuery = {
+  components: {
+    nodes: Array<{
+      id: string;
+      key: string;
+      actions: {
+        nodes: Array<{ id: string; key: string; label: string; description: string }>;
+        pageInfo: { hasNextPage: boolean; endCursor: string | null };
+      };
+    }>;
+  };
+};
+
+export const ListComponentTriggersDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "listComponentTriggers" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "componentKey" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "after" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "public" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "components" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "key" },
+                value: { kind: "Variable", name: { kind: "Name", value: "componentKey" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "public" },
+                value: { kind: "Variable", name: { kind: "Name", value: "public" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      { kind: "Field", name: { kind: "Name", value: "key" } },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "actions" },
+                        arguments: [
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "isTrigger" },
+                            value: { kind: "BooleanValue", value: true },
+                          },
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "after" },
+                            value: { kind: "Variable", name: { kind: "Name", value: "after" } },
+                          },
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "first" },
+                            value: { kind: "Variable", name: { kind: "Name", value: "first" } },
+                          },
+                        ],
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "nodes" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "id" } },
+                                  { kind: "Field", name: { kind: "Name", value: "key" } },
+                                  { kind: "Field", name: { kind: "Name", value: "label" } },
+                                  { kind: "Field", name: { kind: "Name", value: "description" } },
+                                ],
+                              },
+                            },
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "pageInfo" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "hasNextPage" } },
+                                  { kind: "Field", name: { kind: "Name", value: "endCursor" } },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ListComponentTriggersQuery, ListComponentTriggersQueryVariables>;

--- a/src/graphql/operations/listComponentTriggers.graphql
+++ b/src/graphql/operations/listComponentTriggers.graphql
@@ -1,0 +1,20 @@
+query listComponentTriggers($componentKey: String, $after: String, $first: Int, $public: Boolean) {
+  components(key: $componentKey, public: $public) {
+    nodes {
+      id
+      key
+      actions(isTrigger: true, after: $after, first: $first) {
+        nodes {
+          id
+          key
+          label
+          description
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}

--- a/src/graphql/operations/listComponents.generated.ts
+++ b/src/graphql/operations/listComponents.generated.ts
@@ -1,0 +1,140 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ListComponentsQueryVariables = Exact<{
+  showAllVersions?: boolean | null | undefined;
+  after?: string | null | undefined;
+  first?: number | null | undefined;
+  filterQuery?: unknown;
+}>;
+
+export type ListComponentsQuery = {
+  components: {
+    nodes: Array<{
+      id: string;
+      key: string;
+      public: boolean;
+      label: string;
+      description: string;
+      versionNumber: number;
+      category: string | null;
+      versionCreatedAt: string | null;
+      customer: { id: string; externalId: string | null; name: string } | null;
+    }>;
+    pageInfo: { hasNextPage: boolean; endCursor: string | null };
+  };
+};
+
+export const ListComponentsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "listComponents" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "showAllVersions" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "after" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "filterQuery" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "JSONString" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "components" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "allVersions" },
+                value: { kind: "Variable", name: { kind: "Name", value: "showAllVersions" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "after" },
+                value: { kind: "Variable", name: { kind: "Name", value: "after" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "first" },
+                value: { kind: "Variable", name: { kind: "Name", value: "first" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "filterQuery" },
+                value: { kind: "Variable", name: { kind: "Name", value: "filterQuery" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      { kind: "Field", name: { kind: "Name", value: "key" } },
+                      { kind: "Field", name: { kind: "Name", value: "public" } },
+                      { kind: "Field", name: { kind: "Name", value: "label" } },
+                      { kind: "Field", name: { kind: "Name", value: "description" } },
+                      { kind: "Field", name: { kind: "Name", value: "versionNumber" } },
+                      { kind: "Field", name: { kind: "Name", value: "category" } },
+                      { kind: "Field", name: { kind: "Name", value: "versionCreatedAt" } },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "customer" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "id" } },
+                            { kind: "Field", name: { kind: "Name", value: "externalId" } },
+                            { kind: "Field", name: { kind: "Name", value: "name" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "pageInfo" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "hasNextPage" } },
+                      { kind: "Field", name: { kind: "Name", value: "endCursor" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ListComponentsQuery, ListComponentsQueryVariables>;

--- a/src/graphql/operations/listComponents.graphql
+++ b/src/graphql/operations/listComponents.graphql
@@ -1,0 +1,33 @@
+query listComponents(
+  $showAllVersions: Boolean
+  $after: String
+  $first: Int
+  $filterQuery: JSONString
+) {
+  components(
+    allVersions: $showAllVersions
+    after: $after
+    first: $first
+    filterQuery: $filterQuery
+  ) {
+    nodes {
+      id
+      key
+      public
+      label
+      description
+      versionNumber
+      category
+      versionCreatedAt
+      customer {
+        id
+        externalId
+        name
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}

--- a/src/graphql/operations/listCustomerRoles.generated.ts
+++ b/src/graphql/operations/listCustomerRoles.generated.ts
@@ -1,0 +1,41 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ListCustomerRolesQueryVariables = Exact<{ [key: string]: never }>;
+
+export type ListCustomerRolesQuery = {
+  customerRoles: Array<{ id: string; name: string; description: string } | null>;
+};
+
+export const ListCustomerRolesDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "listCustomerRoles" },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "customerRoles" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "id" } },
+                { kind: "Field", name: { kind: "Name", value: "name" } },
+                { kind: "Field", name: { kind: "Name", value: "description" } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ListCustomerRolesQuery, ListCustomerRolesQueryVariables>;

--- a/src/graphql/operations/listCustomerRoles.graphql
+++ b/src/graphql/operations/listCustomerRoles.graphql
@@ -1,0 +1,7 @@
+query listCustomerRoles {
+  customerRoles {
+    id
+    name
+    description
+  }
+}

--- a/src/graphql/operations/listInstanceTestLogs.generated.ts
+++ b/src/graphql/operations/listInstanceTestLogs.generated.ts
@@ -1,0 +1,118 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+import type * as Types from "../schema.generated.js";
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+/** Indicates the severity level of a log message. */
+export type LogSeverityLevel = "DEBUG" | "ERROR" | "FATAL" | "INFO" | "METRIC" | "TRACE" | "WARN";
+
+export type ListInstanceTestLogsQueryVariables = Exact<{
+  executionId: string | number;
+  nextCursor?: string | null | undefined;
+}>;
+
+export type ListInstanceTestLogsQuery = {
+  logs: {
+    edges: Array<{
+      cursor: string;
+      node: { timestamp: string; severity: Types.LogSeverityLevel; message: string };
+    }>;
+  };
+};
+
+export const ListInstanceTestLogsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "listInstanceTestLogs" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "executionId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "nextCursor" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "logs" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "executionResult" },
+                value: { kind: "Variable", name: { kind: "Name", value: "executionId" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "after" },
+                value: { kind: "Variable", name: { kind: "Name", value: "nextCursor" } },
+              },
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "orderBy" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "field" },
+                      value: { kind: "EnumValue", value: "TIMESTAMP" },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "direction" },
+                      value: { kind: "EnumValue", value: "ASC" },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "edges" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "node" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "timestamp" } },
+                            { kind: "Field", name: { kind: "Name", value: "severity" } },
+                            { kind: "Field", name: { kind: "Name", value: "message" } },
+                          ],
+                        },
+                      },
+                      { kind: "Field", name: { kind: "Name", value: "cursor" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ListInstanceTestLogsQuery, ListInstanceTestLogsQueryVariables>;

--- a/src/graphql/operations/listInstanceTestLogs.graphql
+++ b/src/graphql/operations/listInstanceTestLogs.graphql
@@ -1,0 +1,16 @@
+query listInstanceTestLogs($executionId: ID!, $nextCursor: String) {
+  logs(
+    executionResult: $executionId
+    after: $nextCursor
+    orderBy: { field: TIMESTAMP, direction: ASC }
+  ) {
+    edges {
+      node {
+        timestamp
+        severity
+        message
+      }
+      cursor
+    }
+  }
+}

--- a/src/graphql/operations/listIntegrationVersions.generated.ts
+++ b/src/graphql/operations/listIntegrationVersions.generated.ts
@@ -1,0 +1,149 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ListIntegrationVersionsQueryVariables = Exact<{
+  integrationId: string | number;
+  onlyAvailable?: boolean | null | undefined;
+  onlyShowOne?: number | null | undefined;
+}>;
+
+export type ListIntegrationVersionsQuery = {
+  integration: {
+    versionSequence: {
+      nodes: Array<{
+        id: string;
+        versionNumber: number;
+        versionCreatedAt: string | null;
+        versionComment: string | null;
+        versionIsAvailable: boolean;
+        versionCreatedBy: { email: string } | null;
+      }>;
+    };
+  } | null;
+};
+
+export const ListIntegrationVersionsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "listIntegrationVersions" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "integrationId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "onlyAvailable" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "onlyShowOne" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integration" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "integrationId" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "versionSequence" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "versionIsAvailable" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "onlyAvailable" } },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "sortBy" },
+                      value: {
+                        kind: "ListValue",
+                        values: [
+                          {
+                            kind: "ObjectValue",
+                            fields: [
+                              {
+                                kind: "ObjectField",
+                                name: { kind: "Name", value: "field" },
+                                value: { kind: "EnumValue", value: "VERSION_NUMBER" },
+                              },
+                              {
+                                kind: "ObjectField",
+                                name: { kind: "Name", value: "direction" },
+                                value: { kind: "EnumValue", value: "DESC" },
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "first" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "onlyShowOne" } },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "id" } },
+                            { kind: "Field", name: { kind: "Name", value: "versionNumber" } },
+                            { kind: "Field", name: { kind: "Name", value: "versionCreatedAt" } },
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "versionCreatedBy" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "email" } },
+                                ],
+                              },
+                            },
+                            { kind: "Field", name: { kind: "Name", value: "versionComment" } },
+                            { kind: "Field", name: { kind: "Name", value: "versionIsAvailable" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ListIntegrationVersionsQuery, ListIntegrationVersionsQueryVariables>;

--- a/src/graphql/operations/listIntegrationVersions.graphql
+++ b/src/graphql/operations/listIntegrationVersions.graphql
@@ -1,0 +1,20 @@
+query listIntegrationVersions($integrationId: ID!, $onlyAvailable: Boolean, $onlyShowOne: Int) {
+  integration(id: $integrationId) {
+    versionSequence(
+      versionIsAvailable: $onlyAvailable
+      sortBy: [{ field: VERSION_NUMBER, direction: DESC }]
+      first: $onlyShowOne
+    ) {
+      nodes {
+        id
+        versionNumber
+        versionCreatedAt
+        versionCreatedBy {
+          email
+        }
+        versionComment
+        versionIsAvailable
+      }
+    }
+  }
+}

--- a/src/graphql/operations/listLogSeverityLevels.generated.ts
+++ b/src/graphql/operations/listLogSeverityLevels.generated.ts
@@ -1,0 +1,40 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ListLogSeverityLevelsQueryVariables = Exact<{ [key: string]: never }>;
+
+export type ListLogSeverityLevelsQuery = {
+  logSeverityLevels: Array<{ id: number | null; name: string | null } | null>;
+};
+
+export const ListLogSeverityLevelsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "listLogSeverityLevels" },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "logSeverityLevels" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "id" } },
+                { kind: "Field", name: { kind: "Name", value: "name" } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ListLogSeverityLevelsQuery, ListLogSeverityLevelsQueryVariables>;

--- a/src/graphql/operations/listLogSeverityLevels.graphql
+++ b/src/graphql/operations/listLogSeverityLevels.graphql
@@ -1,0 +1,6 @@
+query listLogSeverityLevels {
+  logSeverityLevels {
+    id
+    name
+  }
+}

--- a/src/graphql/operations/listOrganizationRoles.generated.ts
+++ b/src/graphql/operations/listOrganizationRoles.generated.ts
@@ -1,0 +1,41 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ListOrganizationRolesQueryVariables = Exact<{ [key: string]: never }>;
+
+export type ListOrganizationRolesQuery = {
+  organizationRoles: Array<{ id: string; name: string; description: string } | null>;
+};
+
+export const ListOrganizationRolesDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "listOrganizationRoles" },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "organizationRoles" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "id" } },
+                { kind: "Field", name: { kind: "Name", value: "name" } },
+                { kind: "Field", name: { kind: "Name", value: "description" } },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ListOrganizationRolesQuery, ListOrganizationRolesQueryVariables>;

--- a/src/graphql/operations/listOrganizationRoles.graphql
+++ b/src/graphql/operations/listOrganizationRoles.graphql
@@ -1,0 +1,7 @@
+query listOrganizationRoles {
+  organizationRoles {
+    id
+    name
+    description
+  }
+}

--- a/src/graphql/operations/listOrganizationSigningKeys.generated.ts
+++ b/src/graphql/operations/listOrganizationSigningKeys.generated.ts
@@ -1,0 +1,74 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ListOrganizationSigningKeysQueryVariables = Exact<{ [key: string]: never }>;
+
+export type ListOrganizationSigningKeysQuery = {
+  organization: {
+    signingKeys: {
+      nodes: Array<{
+        id: string;
+        publicKey: string;
+        privateKeyPreview: string;
+        issuedAt: string;
+        imported: boolean;
+      }>;
+    };
+  } | null;
+};
+
+export const ListOrganizationSigningKeysDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "listOrganizationSigningKeys" },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "organization" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "signingKeys" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "id" } },
+                            { kind: "Field", name: { kind: "Name", value: "publicKey" } },
+                            { kind: "Field", name: { kind: "Name", value: "privateKeyPreview" } },
+                            { kind: "Field", name: { kind: "Name", value: "issuedAt" } },
+                            { kind: "Field", name: { kind: "Name", value: "imported" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  ListOrganizationSigningKeysQuery,
+  ListOrganizationSigningKeysQueryVariables
+>;

--- a/src/graphql/operations/listOrganizationSigningKeys.graphql
+++ b/src/graphql/operations/listOrganizationSigningKeys.graphql
@@ -1,0 +1,13 @@
+query listOrganizationSigningKeys {
+  organization {
+    signingKeys {
+      nodes {
+        id
+        publicKey
+        privateKeyPreview
+        issuedAt
+        imported
+      }
+    }
+  }
+}

--- a/src/graphql/operations/logs.generated.ts
+++ b/src/graphql/operations/logs.generated.ts
@@ -1,0 +1,107 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+import type * as Types from "../schema.generated.js";
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+/** Indicates the severity level of a log message. */
+export type LogSeverityLevel = "DEBUG" | "ERROR" | "FATAL" | "INFO" | "METRIC" | "TRACE" | "WARN";
+
+export type LogsQueryVariables = Exact<{
+  executionId: string | number;
+}>;
+
+export type LogsQuery = {
+  executionResult: {
+    logs: {
+      nodes: Array<{ timestamp: string; severity: Types.LogSeverityLevel; message: string }>;
+    };
+  } | null;
+};
+
+export const LogsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "logs" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "executionId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "executionResult" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "executionId" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "logs" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "orderBy" },
+                      value: {
+                        kind: "ObjectValue",
+                        fields: [
+                          {
+                            kind: "ObjectField",
+                            name: { kind: "Name", value: "field" },
+                            value: { kind: "EnumValue", value: "TIMESTAMP" },
+                          },
+                          {
+                            kind: "ObjectField",
+                            name: { kind: "Name", value: "direction" },
+                            value: { kind: "EnumValue", value: "ASC" },
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "timestamp" } },
+                            { kind: "Field", name: { kind: "Name", value: "severity" } },
+                            { kind: "Field", name: { kind: "Name", value: "message" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<LogsQuery, LogsQueryVariables>;

--- a/src/graphql/operations/logs.graphql
+++ b/src/graphql/operations/logs.graphql
@@ -1,0 +1,11 @@
+query logs($executionId: ID!) {
+  executionResult(id: $executionId) {
+    logs(orderBy: { field: TIMESTAMP, direction: ASC }) {
+      nodes {
+        timestamp
+        severity
+        message
+      }
+    }
+  }
+}

--- a/src/graphql/operations/markAvailability.generated.ts
+++ b/src/graphql/operations/markAvailability.generated.ts
@@ -1,0 +1,102 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type MarkAvailabilityMutationVariables = Exact<{
+  id: string | number;
+  available: boolean;
+}>;
+
+export type MarkAvailabilityMutation = {
+  updateIntegrationVersionAvailability: {
+    integration: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const MarkAvailabilityDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "markAvailability" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "available" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "updateIntegrationVersionAvailability" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "available" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "available" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "integration" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<MarkAvailabilityMutation, MarkAvailabilityMutationVariables>;

--- a/src/graphql/operations/markAvailability.graphql
+++ b/src/graphql/operations/markAvailability.graphql
@@ -1,0 +1,11 @@
+mutation markAvailability($id: ID!, $available: Boolean!) {
+  updateIntegrationVersionAvailability(input: { id: $id, available: $available }) {
+    integration {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/pollExecution.generated.ts
+++ b/src/graphql/operations/pollExecution.generated.ts
@@ -1,0 +1,54 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type PollExecutionQueryVariables = Exact<{
+  executionId: string | number;
+}>;
+
+export type PollExecutionQuery = { executionResult: { endedAt: string | null } | null };
+
+export const PollExecutionDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "pollExecution" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "executionId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "executionResult" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "executionId" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [{ kind: "Field", name: { kind: "Name", value: "endedAt" } }],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<PollExecutionQuery, PollExecutionQueryVariables>;

--- a/src/graphql/operations/pollExecution.graphql
+++ b/src/graphql/operations/pollExecution.graphql
@@ -1,0 +1,5 @@
+query pollExecution($executionId: ID!) {
+  executionResult(id: $executionId) {
+    endedAt
+  }
+}

--- a/src/graphql/operations/publishComponent.generated.ts
+++ b/src/graphql/operations/publishComponent.generated.ts
@@ -1,0 +1,546 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+import type * as Types from "../schema.generated.js";
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+/** Represents a collection of data that defines a Component Action. */
+export type ActionDefinitionInput = {
+  /** Specifies whether the Action will allow Conditional Branching. */
+  allowsBranching?: boolean | null | undefined;
+  /** Specifies how the Action handles Authorization. */
+  authorization?: AuthorizationDefinition | null | undefined;
+  /** Specifies whether an Action will break out of a loop. */
+  breakLoop?: boolean | null | undefined;
+  /** Specifies whether the Action can call other Component Actions, Data Sources, or Triggers. */
+  canCallComponentFunctions?: boolean | null | undefined;
+  /** Specifies how the Component Action is displayed. */
+  display: ActionDisplayDefinition;
+  /** The input associated with dynamic branching. */
+  dynamicBranchInput?: string | null | undefined;
+  /** An example of the returned payload of an Action. */
+  examplePayload?: unknown;
+  /** Whether the Action's examplePerform is safe to invoke inline. */
+  examplePerformSafety?: ActionPerformSafety | null | undefined;
+  /** The InputFields supported by the Component Action. */
+  inputs: Array<InputFieldDefinition | null | undefined>;
+  /** A string which uniquely identifies the Action in the context of the Component. */
+  key: string;
+  /** Describes the shape of the Action's output. For branching Actions, declares a distinct schema per branch. */
+  outputSchema?: ActionOutputSchemaInput | null | undefined;
+  /** Whether the Action's perform is safe to invoke inline. */
+  performSafety?: ActionPerformSafety | null | undefined;
+  /** The static branch names associated with an Action. */
+  staticBranchNames?: Array<string | null | undefined> | null | undefined;
+  /** Specifies whether the Action will terminate Instance execution. */
+  terminateExecution?: boolean | null | undefined;
+};
+
+/** Represents a collection of data that defines how a Component Action is displayed. */
+export type ActionDisplayDefinition = {
+  /** The category of the Component. */
+  category?: string | null | undefined;
+  /** Additional notes about the Component. */
+  description: string;
+  /** Notes which may provide insight on the intended use of the Action. */
+  directions?: string | null | undefined;
+  /** Specifies whether the Action is important and/or commonly used. */
+  important?: boolean | null | undefined;
+  /** The name of the Component. */
+  label: string;
+};
+
+/**
+ * Tagged-union input describing the shape of an Action's output.
+ *
+ * GraphQL has no native input unions, so the discriminant `type` selects
+ * which payload field applies:
+ *   * 'actionOutput'    -> `schema` (a single JSON Schema)
+ *   * 'branchingOutput' -> `branchSchemas` (a JSON Schema per branch, as a
+ *     list of name/schema pairs — GraphQL has no native map type)
+ * The server validates that exactly the field matching `type` is provided.
+ */
+export type ActionOutputSchemaInput = {
+  /** Per-branch JSON Schemas, one entry per branch. Required for 'branchingOutput'. */
+  branchSchemas?: Array<BranchOutputSchemaInput | null | undefined> | null | undefined;
+  /** A JSON Schema describing the Action's output. Required for 'actionOutput'. */
+  schema?: unknown;
+  /** The output-schema variant: 'actionOutput' or 'branchingOutput'. */
+  type: string;
+};
+
+export type ActionPerformSafety = "NOT_ALLOWED" | "SAFE";
+
+/** Represents authorization details for a Component. */
+export type AuthorizationDefinition = {
+  /** The list of authorization methods supported by the Component. */
+  methods: Array<string | null | undefined>;
+  /** Specifies whether authorization is required for the Component. */
+  required: boolean;
+};
+
+/** A single branch's output schema, identified by branch name. */
+export type BranchOutputSchemaInput = {
+  /** The branch name; must match one of the Action's staticBranchNames. */
+  name: string;
+  /** A JSON Schema describing this branch's output. */
+  schema: unknown;
+};
+
+/** Represents a collection of data that defines a Component. */
+export type ComponentDefinitionInput = {
+  /** Specifies how the Component handles Authorization. */
+  authorization?: AuthorizationDefinition | null | undefined;
+  /** Specifies how the Component is displayed. */
+  display: ComponentDisplayDefinition;
+  /** The URL that specifies where the Component documentation exists. */
+  documentationUrl?: string | null | undefined;
+  /** Specifies whether the Component is for a Code Native Integration. */
+  forCodeNativeIntegration?: boolean | null | undefined;
+  /** A string that uniquely identifies the Component. */
+  key: string;
+  /** Specifies whether the Component is publicly available or whether it's private to the Organization. */
+  public?: boolean | null | undefined;
+  /** This field has been deprecated. */
+  version?: string | null | undefined;
+};
+
+/** Represents a collection of data that defines how a Component is displayed. */
+export type ComponentDisplayDefinition = {
+  /** The category of the Component. */
+  category?: string | null | undefined;
+  /** Additional notes about the Component. */
+  description: string;
+  /** The URL that specifies where the Component icon exists. */
+  iconPath?: string | null | undefined;
+  /** The name of the Component. */
+  label: string;
+};
+
+/** Represents a collection of data that defines a Component Connection. */
+export type ConnectionDefinitionInput = {
+  /** Optional path to the avatar icon for this Connection. */
+  avatarIconPath?: string | null | undefined;
+  /** Additional notes about the Connection. */
+  comments?: string | null | undefined;
+  /** Optional path to the connect icon for this Connection. */
+  iconPath?: string | null | undefined;
+  /** Inputs for this Connection. */
+  inputs?: Array<ConnectionInputFieldDefinition | null | undefined> | null | undefined;
+  /** A string which uniquely identifies the Connection in the context of the Component. */
+  key: string;
+  /** The name of the Connection. */
+  label: string;
+  /** Metadata to support bespoke OAuth2 flow behaviors for this Connection. */
+  oauth2Config?: ConnectionOAuth2Configuration | null | undefined;
+  /** Type of OAuth2 PKCE method, if any. */
+  oauth2PkceMethod?: string | null | undefined;
+  /** Type of OAuth2 connection, if any. */
+  oauth2Type?: string | null | undefined;
+};
+
+/** Represents an input field for a Connection. */
+export type ConnectionInputFieldDefinition = {
+  /** Specifies the type of collection to use for storing input values, if applicable. */
+  collection?: string | null | undefined;
+  /** Additional notes about the InputField. */
+  comments?: string | null | undefined;
+  /** If present, the related Data Source capable of supplying a value to this InputField. */
+  dataSource?: string | null | undefined;
+  /** The default value for the InputField. */
+  default?: unknown;
+  /** An example valid input for this InputField. */
+  example?: string | null | undefined;
+  /** Nested InputFields. Permitted when `type` is 'structuredObject' or 'dynamicObject'. A top-level 'structuredObject' may only contain leaf children. A 'dynamicObject's children must each be a 'structuredObject' configuration; each configuration may itself contain a nested 'structuredObject' one level deep. */
+  inputs?: Array<InputFieldDefinition | null | undefined> | null | undefined;
+  /** A string which uniquely identifies the InputField in the context of the Action. */
+  key: string;
+  /** Label used for the Keys of a 'keyvaluelist' collection. */
+  keyLabel?: string | null | undefined;
+  /** The name of the InputField. */
+  label: string;
+  /** Language to use for the Code Field. */
+  language?: string | null | undefined;
+  /** Dictates how possible choices are provided for this InputField. */
+  model?: Array<InputFieldChoice | null | undefined> | null | undefined;
+  /** Whether or not the field is controlled by the attached On-Prem Resource. */
+  onPremiseControlled?: boolean | null | undefined;
+  /** Placeholder text that will appear in the InputField UI. */
+  placeholder?: string | null | undefined;
+  /** Specifies whether the InputField is required by the Action. */
+  required?: boolean | null | undefined;
+  /** Specifies the scope in which this input is accessible. */
+  scope?: InputFieldScope | null | undefined;
+  /** Whether or not the field is shown to Integrators and Deployers. Field must have a default is this is `false`. */
+  shown?: boolean | null | undefined;
+  /** Specifies the type of data the InputField handles. */
+  type: string;
+};
+
+/** Represents metadata to support bespoke OAuth2 flow behaviors for a Component Connection. */
+export type ConnectionOAuth2Configuration = {
+  /** A list of allowed parameter keys to pass between the authorize response and the token request. */
+  allowedTokenParams?: Array<string | null | undefined> | null | undefined;
+  /** An optional override for the grant_type of an OAuth2 flow. */
+  overrideGrantType?: string | null | undefined;
+};
+
+/** Represents a collection of data that defines a Component Data Source. */
+export type DataSourceDefinitionInput = {
+  /** Specifies how the Data Source handles Authorization. */
+  authorization?: AuthorizationDefinition | null | undefined;
+  /** Specifies whether the Data Source can call other Component Actions, Data Sources, or Triggers. */
+  canCallComponentFunctions?: boolean | null | undefined;
+  /** The type of the resulting data from the Data Source. */
+  dataSourceType: string;
+  /** Specifies the key of a Data Source in this Component which can provide additional details about the content for this Data Source, such as example values when selecting particular API object fields. */
+  detailDataSource?: string | null | undefined;
+  /** Specifies how the Data Source is displayed. */
+  display: ActionDisplayDefinition;
+  /** An example of the returned payload of an Data Source. */
+  examplePayload?: unknown;
+  /** The InputFields supported by the Data Source. */
+  inputs: Array<InputFieldDefinition | null | undefined>;
+  /** A string which uniquely identifies the Data Source in the context of the Component. */
+  key: string;
+};
+
+/** Represents a choice for an InputField. */
+export type InputFieldChoice = {
+  /** The label to display for the choice. */
+  label: string;
+  /** The value of the choice. */
+  value: string;
+};
+
+/** Represents an input field for a Component Action. */
+export type InputFieldDefinition = {
+  /** Specifies the type of collection to use for storing input values, if applicable. */
+  collection?: string | null | undefined;
+  /** Additional notes about the InputField. */
+  comments?: string | null | undefined;
+  /** If present, the related Data Source capable of supplying a value to this InputField. */
+  dataSource?: string | null | undefined;
+  /** The default value for the InputField. */
+  default?: unknown;
+  /** An example valid input for this InputField. */
+  example?: string | null | undefined;
+  /** Nested InputFields. Permitted when `type` is 'structuredObject' or 'dynamicObject'. A top-level 'structuredObject' may only contain leaf children. A 'dynamicObject's children must each be a 'structuredObject' configuration; each configuration may itself contain a nested 'structuredObject' one level deep. */
+  inputs?: Array<InputFieldDefinition | null | undefined> | null | undefined;
+  /** A string which uniquely identifies the InputField in the context of the Action. */
+  key: string;
+  /** Label used for the Keys of a 'keyvaluelist' collection. */
+  keyLabel?: string | null | undefined;
+  /** The name of the InputField. */
+  label: string;
+  /** Language to use for the Code Field. */
+  language?: string | null | undefined;
+  /** Dictates how possible choices are provided for this InputField. */
+  model?: Array<InputFieldChoice | null | undefined> | null | undefined;
+  /** Placeholder text that will appear in the InputField UI. */
+  placeholder?: string | null | undefined;
+  /** Specifies whether the InputField is required by the Action. */
+  required?: boolean | null | undefined;
+  /** Specifies the scope in which this input is accessible. */
+  scope?: InputFieldScope | null | undefined;
+  /** Specifies the type of data the InputField handles. */
+  type: string;
+};
+
+export type InputFieldScope = "ON_DEPLOY";
+
+/** Represents a collection of data that defines a Component Trigger. */
+export type TriggerDefinitionInput = {
+  /** Specifies whether the Action will allow Conditional Branching. */
+  allowsBranching?: boolean | null | undefined;
+  /** Specifies how the Action handles Authorization. */
+  authorization?: AuthorizationDefinition | null | undefined;
+  /** Specifies whether an Action will break out of a loop. */
+  breakLoop?: boolean | null | undefined;
+  /** Specifies whether the Action can call other Component Actions, Data Sources, or Triggers. */
+  canCallComponentFunctions?: boolean | null | undefined;
+  /** Specifies how the Component Action is displayed. */
+  display: ActionDisplayDefinition;
+  /** The input associated with dynamic branching. */
+  dynamicBranchInput?: string | null | undefined;
+  /** An example of the returned payload of an Action. */
+  examplePayload?: unknown;
+  /** Whether the Action's examplePerform is safe to invoke inline. */
+  examplePerformSafety?: ActionPerformSafety | null | undefined;
+  /** Whether this Trigger defines a getNextDiscoveryState function for pagination. */
+  hasGetNextDiscoveryState?: boolean | null | undefined;
+  /** Whether this Trigger defines an onDeployResolver.getNextDiscoveryState function for pagination of the on-deploy fire. */
+  hasGetOnDeployNextDiscoveryState?: boolean | null | undefined;
+  /** Whether this Trigger defines an onDeployPerform function. */
+  hasOnDeployPerform?: boolean | null | undefined;
+  hasOnInstanceDelete?: boolean | null | undefined;
+  hasOnInstanceDeploy?: boolean | null | undefined;
+  /** Whether this Trigger defines an onDeployResolver.resolveItems function. */
+  hasResolveOnDeployItems?: boolean | null | undefined;
+  /** Whether this Trigger defines a resolveItems function to extract items from its payload. */
+  hasResolveTriggerItems?: boolean | null | undefined;
+  hasWebhookCreateFunction?: boolean | null | undefined;
+  hasWebhookDeleteFunction?: boolean | null | undefined;
+  /** The InputFields supported by the Component Action. */
+  inputs: Array<InputFieldDefinition | null | undefined>;
+  isCommonTrigger?: boolean | null | undefined;
+  isPollingTrigger?: boolean | null | undefined;
+  /** A string which uniquely identifies the Action in the context of the Component. */
+  key: string;
+  /** Describes the shape of the Action's output. For branching Actions, declares a distinct schema per branch. */
+  outputSchema?: ActionOutputSchemaInput | null | undefined;
+  /** Whether the Action's perform is safe to invoke inline. */
+  performSafety?: ActionPerformSafety | null | undefined;
+  /** Specifies support for triggering an Integration on a recurring schedule. */
+  scheduleSupport?: string | null | undefined;
+  /** The static branch names associated with an Action. */
+  staticBranchNames?: Array<string | null | undefined> | null | undefined;
+  /** Specifies support for synchronous responses to an Integration webhook request. */
+  synchronousResponseSupport?: string | null | undefined;
+  /** Specifies whether the Action will terminate Instance execution. */
+  terminateExecution?: boolean | null | undefined;
+  /** Default number of items per batch. */
+  triggerResolverDefaultBatchSize?: number | null | undefined;
+  /** Default max batches of a single execution running concurrently. */
+  triggerResolverDefaultConcurrentBatchLimit?: number | null | undefined;
+  /** Whether this Trigger supports batching its items. */
+  triggerResolverSupport?: string | null | undefined;
+};
+
+export type PublishComponentMutationVariables = Exact<{
+  definition: Types.ComponentDefinitionInput;
+  actions: Array<Types.ActionDefinitionInput | null | undefined> | Types.ActionDefinitionInput;
+  triggers?:
+    | Array<Types.TriggerDefinitionInput | null | undefined>
+    | Types.TriggerDefinitionInput
+    | null
+    | undefined;
+  dataSources?:
+    | Array<Types.DataSourceDefinitionInput | null | undefined>
+    | Types.DataSourceDefinitionInput
+    | null
+    | undefined;
+  connections?:
+    | Array<Types.ConnectionDefinitionInput | null | undefined>
+    | Types.ConnectionDefinitionInput
+    | null
+    | undefined;
+  comment?: string | null | undefined;
+  customer?: string | number | null | undefined;
+  attributes?: string | null | undefined;
+}>;
+
+export type PublishComponentMutation = {
+  publishComponent: {
+    publishResult: {
+      iconUploadUrl: string | null;
+      packageUploadUrl: string | null;
+      sourceUploadUrl: string | null;
+      component: { id: string; versionNumber: number } | null;
+      connectionIconUploadUrls: Array<{
+        connectionKey: string | null;
+        iconUploadUrl: string | null;
+      } | null> | null;
+      connectionAvatarIconUploadUrls: Array<{
+        connectionKey: string | null;
+        iconUploadUrl: string | null;
+      } | null> | null;
+    } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const PublishComponentDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "publishComponent" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "definition" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ComponentDefinitionInput" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "actions" } },
+          type: {
+            kind: "NonNullType",
+            type: {
+              kind: "ListType",
+              type: { kind: "NamedType", name: { kind: "Name", value: "ActionDefinitionInput" } },
+            },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "triggers" } },
+          type: {
+            kind: "ListType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "TriggerDefinitionInput" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "dataSources" } },
+          type: {
+            kind: "ListType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "DataSourceDefinitionInput" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "connections" } },
+          type: {
+            kind: "ListType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ConnectionDefinitionInput" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "comment" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "customer" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "attributes" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "publishComponent" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "definition" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "definition" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "actions" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "actions" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "triggers" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "triggers" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "dataSources" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "dataSources" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "connections" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "connections" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "comment" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "comment" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "customer" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "customer" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "attributes" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "attributes" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "publishResult" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "component" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "id" } },
+                            { kind: "Field", name: { kind: "Name", value: "versionNumber" } },
+                          ],
+                        },
+                      },
+                      { kind: "Field", name: { kind: "Name", value: "iconUploadUrl" } },
+                      { kind: "Field", name: { kind: "Name", value: "packageUploadUrl" } },
+                      { kind: "Field", name: { kind: "Name", value: "sourceUploadUrl" } },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "connectionIconUploadUrls" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "connectionKey" } },
+                            { kind: "Field", name: { kind: "Name", value: "iconUploadUrl" } },
+                          ],
+                        },
+                      },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "connectionAvatarIconUploadUrls" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "connectionKey" } },
+                            { kind: "Field", name: { kind: "Name", value: "iconUploadUrl" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<PublishComponentMutation, PublishComponentMutationVariables>;

--- a/src/graphql/operations/publishComponent.graphql
+++ b/src/graphql/operations/publishComponent.graphql
@@ -1,0 +1,45 @@
+mutation publishComponent(
+  $definition: ComponentDefinitionInput!
+  $actions: [ActionDefinitionInput]!
+  $triggers: [TriggerDefinitionInput]
+  $dataSources: [DataSourceDefinitionInput]
+  $connections: [ConnectionDefinitionInput]
+  $comment: String
+  $customer: ID
+  $attributes: String
+) {
+  publishComponent(
+    input: {
+      definition: $definition
+      actions: $actions
+      triggers: $triggers
+      dataSources: $dataSources
+      connections: $connections
+      comment: $comment
+      customer: $customer
+      attributes: $attributes
+    }
+  ) {
+    publishResult {
+      component {
+        id
+        versionNumber
+      }
+      iconUploadUrl
+      packageUploadUrl
+      sourceUploadUrl
+      connectionIconUploadUrls {
+        connectionKey
+        iconUploadUrl
+      }
+      connectionAvatarIconUploadUrls {
+        connectionKey
+        iconUploadUrl
+      }
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/publishIntegration.generated.ts
+++ b/src/graphql/operations/publishIntegration.generated.ts
@@ -1,0 +1,110 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type PublishIntegrationMutationVariables = Exact<{
+  id: string | number;
+  comment?: string | null | undefined;
+  attributes?: string | null | undefined;
+}>;
+
+export type PublishIntegrationMutation = {
+  publishIntegration: {
+    integration: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const PublishIntegrationDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "publishIntegration" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "comment" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "attributes" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "publishIntegration" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "comment" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "comment" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "attributes" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "attributes" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "integration" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<PublishIntegrationMutation, PublishIntegrationMutationVariables>;

--- a/src/graphql/operations/publishIntegration.graphql
+++ b/src/graphql/operations/publishIntegration.graphql
@@ -1,0 +1,11 @@
+mutation publishIntegration($id: ID!, $comment: String, $attributes: String) {
+  publishIntegration(input: { id: $id, comment: $comment, attributes: $attributes }) {
+    integration {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/rotateOnPremiseResourceJWT.generated.ts
+++ b/src/graphql/operations/rotateOnPremiseResourceJWT.generated.ts
@@ -1,0 +1,113 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type RotateOnPremiseResourceJwtMutationVariables = Exact<{
+  customerId?: string | number | null | undefined;
+  resourceId: string | number;
+  orgOnly?: boolean | null | undefined;
+}>;
+
+export type RotateOnPremiseResourceJwtMutation = {
+  rotateOnPremiseResourceJWT: {
+    result: { jwt: string | null } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const RotateOnPremiseResourceJwtDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "rotateOnPremiseResourceJWT" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "customerId" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "resourceId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "orgOnly" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "rotateOnPremiseResourceJWT" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "customerId" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "customerId" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "orgOnly" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "orgOnly" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "resourceId" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "resourceId" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "result" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "jwt" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  RotateOnPremiseResourceJwtMutation,
+  RotateOnPremiseResourceJwtMutationVariables
+>;

--- a/src/graphql/operations/rotateOnPremiseResourceJWT.graphql
+++ b/src/graphql/operations/rotateOnPremiseResourceJWT.graphql
@@ -1,0 +1,13 @@
+mutation rotateOnPremiseResourceJWT($customerId: ID, $resourceId: ID!, $orgOnly: Boolean) {
+  rotateOnPremiseResourceJWT(
+    input: { customerId: $customerId, orgOnly: $orgOnly, resourceId: $resourceId }
+  ) {
+    result {
+      jwt
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/setInstanceApiKeys.generated.ts
+++ b/src/graphql/operations/setInstanceApiKeys.generated.ts
@@ -1,0 +1,162 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+import type * as Types from "../schema.generated.js";
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type InputInstanceFlowConfig = {
+  apiKeys?: Array<string | null | undefined> | null | undefined;
+  flowId: string | number;
+  /** Content type of the payload for testing this IntegrationFlow associated with the Instance. */
+  testContentType?: string | null | undefined;
+  /** Headers of the request for testing this IntegrationFlow associated with the Instance. */
+  testHeaders?: unknown;
+  /** Data payload for testing this IntegrationFlow associated with the Instance. */
+  testPayload?: string | null | undefined;
+  /** Specifies whether executions of this InstanceFlowConfig will use Long Running Executions. */
+  usesLre?: boolean | null | undefined;
+};
+
+export type SetInstanceApiKeysMutationVariables = Exact<{
+  instanceId: string | number;
+  flowConfigs?:
+    | Array<Types.InputInstanceFlowConfig | null | undefined>
+    | Types.InputInstanceFlowConfig
+    | null
+    | undefined;
+}>;
+
+export type SetInstanceApiKeysMutation = {
+  updateInstance: {
+    instance: {
+      id: string;
+      flowConfigs: {
+        nodes: Array<{ id: string; apiKeys: Array<string | null> | null; flow: { id: string } }>;
+      };
+    } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const SetInstanceApiKeysDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "setInstanceApiKeys" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "instanceId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "flowConfigs" } },
+          type: {
+            kind: "ListType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "InputInstanceFlowConfig" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "updateInstance" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "instanceId" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "flowConfigs" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "flowConfigs" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "configMode" },
+                      value: { kind: "StringValue", value: "INSTANCE", block: false },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "instance" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "flowConfigs" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "nodes" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "id" } },
+                                  { kind: "Field", name: { kind: "Name", value: "apiKeys" } },
+                                  {
+                                    kind: "Field",
+                                    name: { kind: "Name", value: "flow" },
+                                    selectionSet: {
+                                      kind: "SelectionSet",
+                                      selections: [
+                                        { kind: "Field", name: { kind: "Name", value: "id" } },
+                                      ],
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<SetInstanceApiKeysMutation, SetInstanceApiKeysMutationVariables>;

--- a/src/graphql/operations/setInstanceApiKeys.graphql
+++ b/src/graphql/operations/setInstanceApiKeys.graphql
@@ -1,0 +1,20 @@
+mutation setInstanceApiKeys($instanceId: ID!, $flowConfigs: [InputInstanceFlowConfig]) {
+  updateInstance(input: { id: $instanceId, flowConfigs: $flowConfigs, configMode: "INSTANCE" }) {
+    instance {
+      id
+      flowConfigs {
+        nodes {
+          id
+          apiKeys
+          flow {
+            id
+          }
+        }
+      }
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/state.generated.ts
+++ b/src/graphql/operations/state.generated.ts
@@ -1,0 +1,106 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+import type * as Types from "../schema.generated.js";
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type InstanceConfigVariableStatus =
+  /** active */
+  | "ACTIVE"
+  /** error */
+  | "ERROR"
+  /** failed */
+  | "FAILED"
+  /** pending */
+  | "PENDING";
+
+export type StateQueryVariables = Exact<{
+  integrationId: string | number;
+}>;
+
+export type StateQuery = {
+  integration: {
+    testConfigVariables: {
+      nodes: Array<{ id: string; status: Types.InstanceConfigVariableStatus | null }>;
+    };
+  } | null;
+};
+
+export const StateDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "state" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "integrationId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "integration" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "id" },
+                value: { kind: "Variable", name: { kind: "Name", value: "integrationId" } },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "testConfigVariables" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "status_In" },
+                      value: {
+                        kind: "ListValue",
+                        values: [
+                          { kind: "StringValue", value: "pending", block: false },
+                          { kind: "StringValue", value: "active", block: false },
+                          { kind: "StringValue", value: "error", block: false },
+                        ],
+                      },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "id" } },
+                            { kind: "Field", name: { kind: "Name", value: "status" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<StateQuery, StateQueryVariables>;

--- a/src/graphql/operations/state.graphql
+++ b/src/graphql/operations/state.graphql
@@ -1,0 +1,10 @@
+query state($integrationId: ID!) {
+  integration(id: $integrationId) {
+    testConfigVariables(status_In: ["pending", "active", "error"]) {
+      nodes {
+        id
+        status
+      }
+    }
+  }
+}

--- a/src/graphql/operations/testInstanceFlowConfig.generated.ts
+++ b/src/graphql/operations/testInstanceFlowConfig.generated.ts
@@ -1,0 +1,133 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type TestInstanceFlowConfigMutationVariables = Exact<{
+  id: string | number;
+  payload?: string | null | undefined;
+  contentType?: string | null | undefined;
+}>;
+
+export type TestInstanceFlowConfigMutation = {
+  testInstanceFlowConfig: {
+    testInstanceFlowConfigResult: {
+      flowConfig: { id: string } | null;
+      execution: { id: string } | null;
+    } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const TestInstanceFlowConfigDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "testInstanceFlowConfig" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "payload" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "contentType" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "testInstanceFlowConfig" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "payload" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "payload" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "contentType" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "contentType" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "testInstanceFlowConfigResult" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "flowConfig" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                        },
+                      },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "execution" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                        },
+                      },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  TestInstanceFlowConfigMutation,
+  TestInstanceFlowConfigMutationVariables
+>;

--- a/src/graphql/operations/testInstanceFlowConfig.graphql
+++ b/src/graphql/operations/testInstanceFlowConfig.graphql
@@ -1,0 +1,16 @@
+mutation testInstanceFlowConfig($id: ID!, $payload: String, $contentType: String) {
+  testInstanceFlowConfig(input: { id: $id, payload: $payload, contentType: $contentType }) {
+    testInstanceFlowConfigResult {
+      flowConfig {
+        id
+      }
+      execution {
+        id
+      }
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/updateCustomer.generated.ts
+++ b/src/graphql/operations/updateCustomer.generated.ts
@@ -1,0 +1,135 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type UpdateCustomerMutationVariables = Exact<{
+  id: string | number;
+  name?: string | null | undefined;
+  description?: string | null | undefined;
+  externalId?: string | null | undefined;
+  labels?: Array<string | null | undefined> | string | null | undefined;
+}>;
+
+export type UpdateCustomerMutation = {
+  updateCustomer: {
+    customer: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const UpdateCustomerDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateCustomer" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "name" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "description" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "externalId" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "labels" } },
+          type: {
+            kind: "ListType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "updateCustomer" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "name" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "name" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "description" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "description" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "externalId" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "externalId" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "labels" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "labels" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "customer" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<UpdateCustomerMutation, UpdateCustomerMutationVariables>;

--- a/src/graphql/operations/updateCustomer.graphql
+++ b/src/graphql/operations/updateCustomer.graphql
@@ -1,0 +1,25 @@
+mutation updateCustomer(
+  $id: ID!
+  $name: String
+  $description: String
+  $externalId: String
+  $labels: [String]
+) {
+  updateCustomer(
+    input: {
+      id: $id
+      name: $name
+      description: $description
+      externalId: $externalId
+      labels: $labels
+    }
+  ) {
+    customer {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/updateInstance.generated.ts
+++ b/src/graphql/operations/updateInstance.generated.ts
@@ -1,0 +1,135 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type UpdateInstanceMutationVariables = Exact<{
+  id: string | number;
+  name?: string | null | undefined;
+  description?: string | null | undefined;
+  version?: string | number | null | undefined;
+  labels?: Array<string | null | undefined> | string | null | undefined;
+}>;
+
+export type UpdateInstanceMutation = {
+  updateInstance: {
+    instance: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const UpdateInstanceDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateInstance" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "name" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "description" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "version" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "labels" } },
+          type: {
+            kind: "ListType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "updateInstance" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "name" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "name" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "description" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "description" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "integration" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "version" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "labels" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "labels" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "instance" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<UpdateInstanceMutation, UpdateInstanceMutationVariables>;

--- a/src/graphql/operations/updateInstance.graphql
+++ b/src/graphql/operations/updateInstance.graphql
@@ -1,0 +1,25 @@
+mutation updateInstance(
+  $id: ID!
+  $name: String
+  $description: String
+  $version: ID
+  $labels: [String]
+) {
+  updateInstance(
+    input: {
+      id: $id
+      name: $name
+      description: $description
+      integration: $version
+      labels: $labels
+    }
+  ) {
+    instance {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/updateInstanceGlobalDebug.generated.ts
+++ b/src/graphql/operations/updateInstanceGlobalDebug.generated.ts
@@ -1,0 +1,105 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type UpdateInstanceGlobalDebugMutationVariables = Exact<{
+  instanceId: string | number;
+  globalDebug: boolean;
+}>;
+
+export type UpdateInstanceGlobalDebugMutation = {
+  updateInstance: {
+    instance: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const UpdateInstanceGlobalDebugDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateInstanceGlobalDebug" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "instanceId" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "globalDebug" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "updateInstance" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "instanceId" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "globalDebug" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "globalDebug" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "instance" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  UpdateInstanceGlobalDebugMutation,
+  UpdateInstanceGlobalDebugMutationVariables
+>;

--- a/src/graphql/operations/updateInstanceGlobalDebug.graphql
+++ b/src/graphql/operations/updateInstanceGlobalDebug.graphql
@@ -1,0 +1,11 @@
+mutation updateInstanceGlobalDebug($instanceId: ID!, $globalDebug: Boolean!) {
+  updateInstance(input: { id: $instanceId, globalDebug: $globalDebug }) {
+    instance {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/updateIntegration.generated.ts
+++ b/src/graphql/operations/updateIntegration.generated.ts
@@ -1,0 +1,159 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+import type * as Types from "../schema.generated.js";
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type InputInstanceConfigVariable = {
+  customerConfigVariableId?: string | number | null | undefined;
+  /** The key of the Required Config Var of the Integration for which a value is being provided. */
+  key: string;
+  onPremiseResourceId?: string | number | null | undefined;
+  /** The schedule type for the specified Required Config Var of the Integration. */
+  scheduleType?: string | null | undefined;
+  scopedConfigVariableId?: string | number | null | undefined;
+  /** The timezone for the specified Required Config Var of the Integration. */
+  timeZone?: string | null | undefined;
+  /** The value to provide for the specified Required Config Var of the Integration. */
+  value?: string | null | undefined;
+  /** The values for nested inputs of the specified Required Config Var of the Integration. */
+  values?: unknown;
+};
+
+export type UpdateIntegrationMutationVariables = Exact<{
+  id: string | number;
+  name?: string | null | undefined;
+  description?: string | null | undefined;
+  customer?: string | number | null | undefined;
+  testConfigVars?:
+    | Array<Types.InputInstanceConfigVariable | null | undefined>
+    | Types.InputInstanceConfigVariable
+    | null
+    | undefined;
+}>;
+
+export type UpdateIntegrationMutation = {
+  updateIntegration: {
+    integration: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const UpdateIntegrationDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateIntegration" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "name" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "description" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "customer" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "testConfigVars" } },
+          type: {
+            kind: "ListType",
+            type: {
+              kind: "NamedType",
+              name: { kind: "Name", value: "InputInstanceConfigVariable" },
+            },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "updateIntegration" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "name" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "name" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "description" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "description" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "customer" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "customer" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "testConfigVariables" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "testConfigVars" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "integration" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<UpdateIntegrationMutation, UpdateIntegrationMutationVariables>;

--- a/src/graphql/operations/updateIntegration.graphql
+++ b/src/graphql/operations/updateIntegration.graphql
@@ -1,0 +1,25 @@
+mutation updateIntegration(
+  $id: ID!
+  $name: String
+  $description: String
+  $customer: ID
+  $testConfigVars: [InputInstanceConfigVariable]
+) {
+  updateIntegration(
+    input: {
+      id: $id
+      name: $name
+      description: $description
+      customer: $customer
+      testConfigVariables: $testConfigVars
+    }
+  ) {
+    integration {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/updateMarketplaceConfiguration.generated.ts
+++ b/src/graphql/operations/updateMarketplaceConfiguration.generated.ts
@@ -1,0 +1,133 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type UpdateMarketplaceConfigurationMutationVariables = Exact<{
+  id?: string | number | null | undefined;
+  marketplaceConfiguration: string;
+  overview: string;
+  multipleInstances?: boolean | null | undefined;
+}>;
+
+export type UpdateMarketplaceConfigurationMutation = {
+  updateIntegrationMarketplaceConfiguration: {
+    integration: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const UpdateMarketplaceConfigurationDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateMarketplaceConfiguration" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "id" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "marketplaceConfiguration" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "overview" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "multipleInstances" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "updateIntegrationMarketplaceConfiguration" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "id" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "marketplaceConfiguration" },
+                      value: {
+                        kind: "Variable",
+                        name: { kind: "Name", value: "marketplaceConfiguration" },
+                      },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "overview" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "overview" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "allowMultipleMarketplaceInstances" },
+                      value: {
+                        kind: "Variable",
+                        name: { kind: "Name", value: "multipleInstances" },
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "integration" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  UpdateMarketplaceConfigurationMutation,
+  UpdateMarketplaceConfigurationMutationVariables
+>;

--- a/src/graphql/operations/updateMarketplaceConfiguration.graphql
+++ b/src/graphql/operations/updateMarketplaceConfiguration.graphql
@@ -1,0 +1,23 @@
+mutation updateMarketplaceConfiguration(
+  $id: ID
+  $marketplaceConfiguration: String!
+  $overview: String!
+  $multipleInstances: Boolean
+) {
+  updateIntegrationMarketplaceConfiguration(
+    input: {
+      id: $id
+      marketplaceConfiguration: $marketplaceConfiguration
+      overview: $overview
+      allowMultipleMarketplaceInstances: $multipleInstances
+    }
+  ) {
+    integration {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/updateOrganization.generated.ts
+++ b/src/graphql/operations/updateOrganization.generated.ts
@@ -1,0 +1,85 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type UpdateOrganizationMutationVariables = Exact<{
+  name?: string | null | undefined;
+}>;
+
+export type UpdateOrganizationMutation = {
+  updateOrganization: {
+    organization: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const UpdateOrganizationDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateOrganization" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "name" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "updateOrganization" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "name" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "name" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "organization" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<UpdateOrganizationMutation, UpdateOrganizationMutationVariables>;

--- a/src/graphql/operations/updateOrganization.graphql
+++ b/src/graphql/operations/updateOrganization.graphql
@@ -1,0 +1,11 @@
+mutation updateOrganization($name: String) {
+  updateOrganization(input: { name: $name }) {
+    organization {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/updateUser.generated.ts
+++ b/src/graphql/operations/updateUser.generated.ts
@@ -1,0 +1,132 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type UpdateUserMutationVariables = Exact<{
+  user: string | number;
+  name?: string | null | undefined;
+  phone?: string | null | undefined;
+  darkMode?: boolean | null | undefined;
+  darkModeOsSync?: boolean | null | undefined;
+}>;
+
+export type UpdateUserMutation = {
+  updateUser: {
+    user: { id: string } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const UpdateUserDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "updateUser" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "user" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "ID" } },
+          },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "name" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "phone" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "darkMode" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "darkModeOsSync" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Boolean" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "updateUser" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "id" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "user" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "name" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "name" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "phone" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "phone" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "darkMode" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "darkMode" } },
+                    },
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "darkModeSyncWithOs" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "darkModeOsSync" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "user" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "id" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<UpdateUserMutation, UpdateUserMutationVariables>;

--- a/src/graphql/operations/updateUser.graphql
+++ b/src/graphql/operations/updateUser.graphql
@@ -1,0 +1,25 @@
+mutation updateUser(
+  $user: ID!
+  $name: String
+  $phone: String
+  $darkMode: Boolean
+  $darkModeOsSync: Boolean
+) {
+  updateUser(
+    input: {
+      id: $user
+      name: $name
+      phone: $phone
+      darkMode: $darkMode
+      darkModeSyncWithOs: $darkModeOsSync
+    }
+  ) {
+    user {
+      id
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/validateIntegrationSchema.generated.ts
+++ b/src/graphql/operations/validateIntegrationSchema.generated.ts
@@ -1,0 +1,91 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ValidateIntegrationSchemaMutationVariables = Exact<{
+  definition: string;
+}>;
+
+export type ValidateIntegrationSchemaMutation = {
+  validateIntegrationSchema: {
+    result: { isValid: boolean | null } | null;
+    errors: Array<{ field: string; messages: Array<string> }>;
+  } | null;
+};
+
+export const ValidateIntegrationSchemaDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "mutation",
+      name: { kind: "Name", value: "validateIntegrationSchema" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "definition" } },
+          type: {
+            kind: "NonNullType",
+            type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+          },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "validateIntegrationSchema" },
+            arguments: [
+              {
+                kind: "Argument",
+                name: { kind: "Name", value: "input" },
+                value: {
+                  kind: "ObjectValue",
+                  fields: [
+                    {
+                      kind: "ObjectField",
+                      name: { kind: "Name", value: "definition" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "definition" } },
+                    },
+                  ],
+                },
+              },
+            ],
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "result" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [{ kind: "Field", name: { kind: "Name", value: "isValid" } }],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "errors" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "field" } },
+                      { kind: "Field", name: { kind: "Name", value: "messages" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<
+  ValidateIntegrationSchemaMutation,
+  ValidateIntegrationSchemaMutationVariables
+>;

--- a/src/graphql/operations/validateIntegrationSchema.graphql
+++ b/src/graphql/operations/validateIntegrationSchema.graphql
@@ -1,0 +1,11 @@
+mutation validateIntegrationSchema($definition: String!) {
+  validateIntegrationSchema(input: { definition: $definition }) {
+    result {
+      isValid
+    }
+    errors {
+      field
+      messages
+    }
+  }
+}

--- a/src/graphql/operations/whoami.generated.ts
+++ b/src/graphql/operations/whoami.generated.ts
@@ -1,0 +1,69 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type WhoamiQueryVariables = Exact<{ [key: string]: never }>;
+
+export type WhoamiQuery = {
+  authenticatedUser: {
+    name: string;
+    email: string;
+    tenantId: string;
+    org: { id: string; name: string } | null;
+    customer: { id: string; name: string } | null;
+  };
+};
+
+export const WhoamiDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "whoami" },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "authenticatedUser" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                { kind: "Field", name: { kind: "Name", value: "name" } },
+                { kind: "Field", name: { kind: "Name", value: "email" } },
+                { kind: "Field", name: { kind: "Name", value: "tenantId" } },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "org" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      { kind: "Field", name: { kind: "Name", value: "name" } },
+                    ],
+                  },
+                },
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "customer" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      { kind: "Field", name: { kind: "Name", value: "name" } },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<WhoamiQuery, WhoamiQueryVariables>;

--- a/src/graphql/operations/whoami.graphql
+++ b/src/graphql/operations/whoami.graphql
@@ -1,0 +1,15 @@
+query whoami {
+  authenticatedUser {
+    name
+    email
+    tenantId
+    org {
+      id
+      name
+    }
+    customer {
+      id
+      name
+    }
+  }
+}

--- a/src/graphql/organization/listOrganizationUsers.generated.ts
+++ b/src/graphql/organization/listOrganizationUsers.generated.ts
@@ -1,0 +1,121 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type ListOrganizationUsersQueryVariables = Exact<{
+  after?: string | null | undefined;
+  first?: number | null | undefined;
+}>;
+
+export type ListOrganizationUsersQuery = {
+  organization: {
+    users: {
+      nodes: Array<{
+        id: string;
+        name: string;
+        email: string;
+        externalId: string | null;
+        phone: string;
+        role: { name: string };
+      }>;
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+    };
+  } | null;
+};
+
+export const ListOrganizationUsersDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "listOrganizationUsers" },
+      variableDefinitions: [
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "after" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "String" } },
+        },
+        {
+          kind: "VariableDefinition",
+          variable: { kind: "Variable", name: { kind: "Name", value: "first" } },
+          type: { kind: "NamedType", name: { kind: "Name", value: "Int" } },
+        },
+      ],
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "organization" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "users" },
+                  arguments: [
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "after" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "after" } },
+                    },
+                    {
+                      kind: "Argument",
+                      name: { kind: "Name", value: "first" },
+                      value: { kind: "Variable", name: { kind: "Name", value: "first" } },
+                    },
+                  ],
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "nodes" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "id" } },
+                            { kind: "Field", name: { kind: "Name", value: "name" } },
+                            { kind: "Field", name: { kind: "Name", value: "email" } },
+                            { kind: "Field", name: { kind: "Name", value: "externalId" } },
+                            { kind: "Field", name: { kind: "Name", value: "phone" } },
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "role" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "name" } },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "pageInfo" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            { kind: "Field", name: { kind: "Name", value: "hasNextPage" } },
+                            { kind: "Field", name: { kind: "Name", value: "endCursor" } },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<ListOrganizationUsersQuery, ListOrganizationUsersQueryVariables>;

--- a/src/graphql/organization/listOrganizationUsers.graphql
+++ b/src/graphql/organization/listOrganizationUsers.graphql
@@ -1,0 +1,20 @@
+query listOrganizationUsers($after: String, $first: Int) {
+  organization {
+    users(after: $after, first: $first) {
+      nodes {
+        id
+        name
+        email
+        externalId
+        phone
+        role {
+          name
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}

--- a/src/graphql/schema.generated.ts
+++ b/src/graphql/schema.generated.ts
@@ -1,14 +1,5 @@
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
-export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
-export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
-export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> = {
-  [_ in K]?: never;
-};
-export type Incremental<T> =
-  | T
-  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: { input: string; output: string };
@@ -16,13 +7,20 @@ export type Scalars = {
   Boolean: { input: boolean; output: boolean };
   Int: { input: number; output: number };
   Float: { input: number; output: number };
-  BigInt: { input: any; output: any };
-  Date: { input: any; output: any };
-  DateTime: { input: any; output: any };
-  JSONOrString: { input: any; output: any };
-  JSONString: { input: any; output: any };
-  UUID: { input: any; output: any };
+  BigInt: { input: string | number; output: string };
+  Date: { input: string; output: string };
+  DateTime: { input: string; output: string };
+  GenericScalar: { input: unknown; output: unknown };
+  JSONOrString: { input: unknown; output: unknown };
+  JSONString: { input: unknown; output: unknown };
+  UUID: { input: string; output: string };
 };
+
+export enum ActionBatchSupport {
+  Invalid = "INVALID",
+  Required = "REQUIRED",
+  Valid = "VALID",
+}
 
 export enum ActionDataSourceType {
   /** Boolean */
@@ -69,10 +67,16 @@ export type ActionDefinitionInput = {
   dynamicBranchInput?: InputMaybe<Scalars["String"]["input"]>;
   /** An example of the returned payload of an Action. */
   examplePayload?: InputMaybe<Scalars["JSONString"]["input"]>;
+  /** Whether the Action's examplePerform is safe to invoke inline. */
+  examplePerformSafety?: InputMaybe<ActionPerformSafety>;
   /** The InputFields supported by the Component Action. */
   inputs: Array<InputMaybe<InputFieldDefinition>>;
   /** A string which uniquely identifies the Action in the context of the Component. */
   key: Scalars["String"]["input"];
+  /** Describes the shape of the Action's output. For branching Actions, declares a distinct schema per branch. */
+  outputSchema?: InputMaybe<ActionOutputSchemaInput>;
+  /** Whether the Action's perform is safe to invoke inline. */
+  performSafety?: InputMaybe<ActionPerformSafety>;
   /** The static branch names associated with an Action. */
   staticBranchNames?: InputMaybe<Array<InputMaybe<Scalars["String"]["input"]>>>;
   /** Specifies whether the Action will terminate Instance execution. */
@@ -93,6 +97,26 @@ export type ActionDisplayDefinition = {
   label: Scalars["String"]["input"];
 };
 
+/**
+ * Identifies a single Action by composite key. Action identity at the model
+ * layer is `(tenant, component, key, is_trigger, is_data_source)` — the same
+ * key can be reused across an action, a trigger, and a data source on the
+ * same component, so the trigger/data-source flags are required to
+ * disambiguate. Both default to False (the regular-action case).
+ */
+export type ActionInputFieldsSelector = {
+  actionKey: Scalars["String"]["input"];
+  componentKey: Scalars["String"]["input"];
+  /** Specifies whether the Component is publicly available or whether it's private to the Organization. */
+  componentPublic: Scalars["Boolean"]["input"];
+  /** The pinned version of the Component. Must be a concrete integer. */
+  componentVersion: Scalars["Int"]["input"];
+  /** True when selecting a data source; defaults to False. */
+  isDataSource?: InputMaybe<Scalars["Boolean"]["input"]>;
+  /** True when selecting a trigger; defaults to False. */
+  isTrigger?: InputMaybe<Scalars["Boolean"]["input"]>;
+};
+
 /** Allows specifying which field and direction to order by. */
 export type ActionOrder = {
   /** The direction to order by. */
@@ -109,6 +133,37 @@ export enum ActionOrderField {
   IsTrigger = "IS_TRIGGER",
   Label = "LABEL",
 }
+
+/**
+ * Tagged-union input describing the shape of an Action's output.
+ *
+ * GraphQL has no native input unions, so the discriminant `type` selects
+ * which payload field applies:
+ *   * 'actionOutput'    -> `schema` (a single JSON Schema)
+ *   * 'branchingOutput' -> `branchSchemas` (a JSON Schema per branch, as a
+ *     list of name/schema pairs — GraphQL has no native map type)
+ * The server validates that exactly the field matching `type` is provided.
+ */
+export type ActionOutputSchemaInput = {
+  /** Per-branch JSON Schemas, one entry per branch. Required for 'branchingOutput'. */
+  branchSchemas?: InputMaybe<Array<InputMaybe<BranchOutputSchemaInput>>>;
+  /** A JSON Schema describing the Action's output. Required for 'actionOutput'. */
+  schema?: InputMaybe<Scalars["JSONString"]["input"]>;
+  /** The output-schema variant: 'actionOutput' or 'branchingOutput'. */
+  type: Scalars["String"]["input"];
+};
+
+export enum ActionPerformSafety {
+  NotAllowed = "NOT_ALLOWED",
+  Safe = "SAFE",
+}
+
+/** Specifies availability and recommendation for a single action. */
+export type ActionRuleInput = {
+  actionKey: Scalars["String"]["input"];
+  availability: WorkflowContextAvailability;
+  isRecommended: Scalars["Boolean"]["input"];
+};
 
 export enum ActionScheduleSupport {
   /** Invalid */
@@ -152,6 +207,15 @@ export type AdministerObjectPermissionInput = {
   object: Scalars["ID"]["input"];
   /** The Permission to grant for the specified object. */
   permission: Scalars["ID"]["input"];
+};
+
+export type AdministerObjectPermissionsInput = {
+  /** A unique identifier for the client performing the mutation. */
+  clientMutationId?: InputMaybe<Scalars["String"]["input"]>;
+  /** The ID of the User to mutate. */
+  id?: InputMaybe<Scalars["ID"]["input"]>;
+  /** The object Permissions to grant or revoke for the specified User. */
+  permissions: Array<InputMaybe<InputObjectPermission>>;
 };
 
 export enum AggregateDeploymentStatus {
@@ -286,6 +350,21 @@ export type AuthorizationDefinition = {
   required: Scalars["Boolean"]["input"];
 };
 
+/** A single branch's output schema, identified by branch name. */
+export type BranchOutputSchemaInput = {
+  /** The branch name; must match one of the Action's staticBranchNames. */
+  name: Scalars["String"]["input"];
+  /** A JSON Schema describing this branch's output. */
+  schema: Scalars["JSONString"]["input"];
+};
+
+export type BulkDeleteIntegrationVersionsInput = {
+  /** A unique identifier for the client performing the mutation. */
+  clientMutationId?: InputMaybe<Scalars["String"]["input"]>;
+  /** The Integration version ids to delete. All ids must belong to the same version sequence. */
+  ids: Array<InputMaybe<Scalars["ID"]["input"]>>;
+};
+
 export type BulkDisableInstancesUsingConnectionInput = {
   /** A unique identifier for the client performing the mutation. */
   clientMutationId?: InputMaybe<Scalars["String"]["input"]>;
@@ -300,10 +379,24 @@ export type BulkDisableInstancesUsingCustomerConnectionInput = {
   id?: InputMaybe<Scalars["ID"]["input"]>;
 };
 
+export type BulkReplayExecutionsInput = {
+  /** A unique identifier for the client performing the mutation. */
+  clientMutationId?: InputMaybe<Scalars["String"]["input"]>;
+  /** The Executions to replay. No more than 25 may be specified. */
+  ids: Array<InputMaybe<Scalars["ID"]["input"]>>;
+};
+
 export type BulkUpdateInstancesToLatestIntegrationVersionInput = {
   /** A unique identifier for the client performing the mutation. */
   clientMutationId?: InputMaybe<Scalars["String"]["input"]>;
   /** The ID of the Integration to mutate. */
+  id?: InputMaybe<Scalars["ID"]["input"]>;
+};
+
+export type CancelBatchExecutionProcessingInput = {
+  /** A unique identifier for the client performing the mutation. */
+  clientMutationId?: InputMaybe<Scalars["String"]["input"]>;
+  /** The ID of the InstanceExecutionResult to mutate. */
   id?: InputMaybe<Scalars["ID"]["input"]>;
 };
 
@@ -367,6 +460,12 @@ export type ComponentDisplayDefinition = {
   label: Scalars["String"]["input"];
 };
 
+/** References a Component by key and public flag, matching across all versions. */
+export type ComponentFuzzySelector = {
+  isPublic: Scalars["Boolean"]["input"];
+  key: Scalars["String"]["input"];
+};
+
 /** Allows specifying which field and direction to order by. */
 export type ComponentOrder = {
   /** The direction to order by. */
@@ -385,6 +484,21 @@ export enum ComponentOrderField {
   VersionNumber = "VERSION_NUMBER",
 }
 
+/**
+ * Specifies a component-level rule with optional per-action overrides.
+ *
+ * If availability is provided, it applies to the whole component.
+ * If actions are provided, each action gets its own availability.
+ * These are mutually exclusive.
+ */
+export type ComponentRuleInput = {
+  actions?: InputMaybe<Array<InputMaybe<ActionRuleInput>>>;
+  availability?: InputMaybe<WorkflowContextAvailability>;
+  component: ComponentFuzzySelector;
+  isRecommended?: InputMaybe<Scalars["Boolean"]["input"]>;
+  scope: WorkflowContextRuleScope;
+};
+
 /** Represents a collection of data that references a Component. */
 export type ComponentSelector = {
   /** Specifies whether the Component is publicly available or whether it's private to the Organization. */
@@ -394,6 +508,25 @@ export type ComponentSelector = {
   /** The version of the Component */
   version?: InputMaybe<Scalars["String"]["input"]>;
 };
+
+/**
+ * References a Component by key, public flag, and signature for
+ * tenant-portable identification.
+ */
+export type ComponentSignatureSelector = {
+  /** Specifies whether the Component is publicly available or whether it's private to the Organization. */
+  isPublic: Scalars["Boolean"]["input"];
+  /** A string that uniquely identifies the Component. */
+  key: Scalars["String"]["input"];
+  /** The signature of the Component for version-independent identification. */
+  signature: Scalars["String"]["input"];
+};
+
+export enum ConcurrencyLimitSource {
+  Batch = "BATCH",
+  Customer = "CUSTOMER",
+  Tenant = "TENANT",
+}
 
 /** Represents a collection of data that defines a Component Connection. */
 export type ConnectionDefinitionInput = {
@@ -429,6 +562,8 @@ export type ConnectionInputFieldDefinition = {
   default?: InputMaybe<Scalars["JSONOrString"]["input"]>;
   /** An example valid input for this InputField. */
   example?: InputMaybe<Scalars["String"]["input"]>;
+  /** Nested InputFields. Permitted when `type` is 'structuredObject' or 'dynamicObject'. A top-level 'structuredObject' may only contain leaf children. A 'dynamicObject's children must each be a 'structuredObject' configuration; each configuration may itself contain a nested 'structuredObject' one level deep. */
+  inputs?: InputMaybe<Array<InputMaybe<InputFieldDefinition>>>;
   /** A string which uniquely identifies the InputField in the context of the Action. */
   key: Scalars["String"]["input"];
   /** Label used for the Keys of a 'keyvaluelist' collection. */
@@ -445,6 +580,8 @@ export type ConnectionInputFieldDefinition = {
   placeholder?: InputMaybe<Scalars["String"]["input"]>;
   /** Specifies whether the InputField is required by the Action. */
   required?: InputMaybe<Scalars["Boolean"]["input"]>;
+  /** Specifies the scope in which this input is accessible. */
+  scope?: InputMaybe<InputFieldScope>;
   /** Whether or not the field is shown to Integrators and Deployers. Field must have a default is this is `false`. */
   shown?: InputMaybe<Scalars["Boolean"]["input"]>;
   /** Specifies the type of data the InputField handles. */
@@ -481,6 +618,13 @@ export enum ConnectionOrderField {
   Order = "ORDER",
 }
 
+export enum ConnectionStatus {
+  Active = "ACTIVE",
+  Error = "ERROR",
+  Failed = "FAILED",
+  Pending = "PENDING",
+}
+
 /** Represents a single preset input for a ConnectionTemplate */
 export type ConnectionTemplateField = {
   /** The key of an InputField that the value is associated with. */
@@ -505,6 +649,8 @@ export enum ConnectionTemplateOrderField {
 export type ConvertLowCodeIntegrationInput = {
   /** A unique identifier for the client performing the mutation. */
   clientMutationId?: InputMaybe<Scalars["String"]["input"]>;
+  /** Optional YAML definition to convert directly, as an alternative to providing an integration id. */
+  definition?: InputMaybe<Scalars["String"]["input"]>;
   /** The ID of the Integration to mutate. */
   id?: InputMaybe<Scalars["ID"]["input"]>;
   /** Whether to include inline comments in the generated code. */
@@ -785,6 +931,8 @@ export type CreateScopedConfigVariableInput = {
   description?: InputMaybe<Scalars["String"]["input"]>;
   /** The collection of Expressions that serve as inputs to this variable. */
   inputs?: InputMaybe<Array<InputMaybe<InputExpression>>>;
+  /** Specifies whether this Config Variable is meant for testing. */
+  isTest?: InputMaybe<Scalars["Boolean"]["input"]>;
   /** The display name of this variable. */
   key: Scalars["String"]["input"];
   /** Enforces which group of users can modify the variable. */
@@ -841,6 +989,26 @@ export type CreateWebhookEndpointInput = {
   secret?: InputMaybe<Scalars["String"]["input"]>;
   /** The URL where webhook events will be sent. */
   url: Scalars["String"]["input"];
+};
+
+export type CreateWorkflowContextInput = {
+  /** The default availability for actions in this context. */
+  actionDefaultAvailability: Scalars["String"]["input"];
+  /** A unique identifier for the client performing the mutation. */
+  clientMutationId?: InputMaybe<Scalars["String"]["input"]>;
+  /** A JSON schema describing the structure of this context. */
+  contextSchema?: InputMaybe<Scalars["String"]["input"]>;
+  defaultTrigger?: InputMaybe<WorkflowContextDefaultTriggerInput>;
+  /** Additional notes about the WorkflowContext. */
+  description?: InputMaybe<Scalars["String"]["input"]>;
+  inputs?: InputMaybe<Array<InputMaybe<InputExpression>>>;
+  /** The name of the WorkflowContext. */
+  name: Scalars["String"]["input"];
+  rules?: InputMaybe<Array<InputMaybe<ComponentRuleInput>>>;
+  /** A stable identifier for the WorkflowContext. */
+  stableKey: Scalars["String"]["input"];
+  /** The default availability for triggers in this context. */
+  triggerDefaultAvailability: Scalars["String"]["input"];
 };
 
 export enum CredentialFieldType {
@@ -1046,6 +1214,13 @@ export type DeleteIntegrationTemplateInput = {
   id?: InputMaybe<Scalars["ID"]["input"]>;
 };
 
+export type DeleteIntegrationVersionInput = {
+  /** A unique identifier for the client performing the mutation. */
+  clientMutationId?: InputMaybe<Scalars["String"]["input"]>;
+  /** The ID of the Integration to mutate. */
+  id?: InputMaybe<Scalars["ID"]["input"]>;
+};
+
 export type DeleteOnPremiseResourceInput = {
   /** A unique identifier for the client performing the mutation. */
   clientMutationId?: InputMaybe<Scalars["String"]["input"]>;
@@ -1099,6 +1274,13 @@ export type DeleteWebhookEndpointInput = {
   /** A unique identifier for the client performing the mutation. */
   clientMutationId?: InputMaybe<Scalars["String"]["input"]>;
   /** The ID of the WebhookEndpoint to mutate. */
+  id?: InputMaybe<Scalars["ID"]["input"]>;
+};
+
+export type DeleteWorkflowContextInput = {
+  /** A unique identifier for the client performing the mutation. */
+  clientMutationId?: InputMaybe<Scalars["String"]["input"]>;
+  /** The ID of the WorkflowContext to mutate. */
   id?: InputMaybe<Scalars["ID"]["input"]>;
 };
 
@@ -1178,6 +1360,72 @@ export enum EnablementBlocker {
   ReferencesDeletedConnection = "REFERENCES_DELETED_CONNECTION",
 }
 
+export type EventFilterGroup = {
+  filters: Array<EventFilterInput>;
+  /** Nested filter groups combined under this group's operator. */
+  groups?: InputMaybe<Array<EventFilterGroup>>;
+  operator: LogicalOperator;
+};
+
+export type EventFilterInput = {
+  keyPath: Scalars["String"]["input"];
+  operator: FilterOperator;
+  value?: InputMaybe<Scalars["GenericScalar"]["input"]>;
+};
+
+export type EventOrder = {
+  direction: OrderDirection;
+  field: EventOrderField;
+};
+
+export enum EventOrderField {
+  Customer = "CUSTOMER",
+  Flow = "FLOW",
+  FlowConfig = "FLOW_CONFIG",
+  Instance = "INSTANCE",
+  Integration = "INTEGRATION",
+  LogType = "LOG_TYPE",
+  Message = "MESSAGE",
+  Severity = "SEVERITY",
+  Timestamp = "TIMESTAMP",
+}
+
+export enum EventType {
+  ExecutionEvent = "EXECUTION_EVENT",
+  ExecutionSection = "EXECUTION_SECTION",
+  LogEvent = "LOG_EVENT",
+  StepResult = "STEP_RESULT",
+  TriggerPayload = "TRIGGER_PAYLOAD",
+}
+
+/** Allows specifying which field and direction to order by. */
+export type ExecutionBatchOrder = {
+  /** The direction to order by. */
+  direction: OrderDirection;
+  /** The field to order by. */
+  field: ExecutionBatchOrderField;
+};
+
+/** Represents the fields by which collections of the related type may be ordered. */
+export enum ExecutionBatchOrderField {
+  CompletedAt = "COMPLETED_AT",
+  StartedAt = "STARTED_AT",
+}
+
+export enum ExecutionBatchRole {
+  /** Discovery */
+  Discovery = "DISCOVERY",
+  /** Processing */
+  Processing = "PROCESSING",
+}
+
+export enum ExecutionBatchStatus {
+  /** Completed */
+  Completed = "COMPLETED",
+  /** Failed */
+  Failed = "FAILED",
+}
+
 export type ExecutionInvokedByInput = {
   /** ID of the invoking execution. */
   id: Scalars["ID"]["input"];
@@ -1185,7 +1433,52 @@ export type ExecutionInvokedByInput = {
   startedAt: Scalars["DateTime"]["input"];
 };
 
+export enum ExecutionRunInvokeType {
+  AiAgent = "AI_AGENT",
+  CrossFlow = "CROSS_FLOW",
+  DeployFlow = "DEPLOY_FLOW",
+  InstanceSyncFlow = "INSTANCE_SYNC_FLOW",
+  IntegrationEndpointTest = "INTEGRATION_ENDPOINT_TEST",
+  IntegrationFlowTest = "INTEGRATION_FLOW_TEST",
+  Scheduled = "SCHEDULED",
+  TearDownFlow = "TEAR_DOWN_FLOW",
+  Webhook = "WEBHOOK",
+  WebhookSnapshot = "WEBHOOK_SNAPSHOT",
+}
+
+export type ExecutionRunOrder = {
+  direction: OrderDirection;
+  field: ExecutionRunOrderField;
+};
+
+export enum ExecutionRunOrderField {
+  CustomerName = "CUSTOMER_NAME",
+  DurationMs = "DURATION_MS",
+  EndedAt = "ENDED_AT",
+  ErrorStepName = "ERROR_STEP_NAME",
+  FlowName = "FLOW_NAME",
+  InstanceName = "INSTANCE_NAME",
+  IntegrationName = "INTEGRATION_NAME",
+  InvokeType = "INVOKE_TYPE",
+  QueuedAt = "QUEUED_AT",
+  ResultType = "RESULT_TYPE",
+  ResumedAt = "RESUMED_AT",
+  StartedAt = "STARTED_AT",
+  Status = "STATUS",
+  StepCount = "STEP_COUNT",
+}
+
+export enum ExecutionRunResultType {
+  CanceledAsDuplicate = "CANCELED_AS_DUPLICATE",
+  CanceledByUser = "CANCELED_BY_USER",
+  Completed = "COMPLETED",
+  Error = "ERROR",
+  PolledNoChanges = "POLLED_NO_CHANGES",
+}
+
 export enum ExecutionStatus {
+  Canceled = "CANCELED",
+  Canceling = "CANCELING",
   Error = "ERROR",
   Pending = "PENDING",
   Queued = "QUEUED",
@@ -1196,6 +1489,7 @@ export enum ExpressionType {
   Complex = "COMPLEX",
   Configvar = "CONFIGVAR",
   Reference = "REFERENCE",
+  StructuredObject = "STRUCTURED_OBJECT",
   Template = "TEMPLATE",
   Value = "VALUE",
 }
@@ -1214,6 +1508,19 @@ export enum ExternalLogStreamOrderField {
   Name = "NAME",
   UpdatedAt = "UPDATED_AT",
 }
+
+export type FetchActionContentInput = {
+  /** The Action to be run. */
+  action?: InputMaybe<Scalars["ID"]["input"]>;
+  /** A unique identifier for the client performing the mutation. */
+  clientMutationId?: InputMaybe<Scalars["String"]["input"]>;
+  /** The ID of the Instance to mutate. */
+  id?: InputMaybe<Scalars["ID"]["input"]>;
+  /** Input values for the specified Action. */
+  inputs?: InputMaybe<Array<InputMaybe<InputExpression>>>;
+  /** Specifies whether to use the live Action, rather than the example Action. Defaults to example. */
+  runMode?: InputMaybe<RunMode>;
+};
 
 export type FetchConfigWizardPageContentInput = {
   /** A unique identifier for the client performing the mutation. */
@@ -1234,6 +1541,16 @@ export type FetchDataSourceContentInput = {
   /** Input values for the specified Data Source. */
   inputs?: InputMaybe<Array<InputMaybe<InputExpression>>>;
 };
+
+export enum FilterOperator {
+  Contains = "CONTAINS",
+  Eq = "EQ",
+  Gte = "GTE",
+  In = "IN",
+  IsNull = "IS_NULL",
+  Lte = "LTE",
+  NotEq = "NOT_EQ",
+}
 
 export type ForkIntegrationInput = {
   /** A unique identifier for the client performing the mutation. */
@@ -1281,12 +1598,22 @@ export type ImportOrganizationSigningKeyInput = {
 export type ImportWorkflowInput = {
   /** A unique identifier for the client performing the mutation. */
   clientMutationId?: InputMaybe<Scalars["String"]["input"]>;
+  /** A payload of JSON data to inject with the WorkflowContext. */
+  contextData?: InputMaybe<Scalars["String"]["input"]>;
+  /** The stable key of a WorkflowContext to bind to the Workflow. */
+  contextStableKey?: InputMaybe<Scalars["String"]["input"]>;
   /** The Customer the Integration belongs to, if any. If this is NULL then the Integration belongs to the Organization. */
   customer?: InputMaybe<Scalars["ID"]["input"]>;
   /** The YAML serialized definition of the Workflow to import. */
-  definition: Scalars["String"]["input"];
+  definition?: InputMaybe<Scalars["String"]["input"]>;
+  /** The description of the Workflow. */
+  description?: InputMaybe<Scalars["String"]["input"]>;
+  /** An external ID to set on the Workflow. */
+  externalId?: InputMaybe<Scalars["String"]["input"]>;
   /** The ID of the Integration to mutate. */
   id?: InputMaybe<Scalars["ID"]["input"]>;
+  /** The name of the Workflow. */
+  name?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 /** Represents a specific value of a CredentialField. */
@@ -1338,6 +1665,8 @@ export type InputFieldDefinition = {
   default?: InputMaybe<Scalars["JSONOrString"]["input"]>;
   /** An example valid input for this InputField. */
   example?: InputMaybe<Scalars["String"]["input"]>;
+  /** Nested InputFields. Permitted when `type` is 'structuredObject' or 'dynamicObject'. A top-level 'structuredObject' may only contain leaf children. A 'dynamicObject's children must each be a 'structuredObject' configuration; each configuration may itself contain a nested 'structuredObject' one level deep. */
+  inputs?: InputMaybe<Array<InputMaybe<InputFieldDefinition>>>;
   /** A string which uniquely identifies the InputField in the context of the Action. */
   key: Scalars["String"]["input"];
   /** Label used for the Keys of a 'keyvaluelist' collection. */
@@ -1352,9 +1681,15 @@ export type InputFieldDefinition = {
   placeholder?: InputMaybe<Scalars["String"]["input"]>;
   /** Specifies whether the InputField is required by the Action. */
   required?: InputMaybe<Scalars["Boolean"]["input"]>;
+  /** Specifies the scope in which this input is accessible. */
+  scope?: InputMaybe<InputFieldScope>;
   /** Specifies the type of data the InputField handles. */
   type: Scalars["String"]["input"];
 };
+
+export enum InputFieldScope {
+  OnDeploy = "ON_DEPLOY",
+}
 
 export enum InputFieldType {
   /** boolean */
@@ -1371,6 +1706,8 @@ export enum InputFieldType {
   Date = "DATE",
   /** dynamicFieldSelection */
   Dynamicfieldselection = "DYNAMICFIELDSELECTION",
+  /** dynamicObject */
+  Dynamicobject = "DYNAMICOBJECT",
   /** dynamicObjectSelection */
   Dynamicobjectselection = "DYNAMICOBJECTSELECTION",
   /** flow */
@@ -1385,6 +1722,8 @@ export enum InputFieldType {
   Password = "PASSWORD",
   /** string */
   String = "STRING",
+  /** structuredObject */
+  Structuredobject = "STRUCTUREDOBJECT",
   /** template */
   Template = "TEMPLATE",
   /** text */
@@ -1400,6 +1739,7 @@ export type InputInstanceConfigVariable = {
   onPremiseResourceId?: InputMaybe<Scalars["ID"]["input"]>;
   /** The schedule type for the specified Required Config Var of the Integration. */
   scheduleType?: InputMaybe<Scalars["String"]["input"]>;
+  scopedConfigVariableId?: InputMaybe<Scalars["ID"]["input"]>;
   /** The timezone for the specified Required Config Var of the Integration. */
   timeZone?: InputMaybe<Scalars["String"]["input"]>;
   /** The value to provide for the specified Required Config Var of the Integration. */
@@ -1432,6 +1772,16 @@ export type InputIntegrationFlow = {
   testPayload?: InputMaybe<Scalars["String"]["input"]>;
 };
 
+/** A single grant/revoke operation within a batch permission mutation. */
+export type InputObjectPermission = {
+  /** Specifies whether to grant or revoke the specified Permission. */
+  grant: Scalars["Boolean"]["input"];
+  /** The object for which the specified Permission is administered. */
+  object: Scalars["ID"]["input"];
+  /** The Permission to grant or revoke for the specified object. */
+  permission: Scalars["ID"]["input"];
+};
+
 export enum InstanceConfigState {
   FullyConfigured = "FULLY_CONFIGURED",
   NeedsInstanceConfiguration = "NEEDS_INSTANCE_CONFIGURATION",
@@ -1449,6 +1799,8 @@ export enum InstanceConfigVariableScheduleType {
   Minute = "MINUTE",
   /** None */
   None = "NONE",
+  /** Once */
+  Once = "ONCE",
   /** Week */
   Week = "WEEK",
 }
@@ -1490,6 +1842,8 @@ export enum InstanceExecutionResultInvokeType {
   CrossFlow = "CROSS_FLOW",
   /** Deploy Flow */
   DeployFlow = "DEPLOY_FLOW",
+  /** Instance Sync Flow */
+  InstanceSyncFlow = "INSTANCE_SYNC_FLOW",
   /** Integration Endpoint Test */
   IntegrationEndpointTest = "INTEGRATION_ENDPOINT_TEST",
   /** Integration Flow Test */
@@ -1521,6 +1875,8 @@ export enum InstanceExecutionResultOrderField {
 export enum InstanceExecutionResultResultType {
   /** Canceled As Duplicate */
   CanceledAsDuplicate = "CANCELED_AS_DUPLICATE",
+  /** Canceled By User */
+  CanceledByUser = "CANCELED_BY_USER",
   /** Completed */
   Completed = "COMPLETED",
   /** Error */
@@ -1759,6 +2115,11 @@ export enum LogType {
   RateLimit = "RATE_LIMIT",
 }
 
+export enum LogicalOperator {
+  And = "AND",
+  Or = "OR",
+}
+
 export enum MarketplaceConfiguration {
   AvailableAndDeployable = "AVAILABLE_AND_DEPLOYABLE",
   AvailableNotDeployable = "AVAILABLE_NOT_DEPLOYABLE",
@@ -1768,6 +2129,11 @@ export enum MarketplaceConfiguration {
 export enum MediaType {
   Attachment = "ATTACHMENT",
   Avatar = "AVATAR",
+}
+
+export enum MetricsInterval {
+  Daily = "DAILY",
+  Hourly = "HOURLY",
 }
 
 export type OAuthRedirectConfigInput = {
@@ -2023,6 +2389,8 @@ export enum RequiredConfigVariableScheduleType {
   Minute = "MINUTE",
   /** None */
   None = "NONE",
+  /** Once */
+  Once = "ONCE",
   /** Week */
   Week = "WEEK",
 }
@@ -2056,6 +2424,11 @@ export type RotateOnPremiseResourceJwtInput = {
   resourceId: Scalars["ID"]["input"];
 };
 
+export enum RunMode {
+  Example = "EXAMPLE",
+  Live = "LIVE",
+}
+
 export type SaveWorkflowTemplateInput = {
   /** A unique identifier for the client performing the mutation. */
   clientMutationId?: InputMaybe<Scalars["String"]["input"]>;
@@ -2076,6 +2449,8 @@ export enum ScopedConfigVariableManagedBy {
   Org = "ORG",
   /** System */
   System = "SYSTEM",
+  /** User */
+  User = "USER",
 }
 
 /** Allows specifying which field and direction to order by. */
@@ -2112,6 +2487,8 @@ export enum ScopedConfigVariableVariableScope {
   Customer = "CUSTOMER",
   /** Org */
   Org = "ORG",
+  /** User */
+  User = "USER",
 }
 
 /** Allows specifying which field and direction to order by. */
@@ -2173,6 +2550,8 @@ export type TestIntegrationFlowInput = {
   headers?: InputMaybe<Scalars["String"]["input"]>;
   /** The ID of the IntegrationFlow to mutate. */
   id?: InputMaybe<Scalars["ID"]["input"]>;
+  /** Run the test with the Instance Sync Flow invoke type, exercising the trigger's on-deploy sync (onDeployPerform) instead of the normal trigger perform. */
+  instanceSyncFlow?: InputMaybe<Scalars["Boolean"]["input"]>;
   /** The payload to send with the POST request that triggers the Integration Flow Test Instance. */
   payload?: InputMaybe<Scalars["String"]["input"]>;
   /** The result of the test case. */
@@ -2293,8 +2672,20 @@ export type TriggerDefinitionInput = {
   dynamicBranchInput?: InputMaybe<Scalars["String"]["input"]>;
   /** An example of the returned payload of an Action. */
   examplePayload?: InputMaybe<Scalars["JSONString"]["input"]>;
+  /** Whether the Action's examplePerform is safe to invoke inline. */
+  examplePerformSafety?: InputMaybe<ActionPerformSafety>;
+  /** Whether this Trigger defines a getNextDiscoveryState function for pagination. */
+  hasGetNextDiscoveryState?: InputMaybe<Scalars["Boolean"]["input"]>;
+  /** Whether this Trigger defines an onDeployResolver.getNextDiscoveryState function for pagination of the on-deploy fire. */
+  hasGetOnDeployNextDiscoveryState?: InputMaybe<Scalars["Boolean"]["input"]>;
+  /** Whether this Trigger defines an onDeployPerform function. */
+  hasOnDeployPerform?: InputMaybe<Scalars["Boolean"]["input"]>;
   hasOnInstanceDelete?: InputMaybe<Scalars["Boolean"]["input"]>;
   hasOnInstanceDeploy?: InputMaybe<Scalars["Boolean"]["input"]>;
+  /** Whether this Trigger defines an onDeployResolver.resolveItems function. */
+  hasResolveOnDeployItems?: InputMaybe<Scalars["Boolean"]["input"]>;
+  /** Whether this Trigger defines a resolveItems function to extract items from its payload. */
+  hasResolveTriggerItems?: InputMaybe<Scalars["Boolean"]["input"]>;
   hasWebhookCreateFunction?: InputMaybe<Scalars["Boolean"]["input"]>;
   hasWebhookDeleteFunction?: InputMaybe<Scalars["Boolean"]["input"]>;
   /** The InputFields supported by the Component Action. */
@@ -2303,6 +2694,10 @@ export type TriggerDefinitionInput = {
   isPollingTrigger?: InputMaybe<Scalars["Boolean"]["input"]>;
   /** A string which uniquely identifies the Action in the context of the Component. */
   key: Scalars["String"]["input"];
+  /** Describes the shape of the Action's output. For branching Actions, declares a distinct schema per branch. */
+  outputSchema?: InputMaybe<ActionOutputSchemaInput>;
+  /** Whether the Action's perform is safe to invoke inline. */
+  performSafety?: InputMaybe<ActionPerformSafety>;
   /** Specifies support for triggering an Integration on a recurring schedule. */
   scheduleSupport?: InputMaybe<Scalars["String"]["input"]>;
   /** The static branch names associated with an Action. */
@@ -2311,6 +2706,12 @@ export type TriggerDefinitionInput = {
   synchronousResponseSupport?: InputMaybe<Scalars["String"]["input"]>;
   /** Specifies whether the Action will terminate Instance execution. */
   terminateExecution?: InputMaybe<Scalars["Boolean"]["input"]>;
+  /** Default number of items per batch. */
+  triggerResolverDefaultBatchSize?: InputMaybe<Scalars["Int"]["input"]>;
+  /** Default max batches of a single execution running concurrently. */
+  triggerResolverDefaultConcurrentBatchLimit?: InputMaybe<Scalars["Int"]["input"]>;
+  /** Whether this Trigger supports batching its items. */
+  triggerResolverSupport?: InputMaybe<Scalars["String"]["input"]>;
 };
 
 export type UpdateAlertGroupInput = {
@@ -2845,6 +3246,26 @@ export type UpdateWebhookEndpointInput = {
   url?: InputMaybe<Scalars["String"]["input"]>;
 };
 
+export type UpdateWorkflowContextInput = {
+  /** The default availability for actions in this context. */
+  actionDefaultAvailability?: InputMaybe<Scalars["String"]["input"]>;
+  /** A unique identifier for the client performing the mutation. */
+  clientMutationId?: InputMaybe<Scalars["String"]["input"]>;
+  /** A JSON schema describing the structure of this context. */
+  contextSchema?: InputMaybe<Scalars["String"]["input"]>;
+  defaultTrigger?: InputMaybe<WorkflowContextDefaultTriggerInput>;
+  /** Additional notes about the WorkflowContext. */
+  description?: InputMaybe<Scalars["String"]["input"]>;
+  /** The ID of the WorkflowContext to mutate. */
+  id?: InputMaybe<Scalars["ID"]["input"]>;
+  inputs?: InputMaybe<Array<InputMaybe<InputExpression>>>;
+  /** The name of the WorkflowContext. */
+  name?: InputMaybe<Scalars["String"]["input"]>;
+  rules?: InputMaybe<Array<InputMaybe<ComponentRuleInput>>>;
+  /** The default availability for triggers in this context. */
+  triggerDefaultAvailability?: InputMaybe<Scalars["String"]["input"]>;
+};
+
 export type UpdateWorkflowTestConfigurationInput = {
   /** A unique identifier for the client performing the mutation. */
   clientMutationId?: InputMaybe<Scalars["String"]["input"]>;
@@ -2882,6 +3303,8 @@ export enum UserLevelConfigVariableScheduleType {
   Minute = "MINUTE",
   /** None */
   None = "NONE",
+  /** Once */
+  Once = "ONCE",
   /** Week */
   Week = "WEEK",
 }
@@ -2955,6 +3378,50 @@ export enum WebhookEndpointOrderField {
   CreatedAt = "CREATED_AT",
   Name = "NAME",
   UpdatedAt = "UPDATED_AT",
+}
+
+export enum WorkflowContextActionDefaultAvailability {
+  /** Disabled */
+  Disabled = "DISABLED",
+  /** Enabled */
+  Enabled = "ENABLED",
+}
+
+export enum WorkflowContextActionRuleAvailability {
+  /** Disabled */
+  Disabled = "DISABLED",
+  /** Enabled */
+  Enabled = "ENABLED",
+}
+
+export enum WorkflowContextAvailability {
+  Disabled = "DISABLED",
+  Enabled = "ENABLED",
+}
+
+export enum WorkflowContextComponentRuleAvailability {
+  /** Disabled */
+  Disabled = "DISABLED",
+  /** Enabled */
+  Enabled = "ENABLED",
+}
+
+/** Identifies a default trigger by action key and component selector. */
+export type WorkflowContextDefaultTriggerInput = {
+  actionKey: Scalars["String"]["input"];
+  component: ComponentSignatureSelector;
+};
+
+export enum WorkflowContextRuleScope {
+  Action = "ACTION",
+  Trigger = "TRIGGER",
+}
+
+export enum WorkflowContextTriggerDefaultAvailability {
+  /** Disabled */
+  Disabled = "DISABLED",
+  /** Enabled */
+  Enabled = "ENABLED",
 }
 
 /** Allows specifying which field and direction to order by. */

--- a/src/graphql/translations/marketplaceTranslations.generated.ts
+++ b/src/graphql/translations/marketplaceTranslations.generated.ts
@@ -1,0 +1,263 @@
+/** Internal type. DO NOT USE DIRECTLY. */
+type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
+/** Internal type. DO NOT USE DIRECTLY. */
+export type Incremental<T> =
+  | T
+  | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+
+import type { TypedDocumentNode as DocumentNode } from "@graphql-typed-document-node/core";
+export type IntegrationTranslationFragment = {
+  name: string;
+  description: string | null;
+  definition: string | null;
+  category: string | null;
+  overview: string | null;
+  configPages: unknown;
+  requiredConfigVariables: {
+    nodes: Array<{
+      key: string;
+      description: string | null;
+      inputs: { nodes: Array<{ name: string; meta: unknown }> } | null;
+    }>;
+  };
+};
+
+export type MarketplaceTranslationsQueryVariables = Exact<{ [key: string]: never }>;
+
+export type MarketplaceTranslationsQuery = {
+  marketplaceIntegrations: {
+    nodes: Array<{
+      id: string;
+      name: string;
+      description: string | null;
+      definition: string | null;
+      category: string | null;
+      overview: string | null;
+      configPages: unknown;
+      instances: {
+        nodes: Array<{
+          id: string;
+          name: string;
+          integration: {
+            name: string;
+            description: string | null;
+            definition: string | null;
+            category: string | null;
+            overview: string | null;
+            configPages: unknown;
+            requiredConfigVariables: {
+              nodes: Array<{
+                key: string;
+                description: string | null;
+                inputs: { nodes: Array<{ name: string; meta: unknown }> } | null;
+              }>;
+            };
+          };
+        }>;
+      };
+      requiredConfigVariables: {
+        nodes: Array<{
+          key: string;
+          description: string | null;
+          inputs: { nodes: Array<{ name: string; meta: unknown }> } | null;
+        }>;
+      };
+    }>;
+  };
+};
+
+export const IntegrationTranslationFragmentDoc = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "IntegrationTranslation" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Integration" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+          { kind: "Field", name: { kind: "Name", value: "description" } },
+          { kind: "Field", name: { kind: "Name", value: "definition" } },
+          { kind: "Field", name: { kind: "Name", value: "category" } },
+          { kind: "Field", name: { kind: "Name", value: "overview" } },
+          { kind: "Field", name: { kind: "Name", value: "configPages" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "requiredConfigVariables" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "key" } },
+                      { kind: "Field", name: { kind: "Name", value: "description" } },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "inputs" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "nodes" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "name" } },
+                                  { kind: "Field", name: { kind: "Name", value: "meta" } },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<IntegrationTranslationFragment, unknown>;
+export const MarketplaceTranslationsDocument = {
+  kind: "Document",
+  definitions: [
+    {
+      kind: "OperationDefinition",
+      operation: "query",
+      name: { kind: "Name", value: "MarketplaceTranslations" },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "marketplaceIntegrations" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "id" } },
+                      {
+                        kind: "FragmentSpread",
+                        name: { kind: "Name", value: "IntegrationTranslation" },
+                      },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "instances" },
+                        arguments: [
+                          {
+                            kind: "Argument",
+                            name: { kind: "Name", value: "isSystem" },
+                            value: { kind: "BooleanValue", value: false },
+                          },
+                        ],
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "nodes" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "id" } },
+                                  { kind: "Field", name: { kind: "Name", value: "name" } },
+                                  {
+                                    kind: "Field",
+                                    name: { kind: "Name", value: "integration" },
+                                    selectionSet: {
+                                      kind: "SelectionSet",
+                                      selections: [
+                                        {
+                                          kind: "FragmentSpread",
+                                          name: { kind: "Name", value: "IntegrationTranslation" },
+                                        },
+                                      ],
+                                    },
+                                  },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+    {
+      kind: "FragmentDefinition",
+      name: { kind: "Name", value: "IntegrationTranslation" },
+      typeCondition: { kind: "NamedType", name: { kind: "Name", value: "Integration" } },
+      selectionSet: {
+        kind: "SelectionSet",
+        selections: [
+          { kind: "Field", name: { kind: "Name", value: "name" } },
+          { kind: "Field", name: { kind: "Name", value: "description" } },
+          { kind: "Field", name: { kind: "Name", value: "definition" } },
+          { kind: "Field", name: { kind: "Name", value: "category" } },
+          { kind: "Field", name: { kind: "Name", value: "overview" } },
+          { kind: "Field", name: { kind: "Name", value: "configPages" } },
+          {
+            kind: "Field",
+            name: { kind: "Name", value: "requiredConfigVariables" },
+            selectionSet: {
+              kind: "SelectionSet",
+              selections: [
+                {
+                  kind: "Field",
+                  name: { kind: "Name", value: "nodes" },
+                  selectionSet: {
+                    kind: "SelectionSet",
+                    selections: [
+                      { kind: "Field", name: { kind: "Name", value: "key" } },
+                      { kind: "Field", name: { kind: "Name", value: "description" } },
+                      {
+                        kind: "Field",
+                        name: { kind: "Name", value: "inputs" },
+                        selectionSet: {
+                          kind: "SelectionSet",
+                          selections: [
+                            {
+                              kind: "Field",
+                              name: { kind: "Name", value: "nodes" },
+                              selectionSet: {
+                                kind: "SelectionSet",
+                                selections: [
+                                  { kind: "Field", name: { kind: "Name", value: "name" } },
+                                  { kind: "Field", name: { kind: "Name", value: "meta" } },
+                                ],
+                              },
+                            },
+                          ],
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  ],
+} as unknown as DocumentNode<MarketplaceTranslationsQuery, MarketplaceTranslationsQueryVariables>;

--- a/src/graphql/translations/marketplaceTranslations.graphql
+++ b/src/graphql/translations/marketplaceTranslations.graphql
@@ -1,0 +1,38 @@
+fragment IntegrationTranslation on Integration {
+  name
+  description
+  definition
+  category
+  overview
+  configPages
+  requiredConfigVariables {
+    nodes {
+      key
+      description
+      inputs {
+        nodes {
+          name
+          meta
+        }
+      }
+    }
+  }
+}
+
+query MarketplaceTranslations {
+  marketplaceIntegrations {
+    nodes {
+      id
+      ...IntegrationTranslation
+      instances(isSystem: false) {
+        nodes {
+          id
+          name
+          integration {
+            ...IntegrationTranslation
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Generate typed GraphQL operation artifacts.

Part **2/24** of the native incur migration. This PR targets `incur-01-runtime`; the stack integrates into the long-lived `agent` branch. Review this diff against its immediate base.

The source contract scans exclude temporary scaffold output so concurrent generator tests cannot race with file reads.

Validation: format/lint, TypeScript, bundle, and **299 passing tests** (3 skipped) on Node 24. CI also checks Node 22/24/26 and Windows.

Review size: **1,459 handwritten changed lines**, plus 12,177 generated or captured artifact lines (marked for GitHub collapsing); counts include additions and deletions.

[Stack review guide](https://github.com/prismatic-io/prism/blob/incur-24-review-evidence/docs/incur-pr-stack.md). Merge bottom-up; rebase descendants after a squash merge.
