### PR TITLE
[incur 05/24] Introduce native incur schemas and request middleware

### DIFF
--- a/src/command-schemas.ts
+++ b/src/command-schemas.ts
@@ -1,0 +1,33 @@
+import { z } from "incur";
+export const globalOptions = z.object({
+  agent: z.boolean().optional().describe("Force structured output optimized for AI agents"),
+  printRequests: z.boolean().optional().describe("Print all GraphQL requests that are issued"),
+  profile: z.string().optional().describe("Use a profile"),
+  quiet: z.boolean().default(false).describe("Reduce helpful notes and text"),
+  readOnly: z.boolean().default(false).describe("Reject commands that can modify remote state"),
+  yes: z.boolean().default(false).describe("Approve non-interactive confirmation prompts"),
+});
+
+export const environmentOptions = z.object({
+  PRISMATIC_URL: z.string().optional().describe("Prismatic stack URL"),
+  PRISM_PROFILE: z.string().optional().describe("Authentication profile (overridden by --profile)"),
+  PRISM_CONFIG_FILE: z.string().optional().describe("Path to the Prism profile configuration file"),
+  PRISM_ACCESS_TOKEN: z
+    .string()
+    .optional()
+    .describe("Access token for non-interactive authentication"),
+  PRISM_REFRESH_TOKEN: z
+    .string()
+    .optional()
+    .describe("Refresh token for non-interactive authentication"),
+  PRISMATIC_TENANT_ID: z
+    .string()
+    .optional()
+    .describe("Tenant associated with environment credentials"),
+  PRISM_AGENT: z.string().optional().describe("Force agent mode when set to true or 1"),
+  PRISM_AGENT_MODE: z.string().optional().describe("Force agent mode when set to true or 1"),
+  FORCE_AGENT_MODE: z.string().optional().describe("Force agent mode when set to true or 1"),
+  PRISM_NO_AGENT: z.string().optional().describe("Force human mode when set to true or 1"),
+  PRISM_READ_ONLY: z.string().optional().describe("Reject commands that can modify state"),
+  FORCE_HUMAN_MODE: z.string().optional().describe("Force human mode when set to true or 1"),
+});

