### PR TITLE
[incur 07/24] Add native table schemas and structured output helpers

### DIFF
--- a/src/commands/alerts/events/list.ts
+++ b/src/commands/alerts/events/list.ts
@@ -3,7 +3,7 @@ import { Args } from "@oclif/core";
 import { ListAlertEventsDocument as LIST_ALERT_EVENTS } from "../../../graphql/operations/listAlertEvents.generated.js";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest } from "../../../graphql.js";
-import { ux } from "../../../utils/ux.js";
+import { ux } from "../../../utils/legacy-ux.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Alert Events for an Alert Monitor";

--- a/src/commands/alerts/groups/list.ts
+++ b/src/commands/alerts/groups/list.ts
@@ -2,7 +2,7 @@ import type { ResultOf } from "@graphql-typed-document-node/core";
 import { ListAlertGroupsDocument as LIST_ALERT_GROUPS } from "../../../graphql/alerts/listAlertGroups.generated.js";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest } from "../../../graphql.js";
-import { ux } from "../../../utils/ux.js";
+import { ux } from "../../../utils/legacy-ux.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Alert Groups in your Organization";

--- a/src/commands/alerts/monitors/list.ts
+++ b/src/commands/alerts/monitors/list.ts
@@ -2,7 +2,7 @@ import type { ResultOf } from "@graphql-typed-document-node/core";
 import { ListAlertMonitorsDocument as LIST_ALERT_MONITORS } from "../../../graphql/alerts/listAlertMonitors.generated.js";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest } from "../../../graphql.js";
-import { ux } from "../../../utils/ux.js";
+import { ux } from "../../../utils/legacy-ux.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Alert Monitors for Customer Instances";

--- a/src/commands/alerts/triggers/list.ts
+++ b/src/commands/alerts/triggers/list.ts
@@ -2,7 +2,7 @@ import type { ResultOf } from "@graphql-typed-document-node/core";
 import { ListAlertTriggersDocument as LIST_ALERT_TRIGGERS } from "../../../graphql/operations/listAlertTriggers.generated.js";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest } from "../../../graphql.js";
-import { ux } from "../../../utils/ux.js";
+import { ux } from "../../../utils/legacy-ux.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Alert Triggers";

--- a/src/commands/alerts/webhooks/list.ts
+++ b/src/commands/alerts/webhooks/list.ts
@@ -2,7 +2,7 @@ import type { ResultOf } from "@graphql-typed-document-node/core";
 import { ListAlertWebhooksDocument as LIST_ALERT_WEBHOOKS } from "../../../graphql/alerts/listAlertWebhooks.generated.js";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest } from "../../../graphql.js";
-import { ux } from "../../../utils/ux.js";
+import { ux } from "../../../utils/legacy-ux.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Alert Webhooks";

--- a/src/commands/components/actions/list.ts
+++ b/src/commands/components/actions/list.ts
@@ -3,7 +3,7 @@ import { ListComponentActionsDocument as LIST_COMPONENT_ACTIONS } from "../../..
 import { Args, Flags } from "@oclif/core";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest } from "../../../graphql.js";
-import { ux } from "../../../utils/ux.js";
+import { ux } from "../../../utils/legacy-ux.js";
 
 interface ActionNode {
   [index: string]: unknown;

--- a/src/commands/components/data-sources/list.ts
+++ b/src/commands/components/data-sources/list.ts
@@ -4,7 +4,7 @@ import type { ListComponentActions2Query } from "../../../graphql/operations/lis
 import { Args, Flags } from "@oclif/core";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest } from "../../../graphql.js";
-import { ux } from "../../../utils/ux.js";
+import { ux } from "../../../utils/legacy-ux.js";
 
 type ComponentDataSourceNode = NonNullable<
   ListComponentActions2Query["components"]["nodes"][number]

--- a/src/commands/components/dev/test.ts
+++ b/src/commands/components/dev/test.ts
@@ -7,7 +7,7 @@ import open from "open";
 import { promisify } from "util";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { exists } from "../../../fs.js";
