### PR TITLE
[incur 08/24] Stream subprocess output with bounded buffering and cancellation

### DIFF
--- a/src/utils/fixtures/npm-package/process-smoke.mjs
+++ b/src/utils/fixtures/npm-package/process-smoke.mjs
@@ -1,10 +1,10 @@
-import { writeFileSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
 
 if (process.argv[2] === "--fail") {
   process.exit(19);
 }
 
-writeFileSync(
+await writeFile(
   process.env.PRISM_PROCESS_TEST_OUTPUT,
   JSON.stringify({
     argument: process.argv[2],

--- a/src/utils/process.test.ts
+++ b/src/utils/process.test.ts
@@ -1,9 +1,19 @@
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { runWithEnvironment } from "../runtime.js";
+import { runCommand } from "../test-command.js";
+import { Cli } from "incur";
+import { mkdtemp, readFile, realpath, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { afterEach, describe, expect, it } from "vitest";
-import { spawnProcess } from "./process.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  defineCommand,
+  commandMiddleware,
+  commandVars,
+  environmentOptions,
+  globalOptions,
+} from "../command.js";
+import { spawnProcess, streamProcess } from "./process.js";
 
 const temporaryDirectories: string[] = [];
 
@@ -21,7 +31,9 @@ afterEach(async () => {
 
 describe("spawnProcess", () => {
   it("resolves when the process exits successfully", async () => {
-    await expect(spawnProcess([process.execPath, "--version"], {})).resolves.toBeUndefined();
+    await expect(spawnProcess([process.execPath, "--version"], {})).resolves.toMatchObject({
+      exitCode: 0,
+    });
   });
 
   it("runs an npm package script by its bare executable name", async () => {
@@ -100,7 +112,207 @@ describe("spawnProcess", () => {
         spawnProcess(["prism-process-smoke", "expected"], {
           [pathKey]: `${fixtureDirectory}${path.delimiter}${process.env[pathKey] ?? ""}`,
         }),
-      ).resolves.toBeUndefined();
+      ).resolves.toMatchObject({ exitCode: 0 });
     },
   );
+});
+
+it("captures child stdout and stderr without writing into the agent transport", async () => {
+  const stdout = vi.spyOn(process.stdout, "write");
+  const stderr = vi.spyOn(process.stderr, "write");
+  const command = defineCommand({
+    run: () =>
+      spawnProcess(
+        [process.execPath, "-e", 'console.log("child output"); console.error("child diagnostic")'],
+        {},
+      ),
+  });
+  try {
+    await expect(runCommand(command, ["--agent"])).resolves.toEqual({
+      exitCode: 0,
+      stdout: "child output\n",
+      stderr: "child diagnostic\n",
+    });
+    expect(stdout).not.toHaveBeenCalled();
+    expect(stderr).not.toHaveBeenCalled();
+  } finally {
+    stdout.mockRestore();
+    stderr.mockRestore();
+  }
+});
+
+it("returns failed child diagnostics through the native CLI JSON error without leaking raw output", async () => {
+  const stdout = vi.spyOn(process.stdout, "write");
+  const stderr = vi.spyOn(process.stderr, "write");
+  const command = defineCommand({
+    run: () =>
+      spawnProcess(
+        [
+          process.execPath,
+          "-e",
+          'console.log("CHILD_OUTPUT"); console.error("DIAGNOSTIC_SENTINEL"); process.exit(3)',
+        ],
+        {},
+      ),
+  });
+  const cli = Cli.create("test", {
+    vars: commandVars,
+    env: environmentOptions,
+    globals: globalOptions,
+  })
+    .use(commandMiddleware)
+    .command("child", command);
+  const output: string[] = [];
+  const exits: number[] = [];
+  try {
+    await cli.serve(["child", "--json"], {
+      stdout: (value) => {
+        output.push(value);
+      },
+      exit: (code) => {
+        exits.push(code);
+      },
+    });
+    const result = JSON.parse(output.join(""));
+    expect(result.message).toContain("exit code 3");
+    expect(result.message).toContain("Child stdout:\nCHILD_OUTPUT");
+    expect(result.message).toContain("Child stderr:\nDIAGNOSTIC_SENTINEL");
+    expect(result.code).toBe("COMMAND_FAILED");
+    expect(exits).toEqual([1]);
+    expect(stdout).not.toHaveBeenCalled();
+    expect(stderr).not.toHaveBeenCalled();
+  } finally {
+    stdout.mockRestore();
+    stderr.mockRestore();
+  }
+});
+
+it("bounds failed child diagnostics and retains their tail", async () => {
+  const command = defineCommand({
+    run: () =>
+      spawnProcess(
+        [
+          process.execPath,
+          "-e",
+          'console.error("A".repeat(20000) + "TAIL_SENTINEL"); process.exit(4)',
+        ],
+        {},
+      ),
+  });
+  let failure: unknown;
+  try {
+    await runCommand(command, ["--agent"]);
+  } catch (error) {
+    failure = error;
+  }
+  expect(failure).toBeInstanceOf(Error);
+  const message = (failure as Error).message;
+  expect(message).toContain("Child stderr (last 8192 characters):");
+  expect(message).toContain("TAIL_SENTINEL");
+  expect(message.length).toBeLessThan(8500);
+});
+
+it("isolates concurrent child working directories and environments", async () => {
+  const originalDirectory = process.cwd();
+  const originalValue = process.env.PRISM_CHILD_TEST_VALUE;
+  const directories = await Promise.all([createTemporaryDirectory(), createTemporaryDirectory()]);
+  await Promise.all(
+    directories.map((cwd, index) =>
+      runWithEnvironment({ ...process.env, PRISM_CHILD_TEST_VALUE: `value-${index}` }, () =>
+        spawnProcess(
+          [
+            process.execPath,
+            "-e",
+            'require("node:fs").writeFileSync("result.json", JSON.stringify({ cwd: process.cwd(), value: process.env.PRISM_CHILD_TEST_VALUE }))',
+          ],
+          {},
+          { cwd },
+        ),
+      ),
+    ),
+  );
+  for (const [index, directory] of directories.entries()) {
+    const result = JSON.parse(await readFile(path.join(directory, "result.json"), "utf8"));
+    // Windows may report an 8.3 path for the same directory; compare canonical paths.
+    expect({ ...result, cwd: await realpath(result.cwd) }).toEqual({
+      cwd: await realpath(directory),
+      value: `value-${index}`,
+    });
+  }
+  expect(process.cwd()).toBe(originalDirectory);
+  expect(process.env.PRISM_CHILD_TEST_VALUE).toBe(originalValue);
+});
+
+describe("native subprocess streaming", () => {
+  it("yields stdout and stderr incrementally in arrival order before completion", async () => {
+    const events = [];
+    const stream = streamProcess(
+      [
+        process.execPath,
+        "-e",
+        'console.log("out-1"); setTimeout(() => console.error("err-1"), 100); setTimeout(() => console.log("out-2"), 200); setTimeout(() => process.exit(0), 300)',
+      ],
+      {},
+    );
+    const first = await stream.next();
+    expect(first).toEqual({ done: false, value: { type: "stdout", data: "out-1\n" } });
+    events.push(first.value);
+    for await (const event of stream) events.push(event);
+    expect(events).toEqual([
+      { type: "stdout", data: "out-1\n" },
+      { type: "stderr", data: "err-1\n" },
+      { type: "stdout", data: "out-2\n" },
+      { type: "completed", exitCode: 0 },
+    ]);
+  });
+
+  it("terminates the child when the consumer closes the iterator", async () => {
+    const stream = streamProcess(
+      [process.execPath, "-e", "console.log(process.pid); setInterval(() => {}, 1000)"],
+      {},
+    );
+    const first = await stream.next();
+    const pid = Number(first.value && "data" in first.value ? first.value.data : undefined);
+    expect(pid).toBeGreaterThan(0);
+    await stream.return(undefined);
+    expect(() => process.kill(pid, 0)).toThrow();
+  });
+
+  it("honors external cancellation without reporting successful completion", async () => {
+    const abort = new AbortController();
+    const stream = streamProcess(
+      [process.execPath, "-e", 'console.log("started"); setInterval(() => {}, 1000)'],
+      {},
+      { signal: abort.signal },
+    );
+    await stream.next();
+    abort.abort(new Error("test cancelled"));
+    await expect(stream.next()).rejects.toThrow("test cancelled");
+  });
+
+  it("retains bounded diagnostics on failure after streaming output", async () => {
+    const stream = streamProcess(
+      [
+        process.execPath,
+        "-e",
+        'console.error("A".repeat(20000) + "TAIL_SENTINEL"); process.exit(4)',
+      ],
+      {},
+    );
+    let failure: unknown;
+    const events = [];
+    try {
+      for await (const event of stream) events.push(event);
+    } catch (error) {
+      failure = error;
+    }
+    expect(events.some((event) => event.type === "stderr")).toBe(true);
+    expect(events.some((event) => event.type === "completed")).toBe(false);
+    expect(failure).toBeInstanceOf(Error);
+    const message = (failure as Error).message;
+    expect(message).toContain("exit code 4");
+    expect(message).toContain("Child stderr (last 8192 characters):");
+    expect(message).toContain("TAIL_SENTINEL");
+    expect(message.length).toBeLessThan(8500);
+  });
 });

--- a/src/utils/process.ts
+++ b/src/utils/process.ts
@@ -1,9 +1,23 @@
+import { getRuntimeEnvironment } from "../runtime.js";
 import { type Output, x } from "tinyexec";
+import { commandSignal, isAgentExecution, writeCommandOutput } from "../command.js";
+
+const diagnosticLimit = 8192;
+const childDiagnostic = (
+  name: string,
+  value: string,
+  truncated = value.length > diagnosticLimit,
+): string => {
+  if (!value) return "";
+  const output = value.slice(-diagnosticLimit).trimEnd();
+  return `\n\nChild ${name}${truncated ? ` (last ${diagnosticLimit} characters)` : ""}:\n${output}`;
+};
 
 export const spawnProcess = async (
   [command, ...args]: string[],
   env: Record<string, string>,
-): Promise<void> => {
+  options: { cwd?: string; signal?: AbortSignal } = {},
+): Promise<Output> => {
   if (!command) {
     throw new Error("No command was provided.");
   }
@@ -11,9 +25,11 @@ export const spawnProcess = async (
   let result: Output;
   try {
     result = await x(command, args, {
+      signal: options.signal ?? commandSignal(),
       nodeOptions: {
-        env: { ...process.env, ...env },
-        stdio: "inherit",
+        env: { ...getRuntimeEnvironment(), ...env },
+        cwd: options.cwd,
+        stdio: isAgentExecution() ? ["ignore", "pipe", "pipe"] : "inherit",
       },
     });
   } catch (error) {
@@ -28,6 +44,150 @@ export const spawnProcess = async (
       result.exitCode !== undefined
         ? `exit code ${result.exitCode}`
         : "termination before reporting an exit code";
-    throw new Error(`Command failed with ${status}: ${command} ${args.join(" ")}`);
+    const diagnostics = isAgentExecution()
+      ? childDiagnostic("stdout", result.stdout) + childDiagnostic("stderr", result.stderr)
+      : "";
+    throw new Error(`Command failed with ${status}: ${command} ${args.join(" ")}${diagnostics}`);
   }
+
+  if (isAgentExecution()) {
+    if (result.stdout) writeCommandOutput(result.stdout);
+    if (result.stderr) writeCommandOutput(result.stderr, "stderr");
+  }
+  return result;
 };
+
+export type ProcessEvent =
+  | { type: "stdout" | "stderr"; data: string }
+  | { type: "completed"; exitCode: 0 };
+
+/** Stream pipe chunks in arrival order with bounded buffering and diagnostics. */
+export async function* streamProcess(
+  [command, ...args]: string[],
+  env: Record<string, string>,
+  options: { cwd?: string; signal?: AbortSignal } = {},
+): AsyncGenerator<ProcessEvent> {
+  if (!command) throw new Error("No command was provided.");
+  options.signal?.throwIfAborted();
+  const child = x(command, args, {
+    nodeOptions: {
+      cwd: options.cwd,
+      env: { ...getRuntimeEnvironment(), ...env },
+      stdio: ["ignore", "pipe", "pipe"],
+      detached: process.platform !== "win32",
+    },
+  }).process;
+  if (!child) throw new Error(`Failed to start ${JSON.stringify(command)}`);
+
+  const pending: Array<Extract<ProcessEvent, { data: string }>> = [];
+  const tails = { stdout: "", stderr: "" };
+  const sizes = { stdout: 0, stderr: 0 };
+  let queued = 0;
+  let settled = false;
+  let failure: Error | undefined;
+  let exitCode: number | null = null;
+  let signalCode: NodeJS.Signals | null = null;
+  let wake: (() => void) | undefined;
+  let killTimer: NodeJS.Timeout | undefined;
+  let treeTermination: Promise<unknown> | undefined;
+  const notify = () => {
+    wake?.();
+    wake = undefined;
+  };
+  const sendSignal = (signal: NodeJS.Signals) => {
+    try {
+      if (process.platform !== "win32" && child.pid) process.kill(-child.pid, signal);
+      else child.kill(signal);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ESRCH") failure ??= error as Error;
+    }
+  };
+  const stop = () => {
+    if (settled || killTimer) return;
+    pending.length = 0;
+    queued = 0;
+    if (process.platform === "win32" && child.pid) {
+      treeTermination = Promise.resolve(
+        x("taskkill", ["/PID", String(child.pid), "/T", "/F"], {
+          timeout: 1000,
+          nodeOptions: { stdio: "ignore" },
+        }),
+      ).then(
+        (result) => {
+          if (result.exitCode !== 0) sendSignal("SIGTERM");
+        },
+        () => sendSignal("SIGTERM"),
+      );
+    } else sendSignal("SIGTERM");
+    killTimer = setTimeout(() => sendSignal("SIGKILL"), 1000);
+    killTimer.unref();
+    // Drain paused pipes so close can settle even if the consumer stopped reading.
+    child.stdout?.resume();
+    child.stderr?.resume();
+  };
+  const completed = new Promise<void>((resolve) => {
+    child.once("error", (error) => {
+      failure = error;
+    });
+    child.once("close", (code, signal) => {
+      exitCode = code;
+      signalCode = signal;
+      settled = true;
+      if (killTimer) clearTimeout(killTimer);
+      notify();
+      resolve();
+    });
+  });
+  for (const type of ["stdout", "stderr"] as const) {
+    child[type]?.setEncoding("utf8");
+    child[type]?.on("data", (data: string) => {
+      sizes[type] += data.length;
+      tails[type] = (tails[type] + data).slice(-diagnosticLimit);
+      if (!killTimer) {
+        pending.push({ type, data });
+        queued += data.length;
+        if (queued >= 65536) {
+          child.stdout?.pause();
+          child.stderr?.pause();
+        }
+      }
+      notify();
+    });
+  }
+  options.signal?.addEventListener("abort", stop, { once: true });
+  if (options.signal?.aborted) stop();
+  try {
+    while (!settled || pending.length > 0) {
+      if (pending.length === 0)
+        await new Promise<void>((resolve) => {
+          wake = resolve;
+        });
+      const event = pending.shift();
+      if (event) {
+        queued -= event.data.length;
+        if (queued < 32768 && !killTimer) {
+          child.stdout?.resume();
+          child.stderr?.resume();
+        }
+        yield event;
+      }
+    }
+    await completed;
+    options.signal?.throwIfAborted();
+    if (failure)
+      throw new Error(`Failed to start ${JSON.stringify(command)}: ${failure.message}`, {
+        cause: failure,
+      });
+    if (exitCode !== 0) {
+      throw new Error(
+        `Command failed with ${exitCode === null ? `signal ${signalCode ?? "unknown"}` : `exit code ${exitCode}`}: ${command} ${args.join(" ")}${childDiagnostic("stdout", tails.stdout, sizes.stdout > diagnosticLimit)}${childDiagnostic("stderr", tails.stderr, sizes.stderr > diagnosticLimit)}`,
+      );
+    }
+    yield { type: "completed", exitCode: 0 };
+  } finally {
+    options.signal?.removeEventListener("abort", stop);
+    stop();
+    await completed;
+    await treeTermination;
+  }
+}


### PR DESCRIPTION
Stream subprocess output with bounded buffering and cancellation.

Part **8/24** of the native incur migration. This PR targets `incur-07-output-schemas`; the stack integrates into the long-lived `agent` branch. Review this diff against its immediate base.

Validation: format/lint, TypeScript, bundle, and **346 passing tests** (3 skipped) on Node 24. CI also checks Node 22/24/26 and Windows.

Review size: **396 handwritten changed lines**; counts include additions and deletions.

[Stack review guide](https://github.com/prismatic-io/prism/blob/incur-24-review-evidence/docs/incur-pr-stack.md). Merge bottom-up; rebase descendants after a squash merge.