--- a/src/command.test.ts
+++ b/src/command.test.ts
@@ -1,0 +1,360 @@
+import { Cli, Errors, Mcp, z } from "incur";
+import { afterEach, describe, expect, expectTypeOf, it } from "vitest";
+import {
+  assertMutationAllowed,
+  commandMiddleware,
+  commandOutput,
+  commandVars,
+  commandWarnings,
+  defineCommand,
+  environmentOptions,
+  globalOptions,
+} from "./command.js";
+import { getRuntimeState, isPrintRequestsEnabled, isQuiet } from "./runtime.js";
+import { runCommand } from "./test-command.js";
+import { ux } from "./utils/ux.js";
+
+const environmentCommand = defineCommand({
+  run: () => ({ printRequests: isPrintRequestsEnabled(), quiet: isQuiet() }),
+});
+
+afterEach(() => {
+  delete process.env.PRISMATIC_PRINT_REQUESTS;
+  delete process.env.PRISM_QUIET;
+});
+
+describe("native schemas and execution context", () => {
+  it("infers handler inputs from native schemas and applies native defaults", async () => {
+    const command = defineCommand({
+      args: z.object({ name: z.string() }),
+      options: z.object({
+        count: z.coerce.number().int().default(1),
+        enabled: z.boolean().optional(),
+      }),
+      output: z.object({ name: z.string(), count: z.number(), enabled: z.boolean() }),
+      run(context) {
+        expectTypeOf(context.args.name).toEqualTypeOf<string>();
+        expectTypeOf(context.options.count).toEqualTypeOf<number>();
+        expectTypeOf(context.options.enabled).toEqualTypeOf<boolean | undefined>();
+        expectTypeOf(context.globals.profile).toEqualTypeOf<string | undefined>();
+        return {
+          name: context.args.name,
+          count: context.options.count,
+          enabled: context.options.enabled ?? false,
+        };
+      },
+    });
+    await expect(runCommand(command, ["example", "--agent"])).resolves.toEqual({
+      name: "example",
+      count: 1,
+      enabled: false,
+    });
+    await expect(
+      runCommand(command, ["example", "--count", "3", "--enabled", "--agent"]),
+    ).resolves.toEqual({ name: "example", count: 3, enabled: true });
+    await expect(
+      runCommand(command, ["example", "--count", "invalid", "--agent"]),
+    ).rejects.toMatchObject({ code: "VALIDATION_ERROR" });
+  });
+
+  it("keeps presence-checked environment switches invocation-local", async () => {
+    await expect(runCommand(environmentCommand, [])).resolves.toEqual({
+      printRequests: false,
+      quiet: false,
+    });
+    await expect(runCommand(environmentCommand, ["--print-requests", "--quiet"])).resolves.toEqual({
+      printRequests: true,
+      quiet: true,
+    });
+    expect(process.env.PRISMATIC_PRINT_REQUESTS).toBeUndefined();
+    expect(process.env.PRISM_QUIET).toBeUndefined();
+  });
+
+  it("allows concurrent native commands while isolating runtime state", async () => {
+    let active = 0;
+    let maximumActive = 0;
+    const command = defineCommand({
+      async run() {
+        active += 1;
+        maximumActive = Math.max(maximumActive, active);
+        const before = { ...getRuntimeState() };
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        const after = { ...getRuntimeState() };
+        active -= 1;
+        return { before, after };
+      },
+    });
+    const [alpha, beta] = await Promise.all([
+      runCommand(command, ["--profile", "alpha", "--print-requests"]),
+      runCommand(command, ["--profile", "beta", "--quiet"]),
+    ]);
+    expect(maximumActive).toBe(2);
+    expect(alpha).toMatchObject({
+      before: { printRequests: true, quiet: false, selectedProfile: "alpha" },
+      after: { printRequests: true, quiet: false, selectedProfile: "alpha" },
+    });
+    expect(beta).toMatchObject({
+      before: { printRequests: false, quiet: true, selectedProfile: "beta" },
+      after: { printRequests: false, quiet: true, selectedProfile: "beta" },
+    });
+  });
+});
+
+describe("native mutation and interaction middleware", () => {
+  it("requires explicit approval and enforces read-only mode", async () => {
+    const command = defineCommand({ mutates: true, run: () => ({ changed: true }) });
+    await expect(runCommand(command, ["--agent"])).rejects.toMatchObject({
+      code: "CONFIRMATION_REQUIRED",
+      exitCode: 2,
+    });
+    await expect(runCommand(command, ["--agent", "--yes", "--read-only"])).rejects.toMatchObject({
+      code: "READ_ONLY",
+      exitCode: 2,
+    });
+    await expect(runCommand(command, ["--agent", "--yes"])).resolves.toEqual({ changed: true });
+  });
+
+  it("preserves context and safeguards when invoking a shared operation", async () => {
+    const operation = (context: Parameters<typeof assertMutationAllowed>[0]) => {
+      assertMutationAllowed(context);
+      return { agent: context.agent, profile: getRuntimeState().selectedProfile };
+    };
+    const command = defineCommand({ run: (context) => operation(context) });
+    await expect(runCommand(command, ["--agent"])).rejects.toMatchObject({
+      code: "CONFIRMATION_REQUIRED",
+    });
+    await expect(
+      runCommand(command, ["--agent", "--yes", "--profile", "selected"]),
+    ).resolves.toEqual({ agent: true, profile: "selected" });
+  });
+
+  it("does not silently approve an interactive prompt", async () => {
+    const command = defineCommand({
+      async run() {
+        return { confirmed: await ux.confirm("Proceed?") };
+      },
+    });
+    await expect(runCommand(command, ["--agent"])).rejects.toMatchObject({ exitCode: 2 });
+    await expect(runCommand(command, ["--agent", "--yes"])).resolves.toEqual({ confirmed: true });
+  });
+
+  it("preserves declared error status through the native pipeline", async () => {
+    const command = defineCommand({ run: () => ux.error("runtime failure", { exit: 1 }) });
+    await expect(runCommand(command, [])).rejects.toMatchObject({ exitCode: 1 });
+  });
+});
+
+describe("native results and streaming", () => {
+  it("streams native domain events exactly once", async () => {
+    const command = defineCommand({
+      output: z.object({ type: z.literal("log"), count: z.number() }),
+      async *run() {
+        yield { type: "log" as const, count: 1 };
+        await Promise.resolve();
+        yield { type: "log" as const, count: 2 };
+      },
+    });
+    await expect(runCommand(command, ["--agent"])).resolves.toEqual([
+      { type: "log", count: 1 },
+      { type: "log", count: 2 },
+    ]);
+  });
+
+  it.each([
+    false,
+    true,
+  ])("returns explicit warning data through native MCP with c.ok=%s", async (useOk) => {
+    const command = defineCommand({
+      run(context) {
+        commandOutput.warn("partial result");
+        const data = { customerId: "customer-id", warnings: commandWarnings() };
+        return useOk ? context.ok(data) : data;
+      },
+    });
+    const result = await Mcp.callTool(
+      { name: "warn", inputSchema: { type: "object", properties: {} }, command },
+      {},
+      { middlewares: [commandMiddleware], vars: commandVars, env: environmentOptions },
+    );
+    expect(result.isError).not.toBe(true);
+    expect(JSON.parse(result.content[0].text)).toEqual({
+      customerId: "customer-id",
+      warnings: ["partial result"],
+    });
+  });
+
+  it.each([
+    false,
+    true,
+  ])("propagates native MCP generator errors with c.error=%s", async (useError) => {
+    const command = defineCommand({
+      async *run(context) {
+        yield { type: "started" };
+        if (useError)
+          return context.error({ code: "NOT_FOUND", message: "Execution not found", exitCode: 2 });
+        throw Object.assign(new Error("Execution not found"), { code: "NOT_FOUND", exitCode: 2 });
+      },
+    });
+    const result = await Mcp.callTool(
+      { name: "fail", inputSchema: { type: "object", properties: {} }, command },
+      {},
+      { middlewares: [commandMiddleware], vars: commandVars, env: environmentOptions },
+    );
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Execution not found");
+  });
+
+  it.each(["json", "jsonl"])("reports generator failure through native CLI %s", async (format) => {
+    const command = defineCommand({
+      async *run(context) {
+        yield { type: "started" };
+        return context.error({ code: "NOT_FOUND", message: "Execution not found", exitCode: 2 });
+      },
+    });
+    const cli = Cli.create("test", {
+      globals: globalOptions,
+      vars: commandVars,
+      env: environmentOptions,
+    })
+      .use(commandMiddleware)
+      .command("fail", command);
+    const output: string[] = [];
+    const exits: number[] = [];
+    await cli.serve(["fail", "--format", format], {
+      stdout: (value) => {
+        output.push(value);
+      },
+      exit: (code) => {
+        exits.push(code);
+      },
+    });
+    expect(exits).toContain(2);
+    expect(output.join("")).toContain('"NOT_FOUND"');
+    expect(output.join("")).not.toContain('"ok":true');
+  });
+});
+
+describe("native output and error contracts", () => {
+  it.each([false, true])("normalizes declared outputs including c.ok=%s", async (useOk) => {
+    const command = defineCommand({
+      output: z.object({ id: z.string() }),
+      run(context) {
+        const data = { id: "resource", undeclared: "must not escape" };
+        return useOk ? context.ok(data) : data;
+      },
+    });
+    const result = await Mcp.callTool(
+      {
+        name: "normalize",
+        inputSchema: { type: "object", properties: {} },
+        outputSchema: { type: "object", properties: { id: { type: "string" } } },
+        command,
+      },
+      {},
+      { middlewares: [commandMiddleware], vars: commandVars, env: environmentOptions },
+    );
+    expect(result.structuredContent).toEqual({ id: "resource" });
+  });
+
+  it("retains native error sentinel retryability and CTAs", async () => {
+    const command = defineCommand({
+      output: z.object({ id: z.string() }),
+      run(context) {
+        return context.error({
+          code: "RATE_LIMITED",
+          message: "Wait a minute",
+          retryable: true,
+          cta: { commands: [{ command: "help", description: "Read retry guidance" }] },
+        });
+      },
+    });
+    const cli = Cli.create("test", {
+      globals: globalOptions,
+      vars: commandVars,
+      env: environmentOptions,
+    })
+      .use(commandMiddleware)
+      .command("run", command);
+    let output = "";
+    await cli.serve(["run", "--agent", "--json"], {
+      stdout: (chunk) => {
+        output += chunk;
+      },
+      exit: () => {},
+    });
+    expect(JSON.parse(output)).toMatchObject({ code: "RATE_LIMITED", retryable: true });
+    const result = await Mcp.callTool(
+      { name: "retry", inputSchema: { type: "object", properties: {} }, command },
+      {},
+      { middlewares: [commandMiddleware], vars: commandVars, env: environmentOptions },
+    );
+    expect(result.isError).toBe(true);
+    expect(result._meta?.cta).toBeDefined();
+  });
+
+  it("enforces read-only mode from the invocation environment", async () => {
+    let invoked = false;
+    const command = defineCommand({
+      mutates: true,
+      run() {
+        invoked = true;
+        return { success: true };
+      },
+    });
+    const cli = Cli.create("test", {
+      globals: globalOptions,
+      vars: commandVars,
+      env: environmentOptions,
+    })
+      .use(commandMiddleware)
+      .command("run", command);
+    let output = "";
+    await cli.serve(["run", "--agent", "--yes", "--json"], {
+      env: { PRISM_READ_ONLY: "true" },
+      stdout: (chunk) => {
+        output += chunk;
+      },
+      exit: () => {},
+    });
+    expect(invoked).toBe(false);
+    expect(JSON.parse(output)).toMatchObject({ code: "READ_ONLY" });
+  });
+});
+
+describe("native stream validation", () => {
+  it("normalizes yielded data and preserves native retryable failures", async () => {
+    const command = defineCommand({
+      output: z.object({ id: z.string() }),
+      async *run() {
+        yield { id: "resource", undeclared: "must not escape" };
+        throw new Errors.IncurError({
+          code: "RATE_LIMITED",
+          message: "Wait",
+          retryable: true,
+          hint: "Retry later",
+        });
+      },
+    });
+    const cli = Cli.create("test", {
+      globals: globalOptions,
+      vars: commandVars,
+      env: environmentOptions,
+    })
+      .use(commandMiddleware)
+      .command("run", command);
+    let output = "";
+    await cli.serve(["run", "--agent", "--format", "jsonl"], {
+      stdout: (chunk) => {
+        output += chunk;
+      },
+      exit: () => {},
+    });
+    const chunks = output
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line));
+    expect(chunks[0]).toEqual({ type: "chunk", data: { id: "resource" } });
+    expect(JSON.stringify(chunks)).not.toContain("must not escape");
+    expect(JSON.stringify(chunks)).toContain('"retryable":true');
+  });
+});

