### PR TITLE
[incur 06/24] Isolate authentication and profile state per invocation

### DIFF
--- a/src/auth.test.ts
+++ b/src/auth.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it, vi } from "vitest";
+import http from "node:http";
 import inquirer from "inquirer";
+import { describe, expect, it, vi } from "vitest";
 import {
   Authenticate,
   createRequestParams,
@@ -80,7 +81,7 @@ describe("createRequestParams", () => {
 
 describe("selectTenant", () => {
   it("logs an error and returns undefined when every tenant is suspended", async () => {
-    const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const outputSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
     const tenants = [
       makeTenant("a", { systemSuspended: true }),
       makeTenant("b", { systemSuspended: true }),
@@ -90,7 +91,7 @@ describe("selectTenant", () => {
 
     expect(result).toBeUndefined();
     expect(inquirer.prompt).not.toHaveBeenCalled();
-    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("no active tenants"));
+    expect(outputSpy).toHaveBeenCalledWith(expect.stringContaining("no active tenants"));
   });
 
   it("filters suspended tenants out of the choice list", async () => {
@@ -377,4 +378,54 @@ describe.skip("auth", () => {
     const data = await response.json();
     expect(data.email).toBeDefined();
   });
+});
+
+it("rejects and closes the authorization callback listener on timeout", async () => {
+  vi.useFakeTimers();
+  const auth = new Authenticate({ domain, clientId, audience, scopes: [], successRedirectUri });
+  const server = http.createServer();
+  const close = vi.spyOn(server, "close");
+  const internals = auth as unknown as {
+    redirectServer: http.Server;
+    createRedirectServer: () => Promise<string>;
+    openChallengeBrowser: () => Promise<void>;
+  };
+  internals.redirectServer = server;
+  vi.spyOn(internals, "createRedirectServer").mockResolvedValue("http://localhost:12345");
+  vi.spyOn(internals, "openChallengeBrowser").mockResolvedValue();
+  try {
+    const assertion = expect(auth.login()).rejects.toThrow("Authentication timed out");
+    await vi.advanceTimersByTimeAsync(3 * 60 * 1000);
+    await assertion;
+    expect(close).toHaveBeenCalledOnce();
+  } finally {
+    vi.useRealTimers();
+  }
+});
+
+it("closes the authorization callback listener when authentication is cancelled", async () => {
+  const auth = new Authenticate({ domain, clientId, audience, scopes: [], successRedirectUri });
+  const server = http.createServer();
+  const close = vi.spyOn(server, "close");
+  const internals = auth as unknown as {
+    redirectServer: http.Server;
+    createRedirectServer: () => Promise<string>;
+    openChallengeBrowser: () => Promise<void>;
+  };
+  internals.redirectServer = server;
+  vi.spyOn(internals, "createRedirectServer").mockResolvedValue("http://localhost:12345");
+  let presented!: () => void;
+  const challenge = new Promise<void>((resolve) => {
+    presented = resolve;
+  });
+  vi.spyOn(internals, "openChallengeBrowser").mockImplementation(async () => {
+    presented();
+  });
+  const abort = new AbortController();
+  const authenticating = auth.login({ signal: abort.signal });
+  const rejected = expect(authenticating).rejects.toThrow();
+  await challenge;
+  abort.abort();
+  await rejected;
+  expect(close).toHaveBeenCalledOnce();
 });

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,17 +1,37 @@
-import { AuthenticatedUserQueryDocument as AUTHENTICATED_USER_QUERY } from "./graphql/operations/AuthenticatedUserQuery.generated.js";
-import { ListUserTenantsDocument as LIST_USER_TENANTS } from "./graphql/operations/ListUserTenants.generated.js";
+import chalk from "chalk";
 import crypto from "crypto";
 import http from "http";
-import { jwtDecode } from "jwt-decode";
 import inquirer from "inquirer";
-import chalk from "chalk";
+import { jwtDecode } from "jwt-decode";
+import open from "open";
+import { z } from "zod";
+import { commandSignal, writeCommandOutput } from "./command.js";
 import { deleteProfile, getActiveProfileName, writeActiveProfile } from "./config.js";
 import { type AuthContext, getAuthContext, getPrismaticUrl } from "./context.js";
+import { AuthenticatedUserQueryDocument as AUTHENTICATED_USER_QUERY } from "./graphql/operations/AuthenticatedUserQuery.generated.js";
+import { ListUserTenantsDocument as LIST_USER_TENANTS } from "./graphql/operations/ListUserTenants.generated.js";
 import { gqlRequest } from "./graphql.js";
-import type { AddressInfo } from "net";
-import open from "open";
-import { whoAmI } from "./utils/user/query.js";
 import { fetch } from "./utils/http.js";
+import { whoAmI } from "./utils/user/query.js";
+
+const tokenResponseSchema = z.object({
+  access_token: z.string(),
+  expires_in: z.number(),
+  refresh_token: z.string().optional(),
+  scope: z.string().default(""),
+  token_type: z.string(),
+});
+
+const tokenErrorResponseSchema = z.object({
+  error: z.string(),
+  error_description: z.string().optional(),
+});
+
+const authConfigSchema = z.object({
+  domain: z.string(),
+  clientId: z.string(),
+  audience: z.string(),
+});
 
 const urlEncodeBase64 = (value: Buffer | string): string => {
   const buffer = typeof value === "string" ? Buffer.from(value) : value;
@@ -128,41 +148,56 @@ export class Authenticate {
    * Start the PKCE authentication flow
    * @returns Promise containing authentication result
    */
-  async login(props?: { url?: boolean }): Promise<Auth> {
+  async login(props?: {
+    url?: boolean;
+    signal?: AbortSignal;
+    onChallenge?: (url: string) => void;
+  }): Promise<Auth> {
     const verifier = codeVerifier();
     const challenge = codeChallenge(verifier);
     const state = codeState();
 
     const redirectUri = await this.createRedirectServer();
 
-    if (props?.url) {
-      const challengeUrl = await this.getChallengeUrl(challenge, state, redirectUri);
-      console.log(challengeUrl);
-    } else {
-      await this.openChallengeBrowser(challenge, state, redirectUri);
-    }
-
     return new Promise<Auth>((resolve, reject) => {
-      // Close the redirect server if we don't get a response
-      const timeoutHandle = setTimeout(this.redirectServer.close, 3 * 60 * 1000);
-
-      this.redirectServer.on("request", (request, response) => {
+      const signal = props?.signal ?? commandSignal();
+      const cleanup = () => {
         clearTimeout(timeoutHandle);
-
-        response.writeHead(301, {
-          Location: this.options.successRedirectUri,
-        });
-        response.end();
-
+        signal?.removeEventListener("abort", aborted);
         this.redirectServer.close();
+      };
+      const fail = (error: unknown) => {
+        cleanup();
+        reject(error);
+      };
+      const aborted = () => fail(signal?.reason ?? new Error("Authentication cancelled."));
+      const timeoutHandle = setTimeout(
+        () => fail(new Error("Authentication timed out after 3 minutes.")),
+        3 * 60 * 1000,
+      );
+      signal?.addEventListener("abort", aborted, { once: true });
+      if (signal?.aborted) {
+        aborted();
+        return;
+      }
 
+      this.redirectServer.once("request", (request, response) => {
+        response.writeHead(301, { Location: this.options.successRedirectUri });
+        response.end();
+        cleanup();
         validateAuthorizationToken(request.url || "", state)
-          .then(async (authorizationToken) =>
+          .then((authorizationToken) =>
             this.retrieveAuthenticationToken(verifier, authorizationToken, redirectUri),
           )
-          .then(resolve)
-          .catch(reject);
+          .then(resolve, reject);
       });
+
+      const presentChallenge = props?.url
+        ? this.getChallengeUrl(challenge, state, redirectUri).then((url) =>
+            props?.onChallenge ? props.onChallenge(url) : writeCommandOutput(url),
+          )
+        : this.openChallengeBrowser(challenge, state, redirectUri);
+      void presentChallenge.catch(fail);
     });
   }
 
@@ -182,15 +217,18 @@ export class Authenticate {
       },
     });
 
-    const response = (await fetchResponse.json()) as any;
+    const responseBody = await fetchResponse.json();
+    const errorResponse = tokenErrorResponseSchema.safeParse(responseBody);
 
-    if (response.error === "access_denied") {
+    if (errorResponse.success && errorResponse.data.error === "access_denied") {
       const description =
-        response.error_description || "You do not have access to the specified tenant.";
+        errorResponse.data.error_description || "You do not have access to the specified tenant.";
       throw new Error(
         `Access denied${tenantId ? ` for tenant ID '${tenantId}'` : ""}. ${description}`,
       );
     }
+
+    const response = tokenResponseSchema.parse(responseBody);
 
     return {
       accessToken: response.access_token,
@@ -233,7 +271,11 @@ export class Authenticate {
       this.retry(5, this.attemptServerCreate)
         .then((server) => {
           this.redirectServer = server;
-          const info = server.address() as AddressInfo;
+          const info = server.address();
+          if (info === null || typeof info === "string") {
+            reject(new Error("Redirect server did not provide a TCP address."));
+            return;
+          }
           const redirectUrl = new URL("http://localhost");
           redirectUrl.port = String(info.port);
           resolve(redirectUrl.toString());
@@ -262,7 +304,9 @@ export class Authenticate {
         "Content-Type": "application/x-www-form-urlencoded",
       },
     });
-    const response = (await fetchResponse.json()) as any;
+    const response = tokenResponseSchema
+      .extend({ refresh_token: z.string() })
+      .parse(await fetchResponse.json());
     return {
       accessToken: response.access_token,
       expiresIn: response.expires_in,
@@ -304,7 +348,7 @@ export class Authenticate {
 const getAuthOptions = async (prismaticUrl?: string) => {
   const resolvedUrl = prismaticUrl ?? (await getPrismaticUrl());
   const fetchResponse = await fetch(new URL("/auth/meta", resolvedUrl).toString());
-  const authConfig = (await fetchResponse.json()) as any;
+  const authConfig = authConfigSchema.parse(await fetchResponse.json());
 
   const { domain, clientId, audience } = authConfig;
   return {
@@ -346,7 +390,7 @@ export const selectTenant = async (
 
   const activeTenants = tenants.filter((t) => !t.systemSuspended);
   if (activeTenants.length === 0) {
-    console.log(
+    writeCommandOutput(
       chalk.red(
         "You have no active tenants on this stack. Please contact Prismatic support for assistance.",
       ),
@@ -388,13 +432,24 @@ export const selectTenant = async (
   }
 };
 
-export const login = async (props?: { url: boolean; profileName?: string }) => {
+export const login = async (props?: {
+  signal?: AbortSignal;
+  onChallenge?: (url: string) => void;
+  nonInteractive?: boolean;
+  profileName?: string;
+  tenantId?: string;
+  url: boolean;
+}) => {
   const profileName = props?.profileName ?? (await getActiveProfileName());
   const prismaticUrl = await getPrismaticUrl();
   const authOptions = await getAuthOptions(prismaticUrl);
   const auth = new Authenticate(authOptions);
 
-  const initialAuth = await auth.login({ url: props?.url });
+  const initialAuth = await auth.login({
+    url: props?.url,
+    signal: props?.signal,
+    onChallenge: props?.onChallenge,
+  });
   await writeActiveProfile(initialAuth, profileName);
 
   const tenants = await fetchUserTenants();
@@ -415,13 +470,27 @@ export const login = async (props?: { url: boolean; profileName?: string }) => {
   }
 
   const activeTenants = tenants.filter((t) => !t.systemSuspended);
+  const requestedTenant = props?.tenantId
+    ? activeTenants.find((tenant) => tenant.tenantId === props.tenantId)
+    : undefined;
+  if (props?.tenantId && !requestedTenant) {
+    throw new Error(`Tenant '${props.tenantId}' is not available to this profile.`);
+  }
   if (!initialTenantSuspended && activeTenants.length <= 1) {
     return;
   }
-
-  const selectedTenantId = await selectTenant(tenants, {
-    currentTenantId: initialTenantId,
-  });
+  if (props?.nonInteractive && !requestedTenant) {
+    throw new Error(
+      `Multiple tenants are available. Re-run with --tenant-id (${activeTenants
+        .map((tenant) => tenant.tenantId)
+        .join(", ")}).`,
+    );
+  }
+  const selectedTenantId =
+    requestedTenant?.tenantId ??
+    (await selectTenant(tenants, {
+      currentTenantId: initialTenantId,
+    }));
 
   if (selectedTenantId) {
     const tenantAuth = await auth.refresh(initialAuth.refreshToken, selectedTenantId);

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,3 +1,4 @@
+import { runWithEnvironment } from "./runtime.js";
 import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { devNull, tmpdir } from "node:os";
 import path from "node:path";
@@ -452,4 +453,26 @@ describe("unversioned config support", () => {
     expect(contents).toContain("defaultProfile: default");
     expect(contents).toContain("accessToken: fresh-token");
   });
+});
+
+it("retains concurrent profile updates without changing request environment", async () => {
+  const directory = await mkdtemp(path.join(tmpdir(), "prism-concurrent-profiles-"));
+  const configPath = path.join(directory, "config.yml");
+  const environment = { ...process.env, PRISM_CONFIG_FILE: configPath };
+  try {
+    await Promise.all(
+      Array.from({ length: 12 }, (_, index) =>
+        runWithEnvironment({ ...environment, PRISM_PROFILE: `profile-${index}` }, async () => {
+          await writeActiveProfile(makeConfig({ accessToken: `token-${index}` }));
+          expect(await getActiveProfileName()).toBe(`profile-${index}`);
+        }),
+      ),
+    );
+    const file = await runWithEnvironment(environment, readConfigFile);
+    expect(Object.keys(file?.profiles ?? {})).toHaveLength(12);
+    for (let index = 0; index < 12; index++)
+      expect(file?.profiles[`profile-${index}`].accessToken).toBe(`token-${index}`);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,10 @@
+import { devNull } from "node:os";
+import { randomUUID } from "node:crypto";
 import path from "path";
 import { z } from "zod";
 import { DEFAULT_PRISMATIC_URL, getEnv } from "./env.js";
 import { fs } from "./fs.js";
+import { getRuntimeState } from "./runtime.js";
 import { dumpYaml, loadYaml } from "./utils/serialize.js";
 import { formatValidationError } from "./utils/validation.js";
 
@@ -64,6 +67,26 @@ const normalizeUnversionedConfig = (raw: Record<string, unknown>): unknown => ({
 
 const getConfigFilePath = (): string => getEnv().PRISM_CONFIG_FILE;
 
+// Serialize only updates to the same configuration file; readers see an atomic
+// replacement and unrelated commands/configuration files remain concurrent.
+const configWrites = new Map<string, Promise<void>>();
+const updateConfig = async <T>(operation: () => Promise<T>): Promise<T> => {
+  const configPath = path.resolve(getConfigFilePath());
+  const previous = configWrites.get(configPath) ?? Promise.resolve();
+  let release!: () => void;
+  const current = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  configWrites.set(configPath, current);
+  await previous;
+  try {
+    return await operation();
+  } finally {
+    release();
+    if (configWrites.get(configPath) === current) configWrites.delete(configPath);
+  }
+};
+
 const writeConfigFile = async (configFile: ConfigFile) => {
   const result = configFileSchema.safeParse(configFile);
   if (!result.success) {
@@ -71,10 +94,21 @@ const writeConfigFile = async (configFile: ConfigFile) => {
       `Prism could not save its configuration:\n${formatValidationError(result.error)}`,
     );
   }
-  const configFilePath = getConfigFilePath();
+  const requestedPath = getConfigFilePath();
+  if (requestedPath === devNull) return;
+  const configFilePath = await fs.realpath(requestedPath).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT") return requestedPath;
+    throw error;
+  });
   await fs.mkdir(path.dirname(configFilePath), { recursive: true });
   const contents = dumpYaml(result.data, { skipInvalid: true });
-  await fs.writeFile(configFilePath, contents, { encoding: "utf-8" });
+  const temporaryPath = `${configFilePath}.${randomUUID()}.tmp`;
+  try {
+    await fs.writeFile(temporaryPath, contents, { encoding: "utf-8", mode: 0o600 });
+    await fs.rename(temporaryPath, configFilePath);
+  } finally {
+    await fs.rm(temporaryPath, { force: true });
+  }
 };
 
 export const readConfigFile = async (): Promise<ConfigFile | null> => {
@@ -107,7 +141,9 @@ export const readConfigFile = async (): Promise<ConfigFile | null> => {
 };
 
 const resolveActiveName = (file: ConfigFile | null): ProfileName => {
-  if (selectedProfile) return selectedProfile;
+  const runtimeProfile = getRuntimeState()?.selectedProfile;
+  if (runtimeProfile) return runtimeProfile;
+  if (!getRuntimeState() && selectedProfile) return selectedProfile;
   const envProfile = getEnv().PRISM_PROFILE;
   if (envProfile) return envProfile;
   return file?.defaultProfile ?? "default";
@@ -127,36 +163,39 @@ export const readProfileSelection = async (
 export const readProfile = async (name?: ProfileName): Promise<Profile | null> =>
   (await readProfileSelection(name)).profile;
 
-export const writeProfile = async (name: ProfileName, profile: Profile) => {
-  await writeConfigFile(withProfile(await readConfigFile(), name, profile));
-};
+export const writeProfile = async (name: ProfileName, profile: Profile) =>
+  updateConfig(async () => {
+    await writeConfigFile(withProfile(await readConfigFile(), name, profile));
+  });
 
-export const deleteProfile = async (name: ProfileName) => {
-  const file = await readConfigFile();
-  if (!file || !hasProfile(file.profiles, name)) return { deleted: false } as const;
+export const deleteProfile = async (name: ProfileName) =>
+  updateConfig(async () => {
+    const file = await readConfigFile();
+    if (!file || !hasProfile(file.profiles, name)) return { deleted: false } as const;
 
-  const { [name]: _removed, ...remaining } = file.profiles;
-  const remainingNames = Object.keys(remaining);
+    const { [name]: _removed, ...remaining } = file.profiles;
+    const remainingNames = Object.keys(remaining);
 
-  if (remainingNames.length === 0) {
-    await fs.unlink(getConfigFilePath());
-    return { deleted: true, isLast: true } as const;
-  }
+    if (remainingNames.length === 0) {
+      await fs.unlink(getConfigFilePath());
+      return { deleted: true, isLast: true } as const;
+    }
 
-  const defaultChanged = file.defaultProfile === name;
-  const defaultProfile = defaultChanged ? remainingNames[0] : file.defaultProfile;
-  await writeConfigFile({ version: CONFIG_VERSION, defaultProfile, profiles: remaining });
-  return { deleted: true, isLast: false, defaultChanged, defaultProfile } as const;
-};
+    const defaultChanged = file.defaultProfile === name;
+    const defaultProfile = defaultChanged ? remainingNames[0] : file.defaultProfile;
+    await writeConfigFile({ version: CONFIG_VERSION, defaultProfile, profiles: remaining });
+    return { deleted: true, isLast: false, defaultChanged, defaultProfile } as const;
+  });
 
-export const useProfile = async (name: ProfileName) => {
-  const file = await readConfigFile();
-  if (!file || !hasProfile(file.profiles, name)) {
-    throw new Error(`Profile "${name}" does not exist.`);
-  }
-  if (file.defaultProfile === name) return;
-  await writeConfigFile({ ...file, defaultProfile: name });
-};
+export const useProfile = async (name: ProfileName) =>
+  updateConfig(async () => {
+    const file = await readConfigFile();
+    if (!file || !hasProfile(file.profiles, name)) {
+      throw new Error(`Profile "${name}" does not exist.`);
+    }
+    if (file.defaultProfile === name) return;
+    await writeConfigFile({ ...file, defaultProfile: name });
+  });
 
 export const listProfiles = async (): Promise<
   { name: ProfileName; prismaticUrl: string; tenantId?: string; isDefault: boolean }[]
@@ -171,9 +210,10 @@ export const listProfiles = async (): Promise<
   }));
 };
 
-export const writeActiveProfile = async (config: Configuration, name?: ProfileName) => {
-  const file = await readConfigFile();
-  const profileName = name ?? resolveActiveName(file);
-  const prismaticUrl = file?.profiles[profileName]?.prismaticUrl ?? resolveProfileUrl();
-  await writeConfigFile(withProfile(file, profileName, { ...config, prismaticUrl }));
-};
+export const writeActiveProfile = async (config: Configuration, name?: ProfileName) =>
+  updateConfig(async () => {
+    const file = await readConfigFile();
+    const profileName = name ?? resolveActiveName(file);
+    const prismaticUrl = file?.profiles[profileName]?.prismaticUrl ?? resolveProfileUrl();
+    await writeConfigFile(withProfile(file, profileName, { ...config, prismaticUrl }));
+  });

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,6 @@
 import { readProfileSelection } from "./config.js";
 import { DEFAULT_PRISMATIC_URL, getEnv } from "./env.js";
+import { getRuntimeState } from "./runtime.js";
 
 export type AuthContext = {
   source: "environment" | "profile";
@@ -27,8 +28,9 @@ export const useProfileAuthContext = (): void => {
 
 export const getAuthContext = async (): Promise<AuthContext> => {
   const env = getEnv();
-  if (profileOnly) return resolveProfileAuthContext();
-  if (!profileOnly && (env.PRISM_ACCESS_TOKEN || env.PRISM_REFRESH_TOKEN)) {
+  const useProfileOnly = getRuntimeState()?.profileOnly ?? profileOnly;
+  if (useProfileOnly) return resolveProfileAuthContext();
+  if (!useProfileOnly && (env.PRISM_ACCESS_TOKEN || env.PRISM_REFRESH_TOKEN)) {
     return {
       source: "environment",
       url: env.PRISMATIC_URL ?? DEFAULT_PRISMATIC_URL,

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,3 +1,4 @@
+import { getRuntimeEnvironment } from "./runtime.js";
 import { homedir } from "os";
 import path from "path";
 import { z } from "zod";
@@ -27,4 +28,4 @@ const envSchema = z.object({
 
 export type Env = z.infer<typeof envSchema>;
 
-export const getEnv = (): Env => envSchema.parse(process.env);
+export const getEnv = (): Env => envSchema.parse(getRuntimeEnvironment());

--- a/src/errors.test.ts
+++ b/src/errors.test.ts
@@ -3,8 +3,8 @@ import { processError } from "./errors.js";
 import { ClientError } from "./graphql.js";
 
 describe("processError", () => {
-  it("passes OclifError through unchanged", () => {
-    const err = Object.assign(new Error("boom"), { oclif: { exit: 2 } });
+  it("passes framework errors through unchanged", () => {
+    const err = Object.assign(new Error("boom"), { exitCode: 2 });
     const out = processError(err);
     expect(out).toBe(err);
   });

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,14 +1,8 @@
-import type { handle, Interfaces } from "@oclif/core";
 import { getReasonPhrase, StatusCodes } from "http-status-codes";
 import type { ClientError } from "./graphql.js";
 
-type OclifError = Interfaces.OclifError;
-
 const isError = (error: unknown): error is Error =>
   Boolean(error) && typeof error === "object" && error !== null && "message" in error;
-
-const isOclifError = (error: unknown): error is Error & OclifError =>
-  isError(error) && "oclif" in error;
 
 const isClientError = (error: unknown): error is ClientError =>
   isError(error) && "response" in error && "request" in error;
@@ -45,32 +39,20 @@ const extractResponseError = ({ response: { errors = [], status } }: ClientError
   }
 };
 
-type ErrorToHandle = Parameters<typeof handle>[0];
-
-export const processError = (error: unknown): ErrorToHandle => {
-  if (isOclifError(error)) {
-    return error;
-  }
-
+export const processError = (error: unknown): Error => {
   if (isClientError(error)) {
-    return {
-      ...error,
+    return Object.assign(new Error(extractResponseError(error)), {
       name: errorName(error, "ClientError"),
-      message: extractResponseError(error),
-    };
+    });
   }
 
-  // Oclif needs the non-enumerable error name copied explicitly.
+  // Preserve the non-enumerable error name when normalizing errors.
   if (isError(error)) {
-    return {
-      ...error,
+    return Object.assign(error, {
       name: errorName(error),
       message: fallbackMessage(error.message, "Unknown error"),
-    };
+    });
   }
 
-  return {
-    name: "Error",
-    message: fallbackMessage(String(error), "Unknown error"),
-  };
+  return new Error(fallbackMessage(String(error), "Unknown error"));
 };

--- a/src/fs.test.ts
+++ b/src/fs.test.ts
@@ -1,0 +1,11 @@
+import { expect, it } from "vitest";
+import { runWithMcpTransport } from "./command.js";
+import { readStdin } from "./fs.js";
+
+it("leaves MCP transport listeners untouched when a file command requests stdin", async () => {
+  const listeners = process.stdin.eventNames().map((name) => [name, process.stdin.listeners(name)]);
+  await expect(runWithMcpTransport(readStdin)).rejects.toMatchObject({ code: "STDIN_UNAVAILABLE" });
+  expect(process.stdin.eventNames().map((name) => [name, process.stdin.listeners(name)])).toEqual(
+    listeners,
+  );
+});

--- a/src/fs.ts
+++ b/src/fs.ts
@@ -1,5 +1,6 @@
 import { promises as fs } from "fs";
 import path from "path";
+import { assertCommandStdinAvailable } from "./command.js";
 
 export const exists = async (path: string): Promise<boolean> => {
   return fs.access(path).then(
@@ -9,6 +10,7 @@ export const exists = async (path: string): Promise<boolean> => {
 };
 
 export const readStdin = async (): Promise<string> => {
+  assertCommandStdinAvailable();
   return new Promise((resolve, reject) => {
     process.stdin
       .on("readable", () => {

--- a/src/graphql.ts
+++ b/src/graphql.ts
@@ -1,8 +1,11 @@
-import { print } from "graphql";
-import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
 import { URL } from "url";
+import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
+import { print } from "graphql";
+import { z } from "zod";
 import { getAccessToken } from "./auth.js";
+import { writeCommandStatus } from "./command.js";
 import { getPrismaticUrl } from "./context.js";
+import { isPrintRequestsEnabled } from "./runtime.js";
 import { fetch } from "./utils/http.js";
 
 interface GQLRequest<TData, TVariables = Record<string, unknown>> {
@@ -59,13 +62,29 @@ export const gql = (strings: TemplateStringsArray, ...values: unknown[]): string
 };
 
 const isErrored = (result: unknown): result is ErroredResult => {
-  if (!(Boolean(result) && typeof result === "object" && result !== null && "errors" in result)) {
-    return false;
-  }
-
-  const assumed = result as ErroredResult;
-  return Boolean(assumed.errors) && assumed.errors.length > 0;
+  return erroredResultSchema.safeParse(result).success;
 };
+
+const erroredResultSchema = z.looseObject({
+  errors: z.array(
+    z.object({
+      field: z.string(),
+      messages: z.array(z.string()),
+    }),
+  ),
+});
+
+const graphQLErrorSchema = z.object({
+  message: z.string(),
+  locations: z.array(z.object({ line: z.number(), column: z.number() })).optional(),
+  path: z.array(z.union([z.string(), z.number()])).optional(),
+});
+
+const graphQLResponseSchema = <T>(dataSchema: z.ZodType<T>) =>
+  z.object({
+    data: dataSchema.optional(),
+    errors: z.array(graphQLErrorSchema).optional(),
+  });
 
 const formatError = (field: string, messages: string[]) => {
   const message = messages.join("\n");
@@ -91,16 +110,16 @@ export const gqlRequest = async <T = unknown, TVariables = Record<string, unknow
 
   const query = typeof document === "string" ? document : print(document);
 
-  if (process.env.PRISMATIC_PRINT_REQUESTS) {
-    console.log("=================================");
-    console.log(`GraphQL Request: ${query}`);
-    console.log(`Variables: ${JSON.stringify(variables)}`);
-    console.log("=================================");
+  if (isPrintRequestsEnabled()) {
+    writeCommandStatus("=================================");
+    writeCommandStatus(`GraphQL Request: ${query}`);
+    writeCommandStatus(`Variables: ${JSON.stringify(variables)}`);
+    writeCommandStatus("=================================");
   }
 
-  let response: Response;
+  let response: Awaited<ReturnType<typeof fetch>>;
   try {
-    response = (await fetch(url, {
+    response = await fetch(url, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -111,7 +130,7 @@ export const gqlRequest = async <T = unknown, TVariables = Record<string, unknow
         query,
         variables: variables || {},
       }),
-    })) as unknown as Response;
+    });
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : String(error);
     throw new Error(`Network request to ${url} failed: ${errorMessage}`);
@@ -121,7 +140,7 @@ export const gqlRequest = async <T = unknown, TVariables = Record<string, unknow
 
   let responseBody: GraphQLResponse<T>;
   try {
-    responseBody = await response.json();
+    responseBody = graphQLResponseSchema(z.custom<T>()).parse(await response.json());
   } catch (_error) {
     throw new ClientError(
       {
@@ -144,9 +163,9 @@ export const gqlRequest = async <T = unknown, TVariables = Record<string, unknow
     );
   }
 
-  const result = responseBody.data as T;
+  const result = responseBody.data;
 
-  const errors = Object.values(result as any)
+  const errors = Object.values(result)
     .filter(isErrored)
     .flatMap(({ errors }) => errors)
     .map(({ field, messages }) => formatError(field, messages));

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -17,13 +17,13 @@ function formatIssue(issue: z.core.$ZodIssue): string {
  * Validate command flags against a Zod schema.
  * Throws an error with a formatted message if validation fails.
  *
- * Use oclif's built-in flag options for simple cases:
+ * Use the command schema's built-in options for simple cases:
  * - `required: true` for required flags
  * - `exclusive: ["other-flag"]` for mutual exclusivity
  * - `dependsOn: ["other-flag"]` for dependencies
  *
  * Use Zod's `.refine()` or `.superRefine()` for complex conditional logic
- * that oclif can't express.
+ * that field relationships cannot express.
  */
 export function validateFlags<T extends z.ZodType>(schema: T, flags: unknown): z.infer<T> {
   const result = schema.safeParse(flags);


### PR DESCRIPTION
Isolate authentication and profile state per invocation.

Part **6/24** of the native incur migration. This PR targets `incur-05-command-runtime`; the stack integrates into the long-lived `agent` branch. Review this diff against its immediate base.

Validation: format/lint, TypeScript, bundle, and **336 passing tests** (3 skipped) on Node 24. CI also checks Node 22/24/26 and Windows.

Review size: **458 handwritten changed lines**; counts include additions and deletions.

[Stack review guide](https://github.com/prismatic-io/prism/blob/incur-24-review-evidence/docs/incur-pr-stack.md). Merge bottom-up; rebase descendants after a squash merge.