-import { ux } from "../../../utils/ux.js";
+import { ux } from "../../../utils/legacy-ux.js";
 import { deleteComponentByKey } from "../../../utils/component/deleteByKey.js";
 import {
   createComponentPackage,

--- a/src/commands/components/list.ts
+++ b/src/commands/components/list.ts
@@ -4,7 +4,7 @@ import { Flags } from "@oclif/core";
 import dayjs from "dayjs";
 import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { gqlRequest } from "../../graphql.js";
-import { ux } from "../../utils/ux.js";
+import { ux } from "../../utils/legacy-ux.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List available Components";

--- a/src/commands/components/publish.ts
+++ b/src/commands/components/publish.ts
@@ -1,7 +1,7 @@
 import { Flags } from "@oclif/core";
 
 import { PrismaticBaseCommand } from "../../baseCommand.js";
-import { ux } from "../../utils/ux.js";
+import { ux } from "../../utils/legacy-ux.js";
 import {
   createComponentPackage,
   createSourceCodePackage,

--- a/src/commands/components/triggers/list.ts
+++ b/src/commands/components/triggers/list.ts
@@ -3,7 +3,7 @@ import { ListComponentTriggersDocument as LIST_COMPONENT_TRIGGERS } from "../../
 import { Args, Flags } from "@oclif/core";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest } from "../../../graphql.js";
-import { ux } from "../../../utils/ux.js";
+import { ux } from "../../../utils/legacy-ux.js";
 
 interface TriggerNode {
   [index: string]: unknown;

--- a/src/commands/customers/list.ts
+++ b/src/commands/customers/list.ts
@@ -2,7 +2,7 @@ import type { ResultOf } from "@graphql-typed-document-node/core";
 import { ListCustomersDocument as LIST_CUSTOMERS } from "../../graphql/customers/listCustomers.generated.js";
 import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { gqlRequest } from "../../graphql.js";
-import { ux } from "../../utils/ux.js";
+import { ux } from "../../utils/legacy-ux.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List your Customers";

--- a/src/commands/customers/users/list.ts
+++ b/src/commands/customers/users/list.ts
@@ -3,7 +3,7 @@ import { ListCustomerUsersDocument as LIST_CUSTOMER_USERS } from "../../../graph
 import { Args } from "@oclif/core";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest, requireResource } from "../../../graphql.js";
-import { ux } from "../../../utils/ux.js";
+import { ux } from "../../../utils/legacy-ux.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Customer Users";

--- a/src/commands/customers/users/roles.ts
+++ b/src/commands/customers/users/roles.ts
@@ -2,7 +2,7 @@ import type { ResultOf } from "@graphql-typed-document-node/core";
 import { ListCustomerRolesDocument as LIST_CUSTOMER_ROLES } from "../../../graphql/operations/listCustomerRoles.generated.js";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest } from "../../../graphql.js";
-import { ux } from "../../../utils/ux.js";
+import { ux } from "../../../utils/legacy-ux.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Roles you can grant to Customer Users";

--- a/src/commands/graphql/query.ts
+++ b/src/commands/graphql/query.ts
@@ -3,7 +3,7 @@ import { readFileSync } from "fs";
 import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { gqlRequest } from "../../graphql.js";
 import { dumpYaml } from "../../utils/serialize.js";
-import { ux } from "../../utils/ux.js";
+import { ux } from "../../utils/legacy-ux.js";
 
 export default class QueryCommand extends PrismaticBaseCommand {
   static description = "Execute an arbitrary GraphQL query against the Prismatic API";

--- a/src/commands/instances/config-vars/list.ts
+++ b/src/commands/instances/config-vars/list.ts
@@ -3,7 +3,7 @@ import { ListInstanceConfigVariablesDocument as LIST_INSTANCE_CONFIG_VARIABLES }
 import { Args } from "@oclif/core";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest, requireResource } from "../../../graphql.js";
-import { ux } from "../../../utils/ux.js";
+import { ux } from "../../../utils/legacy-ux.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Config Variables used on an Instance";

--- a/src/commands/instances/flow-configs/list.ts
+++ b/src/commands/instances/flow-configs/list.ts
@@ -3,7 +3,7 @@ import { ListInstanceFlowConfigsDocument as LIST_INSTANCE_FLOW_CONFIGS } from ".
 import { Args } from "@oclif/core";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest, requireResource } from "../../../graphql.js";
-import { ux } from "../../../utils/ux.js";
+import { ux } from "../../../utils/legacy-ux.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Instance Flow Configs";

--- a/src/commands/instances/flow-configs/test.ts
+++ b/src/commands/instances/flow-configs/test.ts
@@ -4,7 +4,7 @@ import { TestInstanceFlowConfigDocument as TEST_INSTANCE_FLOW_CONFIG } from "../
 import { Args, Flags } from "@oclif/core";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest } from "../../../graphql.js";
-import { ux } from "../../../utils/ux.js";
+import { ux } from "../../../utils/legacy-ux.js";
 
 interface LogNode {
   [index: string]: unknown;

--- a/src/commands/instances/list.ts
+++ b/src/commands/instances/list.ts
@@ -3,7 +3,7 @@ import { ListInstancesDocument as LIST_INSTANCES } from "../../graphql/instances
 import { Flags } from "@oclif/core";
 import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { gqlRequest } from "../../graphql.js";
-import { ux } from "../../utils/ux.js";
+import { ux } from "../../utils/legacy-ux.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Instances";

--- a/src/commands/integrations/flows/list.ts
+++ b/src/commands/integrations/flows/list.ts
@@ -1,7 +1,7 @@
 import { Args } from "@oclif/core";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { getIntegrationFlows } from "../../../utils/integration/flows.js";
-import { ux } from "../../../utils/ux.js";
+import { ux } from "../../../utils/legacy-ux.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Integration Flows";

--- a/src/commands/integrations/flows/listen.test.ts
+++ b/src/commands/integrations/flows/listen.test.ts
@@ -27,7 +27,7 @@ vi.mock(import("inquirer"), () => ({
   },
 }));
 