--- a/src/command.ts
+++ b/src/command.ts
@@ -1,0 +1,406 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { z, Errors, middleware, type Cli } from "incur";
+import { getRuntimeEnvironment, runWithRuntimeState, type RuntimeState } from "./runtime.js";
+import { globalOptions, environmentOptions } from "./command-schemas.js";
+import { fieldsFromSchema, isMcpTransport, getMcpGlobals } from "./compatibility.js";
+export { globalOptions, environmentOptions } from "./command-schemas.js";
+export {
+  argsSchema,
+  optionsSchema,
+  schemaFieldName,
+  encodePassthroughArgument,
+  decodePassthroughArgument,
+  runWithMcpTransport,
+  type Field,
+  type Fields,
+} from "./compatibility.js";
+
+type Execution = {
+  agent: boolean;
+  globals: z.output<typeof globalOptions>;
+  request?: Request;
+  mcp?: boolean;
+  signal: AbortSignal;
+  warnings: string[];
+  runtime: RuntimeState;
+};
+export const commandVars = z.object({
+  execution: z.custom<Execution>().optional(),
+  signal: z.custom<AbortSignal>().optional(),
+});
+type NativeOptions<
+  A extends z.ZodObject | undefined = undefined,
+  O extends z.ZodObject | undefined = undefined,
+  R extends z.ZodType | undefined = undefined,
+> = Cli.create.Options<
+  A,
+  typeof environmentOptions,
+  O,
+  R,
+  typeof commandVars,
+  typeof globalOptions
+>;
+export type CommandContext = Omit<
+  Parameters<NonNullable<NativeOptions<z.ZodObject, z.ZodObject>["run"]>>[0],
+  "ok"
+> & { request?: Request };
+const executionContext = new AsyncLocalStorage<Execution>();
+export const commandMiddleware = middleware<
+  typeof commandVars,
+  typeof environmentOptions,
+  typeof globalOptions
+>(async (c, next) => {
+  const abort = new AbortController();
+  const signal = c.request?.signal
+    ? AbortSignal.any([c.request.signal, abort.signal])
+    : abort.signal;
+  const runtime: RuntimeState = {
+    environment: { ...process.env, ...c.env },
+    printRequests: c.globals.printRequests === true,
+    profileOnly: false,
+    quiet: c.globals.quiet,
+    selectedProfile: c.globals.profile ?? c.env.PRISM_PROFILE,
+  };
+  const execution: Execution = {
+    agent: c.agent,
+    globals: c.globals,
+    request: c.request,
+    signal,
+    warnings: [],
+    runtime,
+  };
+  c.set("execution", execution);
+  c.set("signal", signal);
+  try {
+    await executionContext.run(execution, () => runWithRuntimeState(runtime, next));
+  } finally {
+    abort.abort();
+  }
+});
+
+export const isCommandTransportExecution = () =>
+  isMcpTransport() ||
+  Boolean(executionContext.getStore()?.request || executionContext.getStore()?.mcp);
+export const assertCommandStdinAvailable = (): void => {
+  if (isCommandTransportExecution())
+    throw new Errors.IncurError({
+      code: "STDIN_UNAVAILABLE",
+      exitCode: 2,
+      message: "Standard input is reserved for the transport. Provide an argument or file instead.",
+    });
+};
+export const commandSignal = () => executionContext.getStore()?.signal;
+export const isAgentExecution = () => executionContext.getStore()?.agent === true;
+export const commandGlobals = (): Partial<z.output<typeof globalOptions>> =>
+  executionContext.getStore()?.globals ?? {};
+export const commandWarnings = () => [...(executionContext.getStore()?.warnings ?? [])];
+export const writeCommandOutput = (value: string, stream: "stdout" | "stderr" = "stdout") => {
+  const execution = executionContext.getStore();
+  if (stream === "stderr") execution?.warnings.push(value.replace(/\n$/, ""));
+  if (!execution?.agent)
+    (stream === "stderr" ? process.stderr : process.stdout).write(`${value}\n`);
+};
+export const writeCommandStatus = (value: string) => {
+  if (!isAgentExecution()) process.stderr.write(`${value}\n`);
+};
+export const writeCommandProgress = (value: string) => {
+  if (!isAgentExecution()) process.stderr.write(value);
+};
+export const requireInteractiveInput = (message: string) => {
+  if (isAgentExecution())
+    throw new Errors.IncurError({ code: "INTERACTIVE_INPUT_REQUIRED", message, exitCode: 2 });
+};
+
+type Definition<
+  A extends z.ZodObject | undefined,
+  O extends z.ZodObject | undefined,
+  R extends z.ZodType | undefined,
+> = Omit<NativeOptions<A, O, R>, "run" | "mcp"> & {
+  run: NonNullable<NativeOptions<A, O, R>["run"]>;
+  authContext?: "default" | "profile";
+  mutates?: boolean;
+  hidden?: boolean;
+  mcp?: Cli.FileCommand["mcp"];
+};
+
+// Incur's MCP transport exposes command inputs but does not forward CLI globals.
+// Namespace tool controls to avoid native global/option collisions (upstream issue #229).
+const toolGlobals = z.object({
+  yes: globalOptions.shape.yes.unwrap().optional(),
+  readOnly: globalOptions.shape.readOnly.unwrap().optional(),
+  quiet: globalOptions.shape.quiet.unwrap().optional(),
+  profile: globalOptions.shape.profile,
+  printRequests: globalOptions.shape.printRequests,
+});
+
+/** Incur owns parsing, validation, result envelopes, and generator consumption. */
+export function defineCommand<
+  const A extends z.ZodObject | undefined = undefined,
+  const O extends z.ZodObject | undefined = undefined,
+  const R extends z.ZodType | undefined = undefined,
+>(definition: Definition<A, O, R>) {
+  const contract = {
+    args: fieldsFromSchema(definition.args),
+    options: fieldsFromSchema(definition.options),
+  };
+  const alias = Object.fromEntries(
+    Object.entries(contract.options).flatMap(([name, field]) =>
+      field.char ? [[name.startsWith("no-") ? name.slice(3) : name, field.char]] : [],
+    ),
+  );
+  const scope = middleware<typeof commandVars, typeof environmentOptions, typeof globalOptions>(
+    async (c, next) => {
+      if (!c.var.execution) throw new Error("Command middleware is not installed");
+      c.var.execution.runtime.profileOnly = definition.authContext === "profile";
+      await next();
+    },
+  );
+  const run: NonNullable<NativeOptions<A, O, R>["run"]> = (context) => {
+    const execution = context.var.execution;
+    if (!execution) throw new Error("Command middleware is not installed");
+    // MCP passes globals as flat tool inputs. Resolve them before any handler work;
+    // a server launched read-only remains read-only even if a call supplies false.
+    if (Object.keys(context.globals).length === 0) {
+      execution.mcp = true;
+      const inherited = getMcpGlobals();
+      const provided = toolGlobals.parse(
+        (context.options as Record<string, unknown>).context ?? {},
+      );
+      const explicit = Object.fromEntries(
+        Object.entries(provided).filter(([, value]) => value !== undefined),
+      );
+      context.globals = globalOptions.parse({
+        ...inherited,
+        ...explicit,
+        readOnly: inherited.readOnly === true || provided.readOnly === true,
+      });
+      execution.globals = context.globals;
+      execution.runtime.selectedProfile =
+        context.globals.profile ?? execution.runtime.environment?.PRISM_PROFILE;
+      execution.runtime.quiet = context.globals.quiet;
+      execution.runtime.printRequests = context.globals.printRequests === true;
+    }
+    if (definition.mutates) assertMutationAllowed(context);
+    const abort = new AbortController();
+    const signal = AbortSignal.any([execution.signal, abort.signal]);
+    const local = { ...execution, signal };
+    context.var.signal = signal;
+    const within = <T>(fn: () => T) =>
+      executionContext.run(local, () => runWithRuntimeState(local.runtime, fn));
+    const inspect = <T>(value: T, streaming = false): T => {
+      const tagged =
+        value && typeof value === "object" ? (value as Record<PropertyKey, unknown>) : undefined;
+      const tag = tagged?.[Symbol.for("incur.sentinel")];
+      if (tag === "error") {
+        if (streaming) throw nativeError(tagged);
+        return value;
+      }
+      const data = tag === "ok" ? tagged?.data : value;
+      if (definition.output) {
+        const parsed = definition.output.safeParse(data);
+        if (!parsed.success)
+          throw new Errors.IncurError({
+            code: "OUTPUT_SCHEMA_MISMATCH",
+            message: parsed.error.message,
+            exitCode: 1,
+          });
+        return (tag === "ok" ? { ...tagged, data: parsed.data } : parsed.data) as T;
+      }
+      return value;
+    };
+    try {
+      const result = within(() => definition.run(context));
+      if (result && typeof result === "object" && Symbol.asyncIterator in result) {
+        // Bind iterator operations, not an output collector. Return aborts even while next waits.
+        const iterator = result;
+        const bound: typeof iterator = {
+          [Symbol.asyncIterator]() {
+            return this;
+          },
+          async [Symbol.asyncDispose]() {
+            abort.abort();
+            await within(() => iterator.return(undefined));
+          },
+          async next(...args: [] | [unknown]) {
+            try {
+              const step = await within(() => iterator.next(...args));
+              if (step.done) {
+                if (step.value !== undefined) step.value = inspect(step.value, true);
+                abort.abort();
+              } else step.value = inspect(step.value, true);
+              return step;
+            } catch (error) {
+              abort.abort();
+              await within(() => iterator.return(undefined));
+              throw nativeError(error);
+            }
+          },
+          async return(value: unknown) {
+            abort.abort();
+            return within(() => iterator.return(value));
+          },
+          async throw(error: unknown) {
+            abort.abort();
+            return within(() => iterator.throw(error));
+          },
+        };
+        return bound;
+      }
+      return Promise.resolve(result)
+        .then(inspect)
+        .catch((error) => {
+          throw nativeError(error);
+        })
+        .finally(() => abort.abort());
+    } catch (error) {
+      abort.abort();
+      throw nativeError(error);
+    }
+  };
+  return {
+    ...definition,
+    env: definition.env ?? environmentOptions,
+    contract,
+    options: definition.options
+      ? definition.options.safeExtend({
+          context: toolGlobals
+            .optional()
+            .describe("MCP execution controls; CLI users use global flags"),
+        })
+      : z.object({
+          context: toolGlobals
+            .optional()
+            .describe("MCP execution controls; CLI users use global flags"),
+        }),
+    alias,
+    run,
+    middleware: [scope],
+    destructive: definition.mutates === true || definition.destructive === true,
+    mcp: definition.mcp ?? {
+      annotations: {
+        destructiveHint: definition.mutates === true || definition.destructive === true,
+        idempotentHint: !(definition.mutates || definition.destructive),
+        openWorldHint: true,
+        readOnlyHint: !(definition.mutates || definition.destructive),
+      },
+    },
+  };
+}
+const nativeError = (error: unknown): Errors.IncurError =>
+  error instanceof Errors.IncurError ? error : new Errors.IncurError(structuredError(error));
+const structuredError = (error: unknown) => {
+  const nativeDetails =
+    typeof error === "object" && error !== null
+      ? {
+          ...("retryable" in error && typeof error.retryable === "boolean"
+            ? { retryable: error.retryable }
+            : {}),
+          ...("hint" in error && typeof error.hint === "string" ? { hint: error.hint } : {}),
+        }
+      : {};
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "object" &&
+          error !== null &&
+          "message" in error &&
+          typeof error.message === "string"
+        ? error.message
+        : String(error);
+  const declared =
+    typeof error === "object" && error !== null && "code" in error && typeof error.code === "string"
+      ? error.code
+      : undefined;
+  const exitCode =
+    typeof error === "object" &&
+    error !== null &&
+    "exitCode" in error &&
+    typeof error.exitCode === "number"
+      ? error.exitCode
+      : 1;
+  if (/Unable to connect|Network request .* failed|\bfetch failed\b/i.test(message)) {
+    return { code: "NETWORK_ERROR", exitCode, message, retryable: true };
+  }
+  if (/\bdoes not exist\b|\bnot found\b/i.test(message)) {
+    return {
+      code: declared ?? "NOT_FOUND",
+      exitCode,
+      message,
+      retryable: false,
+      ...nativeDetails,
+    };
+  }
+  return {
+    code: declared ?? (exitCode === 2 ? "VALIDATION_ERROR" : "COMMAND_FAILED"),
+    exitCode,
+    message,
+    retryable: false,
+    ...nativeDetails,
+  };
+};
+
+type MutationContext = {
+  agent: boolean;
+  globals: { readOnly?: boolean; yes?: boolean };
+  env?: { PRISM_READ_ONLY?: string };
+};
+const isReadOnlyContext = (context: MutationContext): boolean =>
+  context.globals.readOnly === true ||
+  /^(?:1|true)$/i.test(
+    context.env?.PRISM_READ_ONLY ?? getRuntimeEnvironment().PRISM_READ_ONLY ?? "",
+  );
+
+export const assertMutationAllowed = (context: MutationContext): void => {
+  if (isReadOnlyContext(context)) {
+    throw new Errors.IncurError({
+      message: "Read-only mode prohibits this command.",
+      code: "READ_ONLY",
+      exitCode: 2,
+    });
+  }
+  if (context.agent && context.globals.yes !== true) {
+    throw new Errors.IncurError({
+      message: "This command can modify state. Approve with --yes, or context.yes=true in MCP.",
+      code: "CONFIRMATION_REQUIRED",
+      exitCode: 2,
+    });
+  }
+};
+
+export const commandOutput: {
+  error(message: string | Error, options?: { exit?: number }): never;
+  exit(code?: number): never;
+  log(...values: unknown[]): void;
+  quietLog(message: string, quiet?: boolean, type?: "warn"): void;
+  stderr(...values: unknown[]): void;
+  warn(...messages: Array<string | Error>): void;
+} = {
+  error(message: string | Error, options?: { exit?: number }): never {
+    const error = typeof message === "string" ? new Error(message) : message;
+    const exitCode = options?.exit ?? 2;
+    Object.assign(error, { exitCode });
+    throw error;
+  },
+  exit(code = 0): never {
+    const error = new Error(`Exited with status ${code}`);
+    Object.assign(error, { exitCode: code, silent: true });
+    throw error;
+  },
+  log(...values: unknown[]): void {
+    writeCommandStatus(values.map((value) => (value == null ? "" : String(value))).join(" "));
+  },
+  quietLog(message: string, quiet = false, type?: "warn"): void {
+    if (quiet) return;
+    if (type === "warn") writeCommandOutput(message, "stderr");
+    else writeCommandStatus(message);
+  },
+  stderr(...values: unknown[]): void {
+    writeCommandOutput(values.map(String).join(" "), "stderr");
+  },
+  warn(...messages: Array<string | Error>): void {
+    writeCommandOutput(
+      messages.map((message) => (message instanceof Error ? message.message : message)).join(" "),
+      "stderr",
+    );
+  },
+};

