### PR TITLE
[incur 03/24] Add typed GraphQL transport and shared API helpers

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,3 +1,5 @@
+import { AuthenticatedUserQueryDocument as AUTHENTICATED_USER_QUERY } from "./graphql/operations/AuthenticatedUserQuery.generated.js";
+import { ListUserTenantsDocument as LIST_USER_TENANTS } from "./graphql/operations/ListUserTenants.generated.js";
 import crypto from "crypto";
 import http from "http";
 import { jwtDecode } from "jwt-decode";
@@ -5,7 +7,7 @@ import inquirer from "inquirer";
 import chalk from "chalk";
 import { deleteProfile, getActiveProfileName, writeActiveProfile } from "./config.js";
 import { type AuthContext, getAuthContext, getPrismaticUrl } from "./context.js";
-import { gqlRequest, gql } from "./graphql.js";
+import { gqlRequest } from "./graphql.js";
 import type { AddressInfo } from "net";
 import open from "open";
 import { whoAmI } from "./utils/user/query.js";
@@ -319,30 +321,12 @@ export interface Tenant {
   url: string;
   orgName: string;
   awsRegion: string;
-  systemSuspended: boolean;
-}
-
-interface ListUserTenantsResponse {
-  listUserTenants: {
-    nodes: Tenant[];
-  };
+  systemSuspended: boolean | null;
 }
 
 export const fetchUserTenants = async (): Promise<Tenant[]> => {
-  const result = await gqlRequest<ListUserTenantsResponse>({
-    document: gql`
-      query ListUserTenants {
-        listUserTenants {
-          nodes {
-            tenantId
-            url
-            orgName
-            awsRegion
-            systemSuspended
-          }
-        }
-      }
-    `,
+  const result = await gqlRequest({
+    document: LIST_USER_TENANTS,
   });
 
   return result.listUserTenants.nodes;
@@ -511,13 +495,7 @@ export const isLoggedIn = async (): Promise<boolean> => {
 
   try {
     await gqlRequest({
-      document: gql`
-        query {
-          authenticatedUser {
-            id
-          }
-        }
-      `,
+      document: AUTHENTICATED_USER_QUERY,
     });
   } catch {
     return false;

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,10 +1,12 @@
+import { print } from "graphql";
+import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
 import { URL } from "url";
 import { getAccessToken } from "./auth.js";
 import { getPrismaticUrl } from "./context.js";
 import { fetch } from "./utils/http.js";
 
-interface GQLRequest<TVariables = Record<string, unknown>> {
-  document: string;
+interface GQLRequest<TData, TVariables = Record<string, unknown>> {
+  document: string | TypedDocumentNode<TData, TVariables>;
   variables?: TVariables;
 }
 
@@ -73,14 +75,22 @@ const formatError = (field: string, messages: string[]) => {
   return `${field}: ${message}`;
 };
 
+export const requireResource = <T>(value: T | null | undefined, name: string): T => {
+  if (value === null || value === undefined) {
+    throw Object.assign(new Error(`${name} not found`), { code: "NOT_FOUND", exitCode: 1 });
+  }
+  return value;
+};
+
+// Raw command queries keep their existing typing until the next PR migrates them.
 export const gqlRequest = async <T = any, TVariables = Record<string, unknown>>({
   document,
   variables,
-}: GQLRequest<TVariables>): Promise<T> => {
+}: GQLRequest<T, TVariables>): Promise<T> => {
   const accessToken = await getAccessToken();
   const url = new URL("/api", await getPrismaticUrl()).toString();
 
-  const query = document;
+  const query = typeof document === "string" ? document : print(document);
 
   if (process.env.PRISMATIC_PRINT_REQUESTS) {
     console.log("=================================");

--- a/src/utils/avatar.ts
+++ b/src/utils/avatar.ts
@@ -1,15 +1,10 @@
+import { GetPresignedUrlDocument as GET_PRESIGNED_URL } from "../graphql/operations/getPresignedUrl.generated.js";
+import { MediaType } from "../graphql/schema.generated.js";
 import mimetypes from "mime-types";
 import { basename, extname } from "path";
 import { fs } from "../fs.js";
-import { gql, gqlRequest } from "../graphql.js";
+import { gqlRequest } from "../graphql.js";
 import { fetch } from "./http.js";
-
-interface GetPresignedUrlResponse {
-  uploadMedia: {
-    uploadUrl: string;
-    objectUrl: string;
-  };
-}
 
 /**
  *
@@ -20,31 +15,16 @@ interface GetPresignedUrlResponse {
 export const uploadAvatar = async (objectId: string, iconPath: string) => {
   const {
     uploadMedia: { uploadUrl, objectUrl },
-  } = await gqlRequest<GetPresignedUrlResponse>({
-    document: gql`
-      query getPresignedUrl(
-        $objectId: ID!
-        $fileName: String!
-        $mediaType: MediaType!
-      ) {
-        uploadMedia(
-          objectId: $objectId
-          fileName: $fileName
-          mediaType: $mediaType
-        ) {
-          uploadUrl
-          objectUrl
-          error
-        }
-      }
-    `,
+  } = await gqlRequest({
+    document: GET_PRESIGNED_URL,
     variables: {
       objectId,
       fileName: basename(iconPath),
-      mediaType: "AVATAR",
+      mediaType: MediaType.Avatar,
     },
   });
 
+  if (!uploadUrl || !objectUrl) throw new Error("Unable to create avatar upload URL");
   await fetch(uploadUrl, {
     method: "PUT",
     body: await fs.readFile(iconPath),

--- a/src/utils/component/deleteByKey.ts
+++ b/src/utils/component/deleteByKey.ts
@@ -1,33 +1,18 @@
-import { gql, gqlRequest } from "../../graphql.js";
+import { ComponentDocument as COMPONENT } from "../../graphql/operations/component.generated.js";
+import { DeleteComponent2Document as DELETE_COMPONENT2 } from "../../graphql/operations/deleteComponent2.generated.js";
+import { gqlRequest } from "../../graphql.js";
 
 export const deleteComponentByKey = async (key: string) => {
   // Fetch a component by key
   const result = await gqlRequest({
-    document: gql`
-      query component($key: String!) {
-        components(key: $key, public: false) {
-          nodes {
-            id
-          }
-        }
-      }
-    `,
+    document: COMPONENT,
     variables: {
       key,
     },
   });
   // Delete the component by ID
   await gqlRequest({
-    document: gql`
-      mutation deleteComponent($id: ID!) {
-        deleteComponent(input: { id: $id }) {
-          errors {
-            field
-            messages
-          }
-        }
-      }
-    `,
+    document: DELETE_COMPONENT2,
     variables: { id: result.components.nodes[0].id },
   });
 };

--- a/src/utils/component/publish.ts
+++ b/src/utils/component/publish.ts
@@ -1,8 +1,11 @@
+import { Component2Document as COMPONENT2 } from "../../graphql/operations/component2.generated.js";
+import { PublishComponentDocument as PUBLISH_COMPONENT } from "../../graphql/operations/publishComponent.generated.js";
+import type { PublishComponentMutationVariables } from "../../graphql/operations/publishComponent.generated.js";
 import crypto from "crypto";
 import mimetypes from "mime-types";
 import { extname } from "path";
 import { fs } from "../../fs.js";
-import { gql, gqlRequest } from "../../graphql.js";
+import { gqlRequest } from "../../graphql.js";
 import { fetch } from "../http.js";
 import { ux } from "../ux.js";
 import type { ComponentDefinition } from "./index.js";
@@ -25,15 +28,7 @@ export const checkPackageSignature = async (
 ): Promise<boolean> => {
   // Retrieve the existing signature of the component if it exists.
   const results = await gqlRequest({
-    document: gql`
-      query component($key: String!, $public: Boolean!) {
-        components(key: $key, public: $public) {
-          nodes {
-            signature
-          }
-        }
-      }
-    `,
+    document: COMPONENT2,
     variables: {
       key,
       public: isPublic ?? false,
@@ -94,7 +89,7 @@ export const publishDefinition = async (
       avatarIconUploadUrl?: string;
     }
   >;
-  versionNumber: string;
+  versionNumber: number;
 }> => {
   const componentDefinition: Record<string, unknown> = Object.entries(rest).reduce(
     (result, [key, value]) =>
@@ -136,53 +131,7 @@ export const publishDefinition = async (
 
   // Initiate start of the publish procedure by sending config data and receive back presigned s3 URL
   const result = await gqlRequest({
-    document: gql`
-      mutation publishComponent(
-        $definition: ComponentDefinitionInput!
-        $actions: [ActionDefinitionInput]!
-        $triggers: [TriggerDefinitionInput]
-        $dataSources: [DataSourceDefinitionInput]
-        $connections: [ConnectionDefinitionInput]
-        $comment: String
-        $customer: ID
-        $attributes: String
-      ) {
-        publishComponent(
-          input: {
-            definition: $definition
-            actions: $actions
-            triggers: $triggers
-            dataSources: $dataSources
-            connections: $connections
-            comment: $comment
-            customer: $customer
-            attributes: $attributes
-          }
-        ) {
-          publishResult {
-            component {
-              id
-              versionNumber
-            }
-            iconUploadUrl
-            packageUploadUrl
-            sourceUploadUrl
-            connectionIconUploadUrls {
-              connectionKey
-              iconUploadUrl
-            }
-            connectionAvatarIconUploadUrls {
-              connectionKey
-              iconUploadUrl
-            }
-          }
-          errors {
-            field
-            messages
-          }
-        }
-      }
-    `,
+    document: PUBLISH_COMPONENT,
     variables: {
       definition: componentDefinition,
       actions: actionDefinitions,
@@ -192,22 +141,28 @@ export const publishDefinition = async (
       comment,
       customer,
       attributes: attributes ? JSON.stringify(attributes) : undefined,
-    },
+    } as unknown as PublishComponentMutationVariables,
   });
 
+  const publishResult = result.publishComponent?.publishResult;
+  if (!publishResult) throw new Error("Component publish returned no upload information");
   const {
     iconUploadUrl,
     packageUploadUrl,
     sourceUploadUrl,
     connectionIconUploadUrls,
     connectionAvatarIconUploadUrls,
-    component: { versionNumber },
-  } = result.publishComponent.publishResult;
+    component,
+  } = publishResult;
+  if (!iconUploadUrl || !packageUploadUrl || !component) {
+    throw new Error("Component publish returned incomplete upload information");
+  }
+  const { versionNumber } = component;
 
   const uploadUrls: Record<string, { iconUploadUrl?: string; avatarIconUploadUrl?: string }> = {};
 
   (
-    connectionIconUploadUrls as Array<{
+    (connectionIconUploadUrls ?? []).filter((value) => value !== null) as Array<{
       connectionKey: string;
       iconUploadUrl: string;
     }>
@@ -216,7 +171,7 @@ export const publishDefinition = async (
   });
 
   (
-    connectionAvatarIconUploadUrls as Array<{
+    (connectionAvatarIconUploadUrls ?? []).filter((value) => value !== null) as Array<{
       connectionKey: string;
       iconUploadUrl: string;
     }>
@@ -230,7 +185,7 @@ export const publishDefinition = async (
   return {
     iconUploadUrl,
     packageUploadUrl,
-    sourceUploadUrl,
+    sourceUploadUrl: sourceUploadUrl ?? undefined,
     connectionIconUploadUrls: uploadUrls,
     versionNumber,
   };

--- a/src/utils/component/query.ts
+++ b/src/utils/component/query.ts
@@ -1,26 +1,16 @@
-import { gql, gqlRequest } from "../../graphql.js";
+import { ComponentsDocument as COMPONENTS } from "../../graphql/operations/components.generated.js";
+import { gqlRequest } from "../../graphql.js";
 
 interface ComponentInfo {
   id: string;
   key: string;
-  versionNumber: string;
+  versionNumber: number;
   public: boolean;
 }
 
 export const queryComponentKeys = async (keys: string[]): Promise<ComponentInfo[]> => {
   const result = await gqlRequest({
-    document: gql`
-      query components($keys: [String]!) {
-        components(key_In: $keys) {
-          nodes {
-            id
-            key
-            versionNumber
-            public
-          }
-        }
-      }
-    `,
+    document: COMPONENTS,
     variables: { keys },
   });
 

--- a/src/utils/component/signature.ts
+++ b/src/utils/component/signature.ts
@@ -1,4 +1,5 @@
-import { gql, gqlRequest } from "../../graphql.js";
+import { Component3Document as COMPONENT3 } from "../../graphql/operations/component3.generated.js";
+import { gqlRequest } from "../../graphql.js";
 import type { ComponentDefinition } from "./index.js";
 
 interface GetPackageSignatureFromApiProps {
@@ -11,15 +12,7 @@ export const getPackageSignatureFromApi = async ({
   packageSignature,
 }: GetPackageSignatureFromApiProps): Promise<string | null> => {
   const results = await gqlRequest({
-    document: gql`
-      query component($key: String!, $public: Boolean!) {
-        components(key: $key, public: $public) {
-          nodes {
-            signature
-          }
-        }
-      }
-    `,
+    document: COMPONENT3,
     variables: {
       key: componentDefinition.key,
       public: componentDefinition.public ?? false,

--- a/src/utils/execution/logs.ts
+++ b/src/utils/execution/logs.ts
@@ -1,6 +1,8 @@
+import { PollExecutionDocument as POLL_EXECUTION } from "../../graphql/operations/pollExecution.generated.js";
+import { LogsDocument as LOGS } from "../../graphql/operations/logs.generated.js";
 import chalk from "chalk";
 import { promisify } from "util";
-import { gql, gqlRequest } from "../../graphql.js";
+import { gqlRequest } from "../../graphql.js";
 import { formatTimestamp } from "../date.js";
 import { ux } from "../ux.js";
 
@@ -18,17 +20,11 @@ export const waitForExecutionCompletion = (executionId: string): Promise<void> =
     const interval = setInterval(async () => {
       try {
         const result = await gqlRequest({
-          document: gql`
-            query pollExecution($executionId: ID!) {
-              executionResult(id: $executionId) {
-                endedAt
-              }
-            }
-          `,
+          document: POLL_EXECUTION,
           variables: { executionId },
         });
 
-        const { endedAt } = result.executionResult;
+        const endedAt = result.executionResult?.endedAt;
         if (endedAt) {
           clearInterval(interval);
 
@@ -51,23 +47,11 @@ export const displayLogs = async (executionId: string): Promise<void> => {
 
   // TODO: Add paging
   const result = await gqlRequest({
-    document: gql`
-      query logs($executionId: ID!) {
-        executionResult(id: $executionId) {
-          logs(orderBy: { field: TIMESTAMP, direction: ASC }) {
-            nodes {
-              timestamp
-              severity
-              message
-            }
-          }
-        }
-      }
-    `,
+    document: LOGS,
     variables: { executionId },
   });
 
-  const logs: Log[] = result.executionResult.logs.nodes;
+  const logs: Log[] = result.executionResult?.logs.nodes ?? [];
   ux.table(
     logs,
     {

--- a/src/utils/execution/stepResults.ts
+++ b/src/utils/execution/stepResults.ts
@@ -1,7 +1,8 @@
+import { ExecutionResultsDocument as EXECUTION_RESULTS } from "../../graphql/operations/executionResults.generated.js";
 import { decode } from "@msgpack/msgpack";
 import { extension } from "mime-types";
 import { fs } from "../../fs.js";
-import { gql, gqlRequest } from "../../graphql.js";
+import { gqlRequest } from "../../graphql.js";
 import { fetch } from "../http.js";
 
 export interface DeserializeResult {
@@ -54,22 +55,11 @@ export const parseData = (
 
 const getFinalStepResult = async (executionId: string) => {
   const result = await gqlRequest({
-    document: gql`
-      query executionResults($executionId: ID!) {
-        executionResult(id: $executionId) {
-          stepResults(last: 1) {
-            nodes {
-              id
-              stepName
-              resultsUrl
-            }
-          }
-        }
-      }
-    `,
+    document: EXECUTION_RESULTS,
     variables: { executionId },
   });
-  const { resultsUrl } = result.executionResult.stepResults.nodes[0];
+  const resultsUrl = result.executionResult?.stepResults.nodes[0]?.resultsUrl;
+  if (!resultsUrl) throw new Error(`Execution ${executionId} has no final step result`);
   const response = await fetch(resultsUrl);
   const arrayBuffer = await response.arrayBuffer();
   const resultsBuffer = Buffer.from(arrayBuffer);

--- a/src/utils/integration/export.ts
+++ b/src/utils/integration/export.ts
@@ -1,4 +1,5 @@
-import { gql, gqlRequest } from "../../graphql.js";
+import { ExportDocument as EXPORT } from "../../graphql/operations/export.generated.js";
+import { gqlRequest } from "../../graphql.js";
 import { loadYaml } from "../serialize.js";
 
 /** The version of the Integration definition to request.
@@ -67,26 +68,14 @@ export const exportDefinition = async ({
   definitionVersion = INTEGRATION_DEFINITION_VERSION,
 }: ExportDefinitionProps): Promise<IntegrationDefinition> => {
   const result = await gqlRequest({
-    document: gql`
-      query export(
-        $id: ID!
-        $version: Int!
-        $useLatestComponentVersions: Boolean!
-      ) {
-        integration(id: $id) {
-          definition(
-            version: $version
-            useLatestComponentVersions: $useLatestComponentVersions
-          )
-        }
-      }
-    `,
+    document: EXPORT,
     variables: {
       id: integrationId,
       version: definitionVersion,
       useLatestComponentVersions: latestComponents,
     },
   });
-  const definition: string = result.integration.definition;
+  const definition = result.integration?.definition;
+  if (!definition) throw new Error(`Integration not found: ${integrationId}`);
   return loadYaml(definition) as IntegrationDefinition;
 };

--- a/src/utils/integration/flows.ts
+++ b/src/utils/integration/flows.ts
@@ -1,12 +1,9 @@
 import inquirer from "inquirer";
-import type { GetExecutionLogsQuery } from "../../graphql/executions/getExecutionLogs.generated.js";
-import GET_EXECUTION_LOGS from "../../graphql/executions/getExecutionLogs.graphql";
-import type { GetExecutionStepResultsQuery } from "../../graphql/executions/getExecutionStepResults.generated.js";
-import GET_EXECUTION_STEP_RESULTS from "../../graphql/executions/getExecutionStepResults.graphql";
-import type { IsCniExecutionCompleteQuery } from "../../graphql/executions/isCniExecutionComplete.generated.js";
-import IS_CNI_EXECUTION_COMPLETE from "../../graphql/executions/isCniExecutionComplete.graphql";
+import { GetExecutionLogsDocument as GET_EXECUTION_LOGS } from "../../graphql/executions/getExecutionLogs.generated.js";
+import { GetExecutionStepResultsDocument as GET_EXECUTION_STEP_RESULTS } from "../../graphql/executions/getExecutionStepResults.generated.js";
+import { IsCniExecutionCompleteDocument as IS_CNI_EXECUTION_COMPLETE } from "../../graphql/executions/isCniExecutionComplete.generated.js";
 import type { GetIntegrationFlowsQuery } from "../../graphql/integrations/getIntegrationFlows.generated.js";
-import GET_INTEGRATION_FLOWS from "../../graphql/integrations/getIntegrationFlows.graphql";
+import { GetIntegrationFlowsDocument as GET_INTEGRATION_FLOWS } from "../../graphql/integrations/getIntegrationFlows.generated.js";
 import { gqlRequest } from "../../graphql.js";
 import { handleError } from "../errors.js";
 
@@ -22,7 +19,7 @@ export async function getIntegrationFlows(integrationId: string): Promise<Integr
   let cursor: string | undefined;
 
   while (hasNextPage) {
-    const result: GetIntegrationFlowsQuery = await gqlRequest<GetIntegrationFlowsQuery>({
+    const result: GetIntegrationFlowsQuery = await gqlRequest({
       document: GET_INTEGRATION_FLOWS,
       variables: {
         id: integrationId,
@@ -57,7 +54,7 @@ export interface FetchLogsResult {
 }
 
 export async function getExecutionLogs(executionId: string, nextCursor?: string) {
-  return await gqlRequest<GetExecutionLogsQuery>({
+  return await gqlRequest({
     document: GET_EXECUTION_LOGS,
     variables: {
       executionId,
@@ -74,7 +71,7 @@ export interface StepResultNode {
 }
 
 export async function getExecutionStepResults(executionId: string, nextCursor?: string) {
-  return await gqlRequest<GetExecutionStepResultsQuery>({
+  return await gqlRequest({
     document: GET_EXECUTION_STEP_RESULTS,
     variables: {
       executionId,
@@ -84,7 +81,7 @@ export async function getExecutionStepResults(executionId: string, nextCursor?: 
 }
 
 export async function isCniExecutionComplete(executionId: string) {
-  const result = await gqlRequest<IsCniExecutionCompleteQuery>({
+  const result = await gqlRequest({
     document: IS_CNI_EXECUTION_COMPLETE,
     variables: {
       executionId,

--- a/src/utils/integration/import.ts
+++ b/src/utils/integration/import.ts
@@ -1,7 +1,12 @@
+import { ImportIntegrationDocument as IMPORT_INTEGRATION } from "../../graphql/operations/importIntegration.generated.js";
+import { CommitAvatarUpload2Document as COMMIT_AVATAR_UPLOAD2 } from "../../graphql/operations/commitAvatarUpload2.generated.js";
+import { SetInstanceApiKeysDocument as SET_INSTANCE_API_KEYS } from "../../graphql/operations/setInstanceApiKeys.generated.js";
+import { Component4Document as COMPONENT4 } from "../../graphql/operations/component4.generated.js";
+import { Integration2Document as INTEGRATION2 } from "../../graphql/operations/integration2.generated.js";
 import chardet from "chardet";
 import { ux } from "@oclif/core";
 import { createRequire } from "node:module";
-import { gqlRequest, gql } from "../../graphql.js";
+import { gqlRequest } from "../../graphql.js";
 import { uploadAvatar } from "../../utils/avatar.js";
 import { exists, fs } from "../../fs.js";
 import { resolve } from "path";
@@ -62,63 +67,8 @@ export const importDefinition = async (
   integrationId?: string,
   replace?: boolean,
 ): Promise<ImportDefinitionResult> => {
-  const result = await gqlRequest<{
-    importIntegration: {
-      integration: Integration;
-      errors: Array<{
-        field: string;
-        messages: string[];
-      }>;
-    };
-  }>({
-    document: gql`
-      mutation importIntegration(
-        $definition: String!
-        $integrationId: ID
-        $replace: Boolean
-      ) {
-        importIntegration(
-          input: {
-            definition: $definition
-            integrationId: $integrationId
-            replace: $replace
-          }
-        ) {
-          integration {
-            id
-            flows {
-              nodes {
-                id
-                name
-              }
-            }
-            testConfigVariables(status: "pending") {
-              nodes {
-                id
-                authorizeUrl
-              }
-            }
-            systemInstance {
-              id
-              flowConfigs {
-                nodes {
-                  id
-                  flow {
-                    id
-                    name
-                  }
-                  apiKeys
-                }
-              }
-            }
-          }
-          errors {
-            field
-            messages
-          }
-        }
-      }
-    `,
+  const result = await gqlRequest({
+    document: IMPORT_INTEGRATION,
     variables: {
       definition,
       integrationId,
@@ -126,16 +76,24 @@ export const importDefinition = async (
     },
   });
 
-  const integration = result.importIntegration.integration;
+  const integration = result.importIntegration?.integration;
   if (!integration) {
     throw new Error("Failed to import integration");
   }
   return {
     integrationId: integration.id,
-    pendingAuthorizations: integration.testConfigVariables.nodes.map(
-      ({ id, authorizeUrl: url }) => ({ id, url }),
+    pendingAuthorizations: integration.testConfigVariables.nodes.flatMap(({ id, authorizeUrl }) =>
+      authorizeUrl ? [{ id, url: authorizeUrl }] : [],
     ),
-    systemInstance: integration.systemInstance,
+    systemInstance: {
+      ...integration.systemInstance,
+      flowConfigs: {
+        nodes: integration.systemInstance.flowConfigs.nodes.map((flowConfig) => ({
+          ...flowConfig,
+          apiKeys: flowConfig.apiKeys?.filter((key): key is string => key !== null) ?? [],
+        })),
+      },
+    },
   };
 };
 
@@ -144,21 +102,7 @@ const setIntegrationAvatar = async (integrationId: string, iconPath: string): Pr
     const avatarUrl = await uploadAvatar(integrationId, iconPath);
 
     await gqlRequest({
-      document: gql`
-        mutation commitAvatarUpload($integrationId: ID!, $avatarUrl: String!) {
-          updateIntegration(
-            input: { id: $integrationId, avatarUrl: $avatarUrl }
-          ) {
-            integration {
-              id
-            }
-            errors {
-              field
-              messages
-            }
-          }
-        }
-      `,
+      document: COMMIT_AVATAR_UPLOAD2,
       variables: {
         integrationId,
         avatarUrl,
@@ -397,64 +341,15 @@ const setFlowTestApiKeys = async ({
   instanceId,
   flowConfigs,
 }: SetFlowTestApiKeysParams): Promise<void> => {
-  const result = await gqlRequest<{
-    updateInstance: {
-      instance: {
-        id: string;
-        flowConfigs: {
-          nodes: Array<{
-            id: string;
-            apiKeys: string[];
-            flow: {
-              id: string;
-            };
-          }>;
-        };
-      };
-      errors: Array<{
-        field: string;
-        messages: string[];
-      }>;
-    };
-  }>({
-    document: gql`
-      mutation setInstanceApiKeys(
-        $instanceId: ID!
-        $flowConfigs: [InputInstanceFlowConfig]
-      ) {
-        updateInstance(
-          input: {
-            id: $instanceId
-            flowConfigs: $flowConfigs
-            configMode: "INSTANCE"
-          }
-        ) {
-          instance {
-            id
-            flowConfigs {
-              nodes {
-                id
-                apiKeys
-                flow {
-                  id
-                }
-              }
-            }
-          }
-          errors {
-            field
-            messages
-          }
-        }
-      }
-    `,
+  const result = await gqlRequest({
+    document: SET_INSTANCE_API_KEYS,
     variables: {
       instanceId,
       flowConfigs,
     },
   });
 
-  if (result.updateInstance.errors?.length) {
+  if (result.updateInstance?.errors?.length) {
     throw new Error(
       `Failed to set test API keys: ${result.updateInstance.errors
         .map((e: { messages: string[] }) => e.messages.join(", "))
@@ -508,26 +403,13 @@ export const loadCodeNativeIntegrationEntryPoint = async (): Promise<{
 
 export const waitForCodeNativeComponentAvailable = async (
   componentKey: string,
-  versionNumber: string,
+  versionNumber: number,
   attemptNumber = 0,
   maximumAttempts = 10,
 ): Promise<boolean> => {
   // Wait until component becomes available
   const results = await gqlRequest({
-    document: gql`
-      query component($componentKey: String!, $versionNumber: Int!) {
-        components(
-          key: $componentKey
-          versionNumber: $versionNumber
-          public: false
-          includeComponentsForCodeNativeIntegrations: true
-        ) {
-          nodes {
-            id
-          }
-        }
-      }
-    `,
+    document: COMPONENT4,
     variables: {
       componentKey,
       versionNumber,
@@ -553,19 +435,13 @@ export const waitForCodeNativeComponentAvailable = async (
 
 export const getIntegrationDefinition = async (integrationId: string): Promise<string> => {
   const result = await gqlRequest({
-    document: gql`
-      query integration($integrationId: ID!) {
-        integration(id: $integrationId) {
-          definition
-        }
-      }
-    `,
+    document: INTEGRATION2,
     variables: { integrationId },
   });
   if (!result.integration) {
     throw new Error(`Integration not found: ${integrationId}`);
   }
-  return result.integration.definition;
+  return result.integration.definition ?? "";
 };
 
 export const compareConfigVars = async (current: string, next: string): Promise<Array<string>> => {

--- a/src/utils/integration/invoke.ts
+++ b/src/utils/integration/invoke.ts
@@ -1,8 +1,6 @@
-import DELETE_INTEGRATION from "../../graphql/integrations/deleteIntegration.graphql";
-import type { GetIntegrationFlowQuery } from "../../graphql/integrations/getIntegrationFlow.generated.js";
-import GET_INTEGRATION_FLOW from "../../graphql/integrations/getIntegrationFlow.graphql";
-import type { TestIntegrationFlowMutation } from "../../graphql/integrations/testIntegrationFlow.generated.js";
-import TEST_INTEGRATION_FLOW from "../../graphql/integrations/testIntegrationFlow.graphql";
+import { DeleteIntegrationDocument as DELETE_INTEGRATION } from "../../graphql/integrations/deleteIntegration.generated.js";
+import { GetIntegrationFlowDocument as GET_INTEGRATION_FLOW } from "../../graphql/integrations/getIntegrationFlow.generated.js";
+import { TestIntegrationFlowDocument as TEST_INTEGRATION_FLOW } from "../../graphql/integrations/testIntegrationFlow.generated.js";
 import { gqlRequest } from "../../graphql.js";
 
 /** Return Flow ID of given flow name on specified Integration. */
@@ -11,7 +9,7 @@ export const getIntegrationFlow = async (
   flowName: string,
 ): Promise<string> => {
   // TODO: Make flows searchable by name.
-  const result = await gqlRequest<GetIntegrationFlowQuery>({
+  const result = await gqlRequest({
     document: GET_INTEGRATION_FLOW,
     variables: { id: integrationId },
   });
@@ -68,7 +66,7 @@ export const runIntegrationFlow = async ({
     throw new Error("Either flowId or flowName must be provided");
   }
 
-  const result = await gqlRequest<TestIntegrationFlowMutation>({
+  const result = await gqlRequest({
     document: TEST_INTEGRATION_FLOW,
     variables: { id: integrationFlowId },
   });

--- a/src/utils/integration/mutate.ts
+++ b/src/utils/integration/mutate.ts
@@ -1,40 +1,23 @@
-import { gql, gqlRequest } from "../../graphql.js";
+import { GetSystemInstanceIdDocument as GET_SYSTEM_INSTANCE_ID } from "../../graphql/operations/getSystemInstanceId.generated.js";
+import { UpdateInstanceGlobalDebugDocument as UPDATE_INSTANCE_GLOBAL_DEBUG } from "../../graphql/operations/updateInstanceGlobalDebug.generated.js";
+import { gqlRequest } from "../../graphql.js";
 
 export const setGlobalDebugOnSystemInstance = async (
   integrationId: string,
   globalDebug: boolean,
 ): Promise<void> => {
   const systemInstanceResult = await gqlRequest({
-    document: gql`
-      query getSystemInstanceId($integrationId: ID!) {
-        integration(id: $integrationId) {
-          systemInstance {
-            id
-          }
-        }
-      }
-    `,
+    document: GET_SYSTEM_INSTANCE_ID,
     variables: {
       integrationId,
     },
   });
 
-  const instanceId = systemInstanceResult.integration.systemInstance.id;
+  const instanceId = systemInstanceResult.integration?.systemInstance.id;
+  if (!instanceId) throw new Error(`Integration not found: ${integrationId}`);
 
   await gqlRequest({
-    document: gql`
-      mutation updateInstanceGlobalDebug($instanceId: ID!, $globalDebug: Boolean!) {
-        updateInstance(input: { id: $instanceId, globalDebug: $globalDebug }) {
-          instance {
-            id
-          }
-          errors {
-            field
-            messages
-          }
-        }
-      }
-    `,
+    document: UPDATE_INSTANCE_GLOBAL_DEBUG,
     variables: {
       instanceId,
       globalDebug,

--- a/src/utils/integration/query.ts
+++ b/src/utils/integration/query.ts
@@ -1,6 +1,7 @@
-import type { GetIntegrationSystemInstanceQuery } from "../../graphql/integrations/getIntegrationSystemInstance.generated.js";
-import GET_INTEGRATION_SYSTEM_INSTANCE from "../../graphql/integrations/getIntegrationSystemInstance.graphql";
-import { gql, gqlRequest } from "../../graphql.js";
+import { Integration3Document as INTEGRATION3 } from "../../graphql/operations/integration3.generated.js";
+import { StateDocument as STATE } from "../../graphql/operations/state.generated.js";
+import { GetIntegrationSystemInstanceDocument as GET_INTEGRATION_SYSTEM_INSTANCE } from "../../graphql/integrations/getIntegrationSystemInstance.generated.js";
+import { gqlRequest } from "../../graphql.js";
 
 interface IntegrationByNameResult {
   id: string;
@@ -10,15 +11,7 @@ export const integrationByName = async (
   name: string,
 ): Promise<IntegrationByNameResult | undefined> => {
   const result = await gqlRequest({
-    document: gql`
-      query integration($name: String!) {
-        integrations(name: $name) {
-          nodes {
-            id
-          }
-        }
-      }
-    `,
+    document: INTEGRATION3,
     variables: { name },
   });
   const [integration, ...rest]: { id: string }[] = result.integrations.nodes;
@@ -31,7 +24,7 @@ export const integrationByName = async (
 export const getIntegrationSystemInstance = async (
   integrationId: string,
 ): Promise<{ isCodeNative?: boolean; isConfigured: boolean; systemInstanceId?: string }> => {
-  const result = await gqlRequest<GetIntegrationSystemInstanceQuery>({
+  const result = await gqlRequest({
     document: GET_INTEGRATION_SYSTEM_INSTANCE,
     variables: {
       integrationId,
@@ -53,29 +46,17 @@ export const pollForActiveConfigVarState = async (
     const interval = setInterval(async () => {
       try {
         const result = await gqlRequest({
-          document: gql`
-            query state($integrationId: ID!) {
-              integration(id: $integrationId) {
-                testConfigVariables(status_In: ["pending", "active", "error"]) {
-                  nodes {
-                    id
-                    status
-                  }
-                }
-              }
-            }
-          `,
+          document: STATE,
           variables: { integrationId },
         });
 
-        const testConfigVariables: { id: string; status: string }[] =
-          result.integration.testConfigVariables.nodes;
+        const testConfigVariables = result.integration?.testConfigVariables.nodes ?? [];
 
-        const [{ status: serverStatus }] = testConfigVariables.filter(
+        const [{ status: serverStatus } = { status: null }] = testConfigVariables.filter(
           ({ id }) => id === configVarId,
         );
 
-        const status = serverStatus.toLowerCase();
+        const status = serverStatus?.toLowerCase();
         if (status !== "pending") {
           clearInterval(interval);
           resolve(status === "active");

--- a/src/utils/user/query.ts
+++ b/src/utils/user/query.ts
@@ -1,4 +1,5 @@
-import { gql, gqlRequest } from "../../graphql.js";
+import { WhoamiDocument as WHOAMI } from "../../graphql/operations/whoami.generated.js";
+import { gqlRequest } from "../../graphql.js";
 
 interface OrgUser {
   userType: "org";
@@ -27,25 +28,25 @@ interface CustomerUser {
 type User = OrgUser | CustomerUser;
 
 export const whoAmI = async (): Promise<User> => {
-  const { authenticatedUser } = await gqlRequest<{ authenticatedUser: User }>({
-    document: gql`
-      query whoami {
-        authenticatedUser {
-          name
-          email
-          tenantId
-          org {
-            id
-            name
-          }
-          customer {
-            id
-            name
-          }
-        }
-      }
-    `,
+  const { authenticatedUser } = await gqlRequest({
+    document: WHOAMI,
   });
-  authenticatedUser.userType = authenticatedUser.org ? "org" : "customer";
-  return authenticatedUser;
+  if (authenticatedUser.org) {
+    return {
+      ...authenticatedUser,
+      userType: "org",
+      org: authenticatedUser.org,
+      customer: undefined,
+    };
+  }
+  if (authenticatedUser.customer) {
+    return {
+      ...authenticatedUser,
+      userType: "customer",
+      customer: authenticatedUser.customer,
+      org: undefined,
+      tenantId: undefined,
+    };
+  }
+  throw new Error("Authenticated user is not associated with an organization or customer");
 };


### PR DESCRIPTION
Add typed GraphQL transport and shared API helpers.

Part **3/24** of the native incur migration. This PR targets `incur-02-graphql-artifacts`; the stack integrates into the long-lived `agent` branch. Review this diff against its immediate base.

Validation: format/lint, TypeScript, bundle, and **299 passing tests** (3 skipped) on Node 24. CI also checks Node 22/24/26 and Windows.

Review size: **622 handwritten changed lines**; counts include additions and deletions.

[Stack review guide](https://github.com/prismatic-io/prism/blob/incur-24-review-evidence/docs/incur-pr-stack.md). Merge bottom-up; rebase descendants after a squash merge.