-vi.mock(import("../../../utils/ux.js"), async (importOriginal) => {
+vi.mock(import("../../../utils/legacy-ux.js"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,

--- a/src/commands/integrations/flows/listen.ts
+++ b/src/commands/integrations/flows/listen.ts
@@ -16,7 +16,7 @@ import { fetch } from "../../../utils/http.js";
 import { type IntegrationFlow, resolveFlow } from "../../../utils/integration/flows.js";
 import { runIntegrationFlow } from "../../../utils/integration/invoke.js";
 import { getAdaptivePollIntervalMs } from "../../../utils/polling.js";
-import { ux } from "../../../utils/ux.js";
+import { ux } from "../../../utils/legacy-ux.js";
 
 const DEFAULT_TIMEOUT_SECONDS = 1200; // 20 minutes
 const DEFAULT_OUTPUT_DIR = "./payloads";

--- a/src/commands/integrations/flows/test.ts
+++ b/src/commands/integrations/flows/test.ts
@@ -8,7 +8,7 @@ import { getPrismaticUrl } from "../../../context.js";
 import { exists, fs } from "../../../fs.js";
 import { handleError } from "../../../utils/errors.js";
 import { fetch } from "../../../utils/http.js";
-import { ux } from "../../../utils/ux.js";
+import { ux } from "../../../utils/legacy-ux.js";
 import {
   type FetchLogsResult,
   getExecutionLogs,

--- a/src/commands/integrations/import.test.ts
+++ b/src/commands/integrations/import.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { ComponentDefinition } from "../../utils/component/index.js";
-import { ux } from "../../utils/ux.js";
+import { ux } from "../../utils/legacy-ux.js";
 import ImportCommand from "./import.js";
 
 vi.mock(import("../../fs.js"), () => ({

--- a/src/commands/integrations/import.ts
+++ b/src/commands/integrations/import.ts
@@ -10,7 +10,7 @@ import {
   loadCodeNativeIntegrationEntryPoint,
 } from "../../utils/integration/import.js";
 import { openIntegration } from "../../utils/integration/open.js";
-import { ux } from "../../utils/ux.js";
+import { ux } from "../../utils/legacy-ux.js";
 
 export default class ImportCommand extends PrismaticBaseCommand {
   static description =

--- a/src/commands/integrations/list.ts
+++ b/src/commands/integrations/list.ts
@@ -3,7 +3,7 @@ import { ListIntegrationsDocument as LIST_INTEGRATIONS } from "../../graphql/int
 import { Flags } from "@oclif/core";
 import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { gqlRequest } from "../../graphql.js";
-import { ux } from "../../utils/ux.js";
+import { ux } from "../../utils/legacy-ux.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Integrations";

--- a/src/commands/integrations/versions/index.ts
+++ b/src/commands/integrations/versions/index.ts
@@ -3,7 +3,7 @@ import { Args, Flags } from "@oclif/core";
 import { ListIntegrationVersionsDocument as LIST_INTEGRATION_VERSIONS } from "../../../graphql/operations/listIntegrationVersions.generated.js";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest, requireResource } from "../../../graphql.js";
-import { ux } from "../../../utils/ux.js";
+import { ux } from "../../../utils/legacy-ux.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Integration versions";

--- a/src/commands/login/index.ts
+++ b/src/commands/login/index.ts
@@ -2,7 +2,7 @@ import { Flags } from "@oclif/core";
 import { isLoggedIn, login } from "../../auth.js";
 import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { getActiveProfileName } from "../../config.js";
-import { ux } from "../../utils/ux.js";
+import { ux } from "../../utils/legacy-ux.js";
 
 export default class LoginCommand extends PrismaticBaseCommand {
   static description = "Log in to your Prismatic account";

--- a/src/commands/logs/severities/list.ts
+++ b/src/commands/logs/severities/list.ts
@@ -2,7 +2,7 @@ import type { ResultOf } from "@graphql-typed-document-node/core";
 import { ListLogSeverityLevelsDocument as LIST_LOG_SEVERITY_LEVELS } from "../../../graphql/operations/listLogSeverityLevels.generated.js";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest } from "../../../graphql.js";
-import { ux } from "../../../utils/ux.js";
+import { ux } from "../../../utils/legacy-ux.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Log Severities for use by Alert Triggers";

--- a/src/commands/me/token/revoke.ts
+++ b/src/commands/me/token/revoke.ts
@@ -1,7 +1,7 @@
 import { Flags } from "@oclif/core";
 import { revokeRefreshToken } from "../../../auth.js";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
-import { ux } from "../../../utils/ux.js";
+import { ux } from "../../../utils/legacy-ux.js";
 
 export default class RevokeTokenCommand extends PrismaticBaseCommand {
   static description = "Revoke all refresh tokens for your user";

--- a/src/commands/on-prem-resources/list.ts
+++ b/src/commands/on-prem-resources/list.ts
@@ -3,7 +3,7 @@ import { ListOnPremiseResourcesDocument as LIST_ON_PREMISE_RESOURCES } from "../
 import { Flags } from "@oclif/core";
 import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { gqlRequest } from "../../graphql.js";
-import { ux } from "../../utils/ux.js";
+import { ux } from "../../utils/legacy-ux.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List On-Premise Resources";

--- a/src/commands/organization/connections/list.ts
+++ b/src/commands/organization/connections/list.ts
@@ -3,7 +3,7 @@ import { Flags } from "@oclif/core";
 import { AvailableConnectionsDocument as AVAILABLE_CONNECTIONS } from "../../../graphql/operations/availableConnections.generated.js";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest } from "../../../graphql.js";
-import { ux } from "../../../utils/ux.js";
+import { ux } from "../../../utils/legacy-ux.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List all integration-agnostic connections available to the organization";

--- a/src/commands/organization/signingKeys/list.ts
+++ b/src/commands/organization/signingKeys/list.ts
@@ -2,7 +2,7 @@ import type { ResultOf } from "@graphql-typed-document-node/core";
 import { ListOrganizationSigningKeysDocument as LIST_ORGANIZATION_SIGNING_KEYS } from "../../../graphql/operations/listOrganizationSigningKeys.generated.js";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest, requireResource } from "../../../graphql.js";
-import { ux } from "../../../utils/ux.js";
+import { ux } from "../../../utils/legacy-ux.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List embedded signing keys for embedded marketplace";

--- a/src/commands/organization/users/list.ts
+++ b/src/commands/organization/users/list.ts
@@ -2,7 +2,7 @@ import type { ResultOf } from "@graphql-typed-document-node/core";
 import { ListOrganizationUsersDocument as LIST_USERS } from "../../../graphql/organization/listOrganizationUsers.generated.js";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest, requireResource } from "../../../graphql.js";
-import { ux } from "../../../utils/ux.js";
+import { ux } from "../../../utils/legacy-ux.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Users of your Organization";

--- a/src/commands/organization/users/roles.ts
+++ b/src/commands/organization/users/roles.ts
@@ -2,7 +2,7 @@ import type { ResultOf } from "@graphql-typed-document-node/core";
 import { ListOrganizationRolesDocument as LIST_ORGANIZATION_ROLES } from "../../../graphql/operations/listOrganizationRoles.generated.js";
 import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { gqlRequest } from "../../../graphql.js";
-import { ux } from "../../../utils/ux.js";
+import { ux } from "../../../utils/legacy-ux.js";
 
 export default class ListCommand extends PrismaticBaseCommand {
   static description = "List Roles you can grant to other users in your Organization";

--- a/src/commands/profiles/list.ts
+++ b/src/commands/profiles/list.ts
@@ -1,6 +1,6 @@
 import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { listProfiles } from "../../config.js";
-import { ux } from "../../utils/ux.js";
+import { ux } from "../../utils/legacy-ux.js";
 
 export default class ProfilesListCommand extends PrismaticBaseCommand {
   static description = "List profiles";

--- a/src/output.ts
+++ b/src/output.ts
@@ -1,0 +1,85 @@
+import { z } from "incur";
+import { type CommandContext, commandWarnings } from "./command.js";
+
+export const warningsOutput = { warnings: z.array(z.string()).optional() };
+
+// Incur appends CTA values verbatim, so preserve each value as one shell argument.
+const quoteArgument = (value: unknown) =>
+  typeof value !== "string" || /^[-A-Za-z0-9_./:@%+=,]+$/.test(value)
+    ? value
+    : `'${value.replaceAll("'", "'\\''")}'`;
+
+type NextCommand = {
+  command: string;
+  description: string;
+  args?: Record<string, unknown>;
+  options?: Record<string, unknown>;
+};
+
+/** Keep human rendering in the handler; expose domain data to incur unchanged. */
+type ResultContext<T> = Pick<CommandContext, "agent" | "globals"> & {
+  ok: (data: T, meta?: { cta: { commands: NextCommand[] } }) => never;
+};
+export const resultOutput = <const T>(
+  context: ResultContext<NoInfer<T>>,
+  data: T,
+  next?: NextCommand,
+): T => {
+  const warnings = commandWarnings();
+  const result = warnings.length > 0 ? { ...data, warnings } : data;
+  if (!next) return result;
+  const profile = context.globals.profile;
+  const command =
+    typeof profile === "string" ? { ...next, options: { ...next.options, profile } } : next;
+  const quoteValues = (values: Record<string, unknown> | undefined) =>
+    values &&
+    Object.fromEntries(Object.entries(values).map(([key, value]) => [key, quoteArgument(value)]));
+  return context.ok(result, {
+    cta: {
+      commands: [
+        { ...command, args: quoteValues(command.args), options: quoteValues(command.options) },
+      ],
+    },
+  });
+};
+
+export const resourceOutputSchema = <K extends string>(field: K) =>
+  z.object({ [field]: z.string() } as { [P in K]: z.ZodString }).extend(warningsOutput);
+
+const resourceNextCommand = (field: string, value: string): NextCommand | undefined => {
+  if (field === "integrationId") {
+    return {
+      command: "integrations flows list",
+      description: "Inspect this integration's flows",
+      args: { integration: value },
+    };
+  }
+  if (field === "instanceId") {
+    return {
+      command: "instances flow-configs list",
+      description: "Inspect this instance's flows",
+      args: { instance: value },
+    };
+  }
+  if (field === "customerId") {
+    return {
+      command: "customers users list",
+      description: "Inspect this customer's users",
+      args: { customer: value },
+    };
+  }
+  return undefined;
+};
+
+/** Preserve the historical single-value stdout while returning a named resource. */
+export const resourceOutput = <K extends string>(
+  context: ResultContext<Record<K, string>>,
+  field: K,
+  value: string,
+) => {
+  return resultOutput(
+    context,
+    { [field]: value } as Record<K, string>,
+    resourceNextCommand(field, value),
+  );
+};

--- a/src/utils/execution/logs.ts
+++ b/src/utils/execution/logs.ts
@@ -75,6 +75,6 @@ export const displayLogs = async (executionId: string): Promise<void> => {
       },
       message: {},
     },
-    { "no-header": true },
+    { header: false },
   );
 };

--- a/src/utils/legacy-table.ts
+++ b/src/utils/legacy-table.ts
@@ -1,12 +1,12 @@
-// Stable Prism table rendering, preserving the historic output format and the
-// case-insensitive key-or-header lookup used by --filter, --columns, and --sort.
+// Minimal reimplementation of @oclif/core v3's ux.table (removed in v4), preserving the
+// flag shape, output format, and the case-insensitive key-or-header lookup that --filter,
+// --columns, and --sort used.
 
+import { Errors, Flags } from "@oclif/core";
 import chalk from "chalk";
-import { z } from "incur";
 import { startCase } from "lodash-es";
 import { orderBy } from "natural-orderby";
 import { dumpYaml } from "./serialize.js";
-import { isAgentExecution, writeCommandOutput } from "../command.js";
 
 export type ColumnDef<T> = {
   header?: string;
@@ -34,126 +34,52 @@ export type TableFlags = {
   csv?: boolean;
   output?: string;
   extended?: boolean;
-  header?: boolean;
-  truncate?: boolean;
+  "no-header"?: boolean;
+  "no-truncate"?: boolean;
 };
 
-export type PaginationFlags = {
-  after?: string;
-  all?: boolean;
-  first?: number;
-};
-
-export const paginationFlags = () => ({
-  after: z.string().optional().describe("Resume listing after this API cursor"),
-  all: z.boolean().optional().describe("Fetch every page instead of returning one resumable page"),
-  first: z.coerce
-    .number()
-    .int()
-    .min(1)
-    .optional()
-    .describe("Maximum number of records to request per API page"),
-});
-
-const nativeFieldSchemas = {
-  public: z.boolean(),
-  enabled: z.boolean(),
-  triggered: z.boolean(),
-  imported: z.boolean(),
-  available: z.boolean(),
-  isDefault: z.boolean(),
-  versionNumber: z.number().int(),
-  labels: z.array(z.string()),
-  headers: z.json(),
-  details: z.json(),
-  value: z.json(),
-  defaultValue: z.json(),
-};
-
-type TableField<K extends string> = K extends keyof typeof nativeFieldSchemas
-  ? (typeof nativeFieldSchemas)[K]
-  : z.ZodString;
-type TableShape<T extends readonly string[]> = {
-  [K in T[number]]: z.ZodOptional<z.ZodNullable<TableField<K>>>;
-};
-export function tableOutputSchema<
-  const T extends readonly string[],
-  const P extends boolean = false,
->(fields: T, paginated: P = false as P) {
-  const row = Object.fromEntries(
-    fields.map((name) => {
-      const field = Object.hasOwn(nativeFieldSchemas, name)
-        ? nativeFieldSchemas[name as keyof typeof nativeFieldSchemas]
-        : z.string();
-      return [name, field.nullable().optional()];
-    }),
-  ) as TableShape<T>;
-  const base = z.object({ items: z.array(z.object(row)) });
-  const page = base.extend({
-    pageInfo: z.object({
-      hasNextPage: z.boolean(),
-      endCursor: z.string().nullable().optional(),
-    }),
-  });
-  return (paginated ? page : base) as P extends true ? typeof page : typeof base;
-}
-
-// Flag order is part of the public CLI contract; don't reorder.
+// Flag order is part of the oclif manifest contract; don't reorder.
 const allFlags = () => ({
-  columns: z
-    .string()
-    .optional()
-    .describe("only show provided columns (comma-separated)")
-    .meta({ cli: { exclusive: ["extended"] } }),
-  csv: z
-    .boolean()
-    .optional()
-    .describe("output is csv format [alias: --output=csv]")
-    .meta({ cli: { exclusive: ["no-truncate"] } }),
-  extended: z
-    .boolean()
-    .optional()
-    .describe("show extra columns")
-    .meta({ cli: { char: "x", exclusive: ["columns"] } }),
-  filter: z
-    .string()
-    .optional()
-    .describe("filter property by regex, ex: name=^foo (prefix key with - to invert)"),
-  header: z
-    .boolean()
-    .optional()
-    .describe("show table headers (use --no-header to hide them)")
-    .meta({ cli: { legacyName: "no-header", exclusive: ["csv"] } }),
-  truncate: z
-    .boolean()
-    .optional()
-    .describe("truncate output to fit the screen (use --no-truncate for full values)")
-    .meta({ cli: { legacyName: "no-truncate", exclusive: ["csv"] } }),
-  output: z
-    .enum(["csv", "json", "yaml"])
-    .optional()
-    .describe("output in a more machine friendly format")
-    .meta({ cli: { exclusive: ["no-truncate", "csv"] } }),
-  sort: z
-    .string()
-    .optional()
-    .describe("property to sort by, comma-separated for multi-key (prepend '-' for descending)"),
+  columns: Flags.string({
+    exclusive: ["extended"],
+    description: "only show provided columns (comma-separated)",
+  }),
+  csv: Flags.boolean({
+    exclusive: ["no-truncate"],
+    description: "output is csv format [alias: --output=csv]",
+  }),
+  extended: Flags.boolean({
+    char: "x",
+    exclusive: ["columns"],
+    description: "show extra columns",
+  }),
+  filter: Flags.string({
+    description: "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+  }),
+  "no-header": Flags.boolean({
+    exclusive: ["csv"],
+    description: "hide table header from output",
+  }),
+  "no-truncate": Flags.boolean({
+    exclusive: ["csv"],
+    description: "do not truncate output to fit screen",
+  }),
+  output: Flags.string({
+    exclusive: ["no-truncate", "csv"],
+    description: "output in a more machine friendly format",
+    options: ["csv", "json", "yaml"],
+  }),
+  sort: Flags.string({
+    description: "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+  }),
 });
 
 export const tableFlags = (opts: { only?: TableFlagKey[]; except?: TableFlagKey[] } = {}) => {
   const flags = allFlags();
-  const keys = (
-    opts.only ??
-    (Object.keys(flags).map((k) =>
-      k === "header" ? "no-header" : k === "truncate" ? "no-truncate" : k,
-    ) as TableFlagKey[])
-  ).filter((k) => !opts.except?.includes(k));
-  return Object.fromEntries(
-    keys.map((k) => {
-      const key = k === "no-header" ? "header" : k === "no-truncate" ? "truncate" : k;
-      return [key, flags[key]];
-    }),
-  ) as ReturnType<typeof allFlags>;
+  const keys = (opts.only ?? (Object.keys(flags) as TableFlagKey[])).filter(
+    (k) => !opts.except?.includes(k),
+  );
+  return Object.fromEntries(keys.map((k) => [k, flags[k]])) as Partial<ReturnType<typeof allFlags>>;
 };
 
 type Column = { key: string; header: string; minWidth: number };
@@ -216,15 +142,15 @@ const pickDisplayColumns = <T>(
   return all.filter((c) => flags.extended || !columns[c.key].extended);
 };
 
-const project = <T>(data: T[], columns: ResolvedColumn<T>[]): Array<Record<string, unknown>> =>
-  data.map((row) => Object.fromEntries(columns.map((c) => [c.key, c.get(row) ?? null])));
+const project = <T>(data: T[], columns: ResolvedColumn<T>[]): Array<Record<string, string>> =>
+  data.map((row) => Object.fromEntries(columns.map((c) => [c.key, toCell(c.get(row))])));
 
 const applyFilter = <T>(
-  rows: Array<Record<string, unknown>>,
+  rows: Array<Record<string, string>>,
   filter: string,
   columns: ColumnsConfig<T>,
-): Array<Record<string, unknown>> => {
-  const invalid = () => new Error("Filter flag has an invalid value");
+): Array<Record<string, string>> => {
+  const invalid = () => new Errors.CLIError("Filter flag has an invalid value", { exit: 1 });
   const eq = filter.indexOf("=");
   const rawInput = eq < 0 ? "" : filter.slice(0, eq);
   const pattern = eq < 0 ? "" : filter.slice(eq + 1);
@@ -238,14 +164,14 @@ const applyFilter = <T>(
   } catch {
     throw invalid();
   }
-  return rows.filter((r) => negate !== regex.test(toCell(r[key])));
+  return rows.filter((r) => negate !== regex.test(r[key] ?? ""));
 };
 
 const applySort = <T>(
-  rows: Array<Record<string, unknown>>,
+  rows: Array<Record<string, string>>,
   sort: string,
   columns: ColumnsConfig<T>,
-): Array<Record<string, unknown>> => {
+): Array<Record<string, string>> => {
   const index = buildKeyIndex(columns);
   const sorters = sort.split(",").map((s) => {
     const desc = s.startsWith("-");
@@ -254,7 +180,7 @@ const applySort = <T>(
   });
   return orderBy(
     rows,
-    sorters.map((s) => (r: Record<string, unknown>) => toCell(r[s.key])),
+    sorters.map((s) => (r: Record<string, string>) => r[s.key] ?? ""),
     sorters.map((s) => s.order),
   );
 };
@@ -277,7 +203,7 @@ const formatText = (
   });
 
   const pad = (cell: string, width: number) =>
-    flags.truncate === false || cell.length <= width
+    flags["no-truncate"] || cell.length <= width
       ? cell.padEnd(width)
       : `${cell.slice(0, Math.max(0, width - 2))}… `;
 
@@ -286,7 +212,7 @@ const formatText = (
     ` ${cells.map((c, i) => pad(c, widths[i] ?? c.length)).join(" ")} `;
 
   const out: string[] = [];
-  if (flags.header !== false) {
+  if (!flags["no-header"]) {
     out.push(chalk.bold(line(columns.map((c) => c.header))));
     out.push(chalk.bold(line(widths.map((w) => "─".repeat(w)))));
   }
@@ -315,7 +241,7 @@ export const printTable = <T>(
   data: T[],
   columns: ColumnsConfig<T>,
   flags: TableFlags = {},
-): { items: Array<Record<string, unknown>> } => {
+): void => {
   // Filter and sort run against every column, then we narrow to the display set — so
   // `--filter label=X --columns id` still matches rows by the hidden `label`.
   const all = buildAllColumns(columns);
@@ -323,33 +249,25 @@ export const printTable = <T>(
   if (flags.filter) rows = applyFilter(rows, flags.filter, columns);
   if (flags.sort) rows = applySort(rows, flags.sort, columns);
 
-  const display = pickDisplayColumns(all, columns, {
-    ...flags,
-    extended: isAgentExecution() || flags.extended,
-  });
+  const display = pickDisplayColumns(all, columns, flags);
   const displayRows = rows.map((r) =>
-    Object.fromEntries(display.map((c) => [c.key, r[c.key] ?? null])),
-  );
-
-  if (isAgentExecution()) return { items: displayRows };
-  const renderedRows = displayRows.map((row) =>
-    Object.fromEntries(Object.entries(row).map(([key, value]) => [key, toCell(value)])),
+    Object.fromEntries(display.map((c) => [c.key, r[c.key] ?? ""])),
   );
 
   switch (resolveOutput(flags)) {
     case "json":
-      writeCommandOutput(JSON.stringify(renderedRows, null, 2));
-      return { items: displayRows };
+      process.stdout.write(`${JSON.stringify(displayRows, null, 2)}\n`);
+      return;
     case "yaml":
-      writeCommandOutput(dumpYaml(renderedRows));
-      return { items: displayRows };
+      process.stdout.write(dumpYaml(displayRows));
+      return;
     case "csv":
-      writeCommandOutput(formatCsv(display, renderedRows));
-      return { items: displayRows };
+      process.stdout.write(`${formatCsv(display, displayRows)}\n`);
+      return;
     case "text": {
-      const text = formatText(display, renderedRows, flags);
-      if (text) writeCommandOutput(text);
-      return { items: displayRows };
+      const text = formatText(display, displayRows, flags);
+      if (text) process.stdout.write(`${text}\n`);
+      return;
     }
   }
 };

--- a/src/utils/legacy-ux.ts
+++ b/src/utils/legacy-ux.ts
@@ -1,0 +1,21 @@
+import { setTimeout as sleep } from "node:timers/promises";
+import { ux as oclifUx } from "@oclif/core";
+import { confirm, pressAnyKey } from "./prompts.js";
+import { printTable, tableFlags } from "./legacy-table.js";
+import { hyperlink } from "./terminal.js";
+
+// Drop-in for the cli-ux `ux` namespace removed in @oclif/core v4. Call sites swap their
+// `@oclif/core` import for this one and keep `ux.table`, `ux.confirm`, etc. unchanged.
+export const ux = {
+  ...oclifUx,
+  table: Object.assign(printTable, { flags: tableFlags }),
+  confirm,
+  anykey: pressAnyKey,
+  url: (text: string, uri: string): void => {
+    process.stdout.write(`${hyperlink(text, uri)}\n`);
+  },
+  log: (...args: unknown[]): void => {
+    console.log(...args);
+  },
+  wait: (ms: number): Promise<void> => sleep(ms),
+};

--- a/src/utils/table.test.ts
+++ b/src/utils/table.test.ts
@@ -1,7 +1,8 @@
-import { captureOutput } from "@oclif/test";
-import { describe, expect, it } from "vitest";
+import { runCommand } from "../test-command.js";
+import { describe, expect, it, vi } from "vitest";
 import { loadYaml } from "./serialize.js";
-import { type ColumnsConfig, printTable, tableFlags } from "./table.js";
+import { defineCommand } from "../command.js";
+import { type ColumnsConfig, printTable, tableFlags, tableOutputSchema } from "./table.js";
 
 type Row = {
   id: string;
@@ -24,17 +25,41 @@ const columns: ColumnsConfig<Row> = {
 };
 
 const render = async (flags: Parameters<typeof printTable>[2] = {}) => {
-  const { stdout } = await captureOutput(async () => {
-    printTable(rows, columns, flags);
+  let stdout = "";
+  const write = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    stdout += String(chunk);
+    return true;
   });
-  return stdout;
+  try {
+    printTable(rows, columns, flags);
+    return stdout;
+  } finally {
+    write.mockRestore();
+  }
+};
+
+const captureOutput = async (callback: () => void | Promise<void>) => {
+  let stdout = "";
+  let error: unknown;
+  const write = vi.spyOn(process.stdout, "write").mockImplementation((chunk) => {
+    stdout += String(chunk);
+    return true;
+  });
+  try {
+    await callback();
+  } catch (caught) {
+    error = caught;
+  } finally {
+    write.mockRestore();
+  }
+  return { error, stdout };
 };
 
 describe("tableFlags", () => {
   it("returns the full flag set by default", () => {
     const flags = tableFlags();
     expect(Object.keys(flags).sort()).toEqual(
-      ["columns", "csv", "extended", "filter", "no-header", "no-truncate", "output", "sort"].sort(),
+      ["columns", "csv", "extended", "filter", "header", "truncate", "output", "sort"].sort(),
     );
   });
 
@@ -46,12 +71,57 @@ describe("tableFlags", () => {
   it("honors `except`", () => {
     const flags = tableFlags({ except: ["sort", "filter"] });
     expect(Object.keys(flags).sort()).toEqual(
-      ["columns", "csv", "extended", "no-header", "no-truncate", "output"].sort(),
+      ["columns", "csv", "extended", "header", "truncate", "output"].sort(),
     );
   });
 });
 
 describe("printTable", () => {
+  it("returns identifiers and native values without changing human JSON tables", async () => {
+    const data = [
+      {
+        id: "resource-1",
+        enabled: false,
+        versionNumber: 2,
+        labels: ["Production"],
+        value: { nested: 42 },
+      },
+    ];
+    const definitions = {
+      id: { extended: true },
+      enabled: {},
+      versionNumber: {},
+      labels: {},
+      value: {},
+    };
+    const command = defineCommand({ run: () => printTable(data, definitions) });
+    const result = await runCommand(command, ["--agent"]);
+    expect(result).toEqual({ items: data });
+    expect(
+      tableOutputSchema(["id", "enabled", "versionNumber", "labels", "value"]).safeParse(result)
+        .success,
+    ).toBe(true);
+    const human = await captureOutput(() => {
+      printTable(data, definitions, { output: "json" });
+    });
+    expect(JSON.parse(human.stdout)).toEqual([
+      { enabled: "false", versionNumber: "2", labels: '["Production"]', value: '{"nested":42}' },
+    ]);
+  });
+
+  it("honors filtering, sorting, and projection in agent mode", async () => {
+    const command = defineCommand({
+      run: () =>
+        printTable(rows, columns, { filter: "role=user", sort: "-name", columns: "id,name" }),
+    });
+
+    await expect(runCommand(command, ["--agent"])).resolves.toEqual({
+      items: [
+        { id: "c3", name: "mike" },
+        { id: "b2", name: "alpha" },
+      ],
+    });
+  });
   it("hides extended columns by default", async () => {
     const stdout = await render();
     expect(stdout).toContain("Name");
@@ -94,7 +164,7 @@ describe("printTable", () => {
   });
 
   it("suppresses the header and separator with --no-header", async () => {
-    const stdout = await render({ "no-header": true });
+    const stdout = await render({ header: false });
     expect(stdout).not.toContain("Name");
     expect(stdout).not.toContain("─");
     expect(stdout).toMatch(/zeta|alpha|mike/);

--- a/src/utils/ux.ts
+++ b/src/utils/ux.ts
@@ -1,21 +1,39 @@
 import { setTimeout as sleep } from "node:timers/promises";
-import { ux as oclifUx } from "@oclif/core";
+import {
+  commandSignal,
+  isAgentExecution,
+  writeCommandStatus,
+  writeCommandProgress,
+} from "../command.js";
 import { confirm, pressAnyKey } from "./prompts.js";
 import { printTable, tableFlags } from "./table.js";
 import { hyperlink } from "./terminal.js";
 
-// Drop-in for the cli-ux `ux` namespace removed in @oclif/core v4. Call sites swap their
-// `@oclif/core` import for this one and keep `ux.table`, `ux.confirm`, etc. unchanged.
+// Human status helpers; native command results carry agent output.
 export const ux = {
-  ...oclifUx,
+  action: {
+    start(message: string): void {
+      writeCommandProgress(`${message}...`);
+    },
+    stop(message = "done", _options?: unknown): void {
+      if (isAgentExecution()) return;
+      writeCommandStatus(` ${message}`);
+    },
+  },
   table: Object.assign(printTable, { flags: tableFlags }),
   confirm,
   anykey: pressAnyKey,
   url: (text: string, uri: string): void => {
-    process.stdout.write(`${hyperlink(text, uri)}\n`);
+    writeCommandStatus(hyperlink(text, uri));
   },
   log: (...args: unknown[]): void => {
-    console.log(...args);
+    writeCommandStatus(args.map(String).join(" "));
   },
-  wait: (ms: number): Promise<void> => sleep(ms),
+  error(message: string, options?: { exit?: number }): never {
+    const error = new Error(message);
+    const exitCode = options?.exit ?? 2;
+    Object.assign(error, { exitCode });
+    throw error;
+  },
+  wait: (ms: number): Promise<void> => sleep(ms, undefined, { signal: commandSignal() }),
 };


### PR DESCRIPTION
Add native table schemas and structured output helpers.

Part **7/24** of the native incur migration. This PR targets `incur-06-auth-isolation`; the stack integrates into the long-lived `agent` branch. Review this diff against its immediate base.

Validation: format/lint, TypeScript, bundle, and **338 passing tests** (3 skipped) on Node 24. CI also checks Node 22/24/26 and Windows.

Review size: **518 handwritten changed lines**; counts include additions and deletions.

[Stack review guide](https://github.com/prismatic-io/prism/blob/incur-24-review-evidence/docs/incur-pr-stack.md). Merge bottom-up; rebase descendants after a squash merge.