--- a/src/command.typecheck.ts
+++ b/src/command.typecheck.ts
@@ -1,0 +1,47 @@
+import { z } from "incur";
+import { defineCommand } from "./command.js";
+
+// This function is never executed. Unlike *.test.ts, this file is included by
+// the project's TypeScript check, so unused @ts-expect-error directives fail CI.
+export function assertNativeCommandInference(): void {
+  defineCommand({
+    args: z.object({ id: z.string() }),
+    options: z.object({ limit: z.number().int().default(1), verbose: z.boolean().optional() }),
+    output: z.object({ id: z.string(), count: z.number() }),
+    run(context) {
+      const id: string = context.args.id;
+      const limit: number = context.options.limit;
+      const verbose: boolean | undefined = context.options.verbose;
+      const profile: string | undefined = context.globals.profile;
+      void [verbose, profile];
+      // @ts-expect-error Positional strings do not become untyped values.
+      const invalidId: number = context.args.id;
+      // @ts-expect-error Schema defaults infer numbers, not arbitrary strings.
+      const invalidLimit: string = context.options.limit;
+      // @ts-expect-error Undeclared positional arguments are unavailable.
+      context.args.missing;
+      // @ts-expect-error Undeclared options are unavailable.
+      context.options.missing;
+      // @ts-expect-error Shared globals remain typed.
+      const invalidProfile: number = context.globals.profile;
+      // @ts-expect-error c.ok requires the declared resource id.
+      context.ok({ count: limit });
+      // @ts-expect-error c.ok validates property types against the output schema.
+      context.ok({ id, count: "wrong" });
+      void [invalidId, invalidLimit, invalidProfile];
+      return { id, count: limit };
+    },
+  });
+
+  defineCommand({
+    output: z.object({ id: z.string() }),
+    // @ts-expect-error The native handler must return the declared output shape.
+    run: () => ({ count: 1 }),
+  });
+
+  defineCommand({
+    output: z.object({ id: z.string() }),
+    // @ts-expect-error Output property types cannot be widened by handler inference.
+    run: () => ({ id: 123 }),
+  });
+}

--- a/src/compatibility.ts
+++ b/src/compatibility.ts
@@ -1,0 +1,128 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { randomUUID } from "node:crypto";
+import { z } from "incur";
+import type { globalOptions } from "./command-schemas.js";
+
+/** Metadata needed only for public argv spellings and cross-option constraints. */
+export type Field = {
+  kind: "boolean" | "integer" | "string";
+  char?: string;
+  default?: unknown;
+  dependsOn?: string[];
+  description?: string;
+  exclusive?: string[];
+  exactlyOne?: string[];
+  hidden?: boolean;
+  min?: number;
+  multiple?: boolean;
+  options?: readonly unknown[];
+  preserveExplicit?: boolean;
+  required?: boolean;
+  legacyName?: string;
+};
+export type Fields = Record<string, Field>;
+export const schemaFieldName = (name: string) => (name.startsWith("no-") ? name.slice(3) : name);
+const passthroughPrefix = `__PRISM_PASSTHROUGH_${randomUUID()}__`;
+export const encodePassthroughArgument = (value: string) =>
+  `${passthroughPrefix}${Buffer.from(value).toString("base64url")}`;
+export const decodePassthroughArgument = (value: string) =>
+  value.startsWith(passthroughPrefix)
+    ? Buffer.from(value.slice(passthroughPrefix.length), "base64url").toString()
+    : value;
+export type McpGlobals = Partial<z.output<typeof globalOptions>>;
+// incur does not forward globals to MCP calls yet (wevm/incur#229).
+// Keep launch defaults scoped to the transport while tools supply per-call context.
+const transport = new AsyncLocalStorage<Readonly<McpGlobals>>();
+export const runWithMcpTransport = <T>(callback: () => T, globals: McpGlobals = {}): T =>
+  transport.run(Object.freeze({ ...globals }), callback);
+export const isMcpTransport = () => transport.getStore() !== undefined;
+export const getMcpGlobals = (): Readonly<McpGlobals> => transport.getStore() ?? {};
+
+export function fieldsFromSchema(schema?: z.ZodObject): Fields {
+  return Object.fromEntries(
+    Object.entries(schema?.shape ?? {}).map(([key, schema]) => {
+      const field = schema as z.ZodType;
+      const meta = (field.meta()?.cli ?? {}) as Partial<Field>;
+      let inner = field;
+      let defaultValue: unknown;
+      while (
+        inner instanceof z.ZodOptional ||
+        inner instanceof z.ZodDefault ||
+        inner instanceof z.ZodNullable
+      ) {
+        if (inner instanceof z.ZodDefault) defaultValue = inner.def.defaultValue;
+        inner = inner.unwrap() as z.ZodType;
+      }
+      const multiple = inner instanceof z.ZodArray;
+      if (inner instanceof z.ZodArray) inner = inner.element as z.ZodType;
+      const kind =
+        inner instanceof z.ZodBoolean
+          ? "boolean"
+          : inner instanceof z.ZodNumber
+            ? "integer"
+            : "string";
+      return [
+        meta.legacyName ?? key,
+        {
+          kind,
+          required: !field.safeParse(undefined).success,
+          description: field.description,
+          ...(defaultValue !== undefined ? { default: defaultValue } : {}),
+          ...(multiple ? { multiple: true } : {}),
+          ...(inner instanceof z.ZodEnum ? { options: Object.values(inner.enum) } : {}),
+          ...meta,
+        },
+      ];
+    }),
+  );
+}
+
+export function optionsSchema<T extends z.ZodRawShape>(schema: z.ZodObject<T>): z.ZodObject<T> {
+  const fields = fieldsFromSchema(schema);
+  return schema.superRefine((input, ctx) => {
+    const values = input as Record<string, unknown>;
+    for (const [name, field] of Object.entries(fields)) {
+      const present = (key: string) => values[schemaFieldName(key)] !== undefined;
+      const issue = (message: string) =>
+        ctx.addIssue({ code: "custom", message, path: [schemaFieldName(name)] });
+      if (field.exactlyOne) {
+        const names = [...new Set([name, ...field.exactlyOne])];
+        if (names.filter(present).length !== 1)
+          issue(`Exactly one of ${names.map((k) => `--${k}`).join(", ")} is required`);
+      }
+      if (!present(name)) continue;
+      for (const exclusive of field.exclusive ?? [])
+        if (present(exclusive))
+          issue(`--${name} cannot also be provided when using --${exclusive}`);
+      for (const dependency of field.dependsOn ?? [])
+        if (!present(dependency)) issue(`--${name} requires --${dependency}`);
+    }
+  });
+}
+
+export function argsSchema<T extends z.ZodRawShape>(schema: z.ZodObject<T>): z.ZodObject<T> {
+  const decode = (field: z.ZodType): z.ZodType => {
+    // Parser inspects wrappers and arrays for token arity. Decode scalar values inside them.
+    if (field instanceof z.ZodOptional) return decode(field.unwrap() as z.ZodType).optional();
+    if (field instanceof z.ZodDefault)
+      return decode(field.unwrap() as z.ZodType).default(field.def.defaultValue);
+    if (field instanceof z.ZodArray) return z.array(decode(field.element as z.ZodType));
+    return z.preprocess(
+      (value) =>
+        typeof value === "string" && !isMcpTransport() ? decodePassthroughArgument(value) : value,
+      field,
+    );
+  };
+  const fields = fieldsFromSchema(schema);
+  const shape = Object.fromEntries(
+    Object.entries(schema.shape).map(([key, value]) => {
+      const field = value as z.ZodType;
+      return [
+        key,
+        decode(field).meta({ ...field.meta(), description: field.description, cli: fields[key] }),
+      ];
+    }),
+  );
+  // Decoding changes input bytes only; each field still returns its declared output type.
+  return z.object(shape) as unknown as z.ZodObject<T>;
+}

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,0 +1,35 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export type RuntimeState = {
+  printRequests: boolean;
+  profileOnly: boolean;
+  quiet: boolean;
+  selectedProfile?: string;
+  environment?: NodeJS.ProcessEnv;
+};
+
+const runtime = new AsyncLocalStorage<RuntimeState>();
+
+export const runWithRuntimeState = <T>(state: RuntimeState, callback: () => T): T =>
+  runtime.run(state, callback);
+
+export const getRuntimeState = (): RuntimeState | undefined => runtime.getStore();
+
+export const isPrintRequestsEnabled = (): boolean =>
+  getRuntimeState()?.printRequests ?? Boolean(process.env.PRISMATIC_PRINT_REQUESTS);
+
+export const isQuiet = (): boolean => getRuntimeState()?.quiet ?? Boolean(process.env.PRISM_QUIET);
+
+export const getRuntimeEnvironment = (): NodeJS.ProcessEnv =>
+  getRuntimeState()?.environment ?? process.env;
+export const runWithEnvironment = <T>(environment: NodeJS.ProcessEnv, callback: () => T): T =>
+  runWithRuntimeState(
+    {
+      printRequests: false,
+      profileOnly: false,
+      quiet: false,
+      ...getRuntimeState(),
+      environment: { ...environment },
+    },
+    callback,
+  );

--- a/src/test-command.ts
+++ b/src/test-command.ts
@@ -1,0 +1,176 @@
+import { Cli, type z } from "incur";
+import { commandMiddleware, commandVars, environmentOptions, globalOptions } from "./command.js";
+
+/** Exercise native parsing and middleware; never provide a synthetic handler context. */
+export async function runCommand<
+  Args extends z.ZodObject | undefined,
+  Env extends z.ZodObject | undefined,
+  Options extends z.ZodObject | undefined,
+  Output extends z.ZodType | undefined,
+>(
+  command: Cli.create.Options<
+    Args,
+    Env,
+    Options,
+    Output,
+    typeof commandVars,
+    typeof globalOptions
+  > & {
+    run: NonNullable<
+      Cli.create.Options<
+        Args,
+        Env,
+        Options,
+        Output,
+        typeof commandVars,
+        typeof globalOptions
+      >["run"]
+    >;
+  },
+  argv: string[],
+): Promise<unknown> {
+  let returned: unknown;
+  let failure: unknown;
+  let exitCode = 0;
+  const output: string[] = [];
+  const agent = argv.includes("--agent") && !argv.includes("--no-agent");
+  const native = Cli.create("test", {
+    globals: globalOptions,
+    env: environmentOptions,
+    vars: commandVars,
+  })
+    .use(commandMiddleware)
+    .command("run", {
+      ...command,
+      run(context) {
+        const observed = {
+          ...context,
+          ok(data: Parameters<typeof context.ok>[0], meta?: Parameters<typeof context.ok>[1]) {
+            returned = data;
+            return context.ok(data, meta);
+          },
+          error(error: Parameters<typeof context.error>[0]) {
+            failure = Object.assign(new Error(error.message), error);
+            return context.error(error);
+          },
+        };
+        try {
+          const result = command.run(observed);
+          if (result && typeof result === "object" && Symbol.asyncIterator in result) {
+            const chunks: unknown[] = [];
+            return (async function* () {
+              try {
+                const iterator = result[Symbol.asyncIterator]();
+                while (true) {
+                  const next = await iterator.next();
+                  if (next.done) {
+                    if (returned === undefined) returned = chunks;
+                    return next.value;
+                  }
+                  chunks.push(next.value);
+                  yield next.value;
+                }
+              } catch (error) {
+                failure = error;
+                throw error;
+              }
+            })();
+          }
+          return Promise.resolve(result).then(
+            (value) => {
+              if (returned === undefined) returned = value;
+              return value;
+            },
+            (error: unknown) => {
+              failure = error;
+              throw error;
+            },
+          );
+        } catch (error) {
+          failure = error;
+          throw error;
+        }
+      },
+    });
+
+  const descriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+  Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: !agent });
+  try {
+    await native.serve(["run", ...argv, ...(agent ? ["--json"] : [])], {
+      stdout(value) {
+        output.push(value);
+        if (!agent) process.stdout.write(value);
+      },
+      exit(code) {
+        exitCode = code;
+      },
+    });
+  } finally {
+    if (descriptor) Object.defineProperty(process.stdout, "isTTY", descriptor);
+    else Reflect.deleteProperty(process.stdout, "isTTY");
+  }
+  if (failure) throw failure;
+  if (exitCode !== 0) {
+    let error: { message?: string; code?: string } = {};
+    if (agent) {
+      try {
+        const parsed = JSON.parse(output.join(""));
+        error = parsed.error ?? parsed;
+      } catch {
+        // Human/builtin validation output remains useful if no JSON was produced.
+      }
+    }
+    throw Object.assign(new Error(error.message ?? output.join("")), error, { exitCode });
+  }
+  return returned;
+}
+
+/** Convert structured test inputs into real argv, then use the native CLI path. */
+export function runCommandInput<
+  Args extends z.ZodObject | undefined,
+  Env extends z.ZodObject | undefined,
+  Options extends z.ZodObject | undefined,
+  Output extends z.ZodType | undefined,
+>(
+  command: Cli.create.Options<
+    Args,
+    Env,
+    Options,
+    Output,
+    typeof commandVars,
+    typeof globalOptions
+  > & {
+    run: NonNullable<
+      Cli.create.Options<
+        Args,
+        Env,
+        Options,
+        Output,
+        typeof commandVars,
+        typeof globalOptions
+      >["run"]
+    >;
+  },
+  input: {
+    agent?: boolean;
+    args?: Record<string, unknown>;
+    options?: Record<string, unknown>;
+    globals?: Record<string, unknown>;
+  },
+): Promise<unknown> {
+  const argv: string[] = [];
+  for (const name of Object.keys(command.args?.shape ?? {})) {
+    const value = input.args?.[name];
+    if (value !== undefined) argv.push(...(Array.isArray(value) ? value : [value]).map(String));
+  }
+  for (const [name, value] of Object.entries({ ...input.options, ...input.globals })) {
+    if (value === undefined) continue;
+    const flag = name.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
+    if (typeof value === "boolean") argv.push(`--${value ? "" : "no-"}${flag}`);
+    else
+      for (const item of Array.isArray(value) ? value : [value])
+        argv.push(`--${flag}`, String(item));
+  }
+  argv.push(input.agent ? "--agent" : "--no-agent");
+  return runCommand(command, argv);
+}

--- a/src/utils/prompts.ts
+++ b/src/utils/prompts.ts
@@ -1,7 +1,15 @@
 import readline from "node:readline";
 import inquirer from "inquirer";
+import { commandGlobals, isAgentExecution, writeCommandStatus } from "../command.js";
 
 export const confirm = async (message: string): Promise<boolean> => {
+  if (isAgentExecution()) {
+    if (commandGlobals().yes === true) return true;
+    throw Object.assign(
+      new Error(`Confirmation required: ${message} Re-run with --yes to approve this operation.`),
+      { exitCode: 2 },
+    );
+  }
   const { value } = await inquirer.prompt<{ value: boolean }>([
     { type: "confirm", name: "value", message, default: false },
   ]);
@@ -9,7 +17,14 @@ export const confirm = async (message: string): Promise<boolean> => {
 };
 
 export const pressAnyKey = async (message: string): Promise<void> => {
-  process.stdout.write(`${message}\n`);
+  writeCommandStatus(message);
+  if (isAgentExecution()) {
+    if (commandGlobals().yes === true) return;
+    throw Object.assign(
+      new Error(`Interactive continuation required: ${message} Re-run with --yes to continue.`),
+      { exitCode: 2 },
+    );
+  }
   await new Promise<void>((resolve) => {
     const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
     const input = process.stdin;


### PR DESCRIPTION
Introduce native incur schemas and request middleware.

Part **5/24** of the native incur migration. This PR targets `incur-04-graphql-client`; the stack integrates into the long-lived `agent` branch. Review this diff against its immediate base.

Validation: format/lint, TypeScript, bundle, and **332 passing tests** (3 skipped) on Node 24. CI also checks Node 22/24/26 and Windows.

Review size: **1,202 handwritten changed lines**; counts include additions and deletions.

[Stack review guide](https://github.com/prismatic-io/prism/blob/incur-24-review-evidence/docs/incur-pr-stack.md). Merge bottom-up; rebase descendants after a squash merge.
