### PR TITLE
[incur 09/24] Mount native incur commands and migrate profiles

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,654 @@
+import { Cli, Completions, Formatter, Parser, type z } from "incur";
+import packageJson from "../package.json" with { type: "json" };
+import {
+  assertMutationAllowed,
+  encodePassthroughArgument,
+  runWithMcpTransport,
+  schemaFieldName,
+  globalOptions,
+  environmentOptions,
+  commandVars,
+  commandMiddleware,
+} from "./command.js";
+import { NativeCommands as Commands } from "./index.js";
+
+const topicDescriptions: Record<string, string> = {
+  alerts: "Manage Alerting resources",
+  "alerts:groups": "Manage Alert Groups",
+  "alerts:monitors": "Manage Alert Monitors",
+  "alerts:webhooks": "Manage Alert Webhooks",
+  components: "Manage, create, and publish Components",
+  "components:dev": "Component development utilities",
+  "components:init": "Create Components",
+  customers: "Manage Customers",
+  "customers:users": "Manage Customer Users",
+  executions: "Fetch results of Instance executions or Integration test runs",
+  graphql: "Execute GraphQL queries against the Prismatic API",
+  instances: "Manage Instances",
+  integrations: "Manage and import Integrations",
+  logs: "Inspect Prismatic log data",
+  "logs:severities": "Manage log severity levels",
+  "on-prem-resources": "Manage on-premise resources",
+  organization: "Manage your Organization",
+  "organization:users": "Manage Organization Users",
+  profiles: "Manage authentication profiles",
+  translations: "Manage translations",
+  workflows: "Manage embedded workflow builder workflows and templates",
+};
+
+type PrismCommand = (typeof Commands)[keyof typeof Commands];
+type Tree = { command?: PrismCommand; children: Map<string, Tree> };
+const root: Tree = { children: new Map() };
+
+export const mutatingCommandIds = new Set(
+  Object.entries(Commands)
+    .filter(([, command]) => command.mutates)
+    .map(([id]) => id),
+);
+export const potentiallyDestructiveCommandIds = new Set(
+  Object.entries(Commands)
+    .filter(([, command]) => command.destructive && !command.mutates)
+    .map(([id]) => id),
+);
+
+for (const [id, command] of Object.entries(Commands)) {
+  let node = root;
+  for (const segment of id.split(":")) {
+    const next = node.children.get(segment) ?? { children: new Map() };
+    node.children.set(segment, next);
+    node = next;
+  }
+  node.command = command;
+}
+
+type MountedDefinition = Cli.create.Options<
+  z.ZodObject | undefined,
+  typeof environmentOptions,
+  z.ZodObject | undefined,
+  z.ZodType | undefined,
+  typeof commandVars,
+  typeof globalOptions
+>;
+type MountedCli = Cli.Cli<
+  Record<never, never>,
+  typeof commandVars,
+  typeof environmentOptions,
+  typeof globalOptions
+>;
+const mount = (name: string, node: Tree, path: string): MountedCli => {
+  const description = node.command?.description ?? topicDescriptions[path];
+  const cli = node.command
+    ? // Commands retain concrete inferred handler types in their own modules. The
+      // heterogeneous route tree erases those types only at this registration seam.
+      Cli.create(name, { ...node.command, description } as unknown as MountedDefinition & {
+        run: NonNullable<MountedDefinition["run"]>;
+      })
+    : Cli.create(name, {
+        description,
+        env: environmentOptions,
+        globals: globalOptions,
+        vars: commandVars,
+      });
+  for (const [childName, child] of node.children) {
+    cli.command(mount(childName, child, path ? `${path}:${childName}` : childName));
+  }
+  return cli;
+};
+
+export const cli = Cli.create("prism", {
+  description: packageJson.description,
+  env: environmentOptions,
+  globalAlias: {},
+  globals: globalOptions,
+  vars: commandVars,
+  mcp: {
+    instructions:
+      "Manage Prismatic integrations and resources. Prefer read commands before destructive changes.",
+    title: "Prismatic CLI",
+  },
+  outputPolicy: "all",
+  version: packageJson.version,
+});
+
+cli.use(commandMiddleware);
+
+for (const [name, node] of root.children) cli.command(mount(name, node, name));
+
+export default cli;
+
+const agentEnvironmentVariables = [
+  "CLAUDE_CODE",
+  "CLAUDECODE",
+  "CURSOR_AGENT",
+  "CODEX",
+  "OPENAI_CODEX",
+  "AIDER",
+  "CLINE",
+  "WINDSURF_AGENT",
+  "GITHUB_COPILOT",
+  "AMAZON_Q",
+  "AWS_Q_DEVELOPER",
+  "GEMINI_CODE_ASSIST",
+  "SRC_CODY",
+  "PI_CODING_AGENT",
+  "FORCE_AGENT_MODE",
+  "PRISM_AGENT",
+  "PRISM_AGENT_MODE",
+] as const;
+
+const truthy = (value: string | undefined) => value === "1" || value?.toLowerCase() === "true";
+
+const beforeDelimiter = (argv: string[]) => {
+  const delimiter = argv.indexOf("--");
+  return delimiter < 0 ? argv : argv.slice(0, delimiter);
+};
+
+const globalValueFlags = new Set([
+  "--profile",
+  "--format",
+  "--filter-output",
+  "--token-limit",
+  "--token-offset",
+]);
+
+// Only a leading command position can introduce a route. In particular, flag
+// values and positional arguments that happen to name commands are opaque.
+const resolveRoute = (argv: string[]) => {
+  let start = 0;
+  while (start < argv.length && argv[start].startsWith("-") && argv[start] !== "--") {
+    const token = argv[start++];
+    if (globalValueFlags.has(token)) start += 1;
+  }
+  let node = root;
+  const path: string[] = [];
+  let end = start;
+  while (end < argv.length) {
+    const segments = argv[end].split(":");
+    let candidate = node;
+    for (const segment of segments) {
+      const child = candidate.children.get(segment);
+      if (!child) return { start, end, path: path.join(":"), command: node.command };
+      candidate = child;
+    }
+    path.push(...segments);
+    node = candidate;
+    end += 1;
+  }
+  return { start, end, path: path.join(":"), command: node.command };
+};
+
+export const normalizeCommandArguments = (argv: string[]): string[] => {
+  const delimiter = argv.indexOf("--");
+  const tokens = [...(delimiter < 0 ? argv : argv.slice(0, delimiter))];
+  if (tokens[0] === "help") {
+    tokens.shift();
+    tokens.push("--help");
+  }
+  const route = resolveRoute(tokens);
+  const fields = new Map<string, { name: string; multiple?: boolean; kind: string }>();
+  for (const [name, field] of Object.entries(route.command?.contract.options ?? {}) as [
+    string,
+    { char?: string; multiple?: boolean; kind: string },
+  ][]) {
+    const descriptor = { ...field, name };
+    fields.set(`--${name}`, descriptor);
+    fields.set(`--${name.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)}`, descriptor);
+    if (field.char) fields.set(`-${field.char}`, descriptor);
+  }
+  const normalized: string[] = [];
+  for (let index = 0; index < tokens.length; index += 1) {
+    if (index === route.start && route.end > route.start) {
+      normalized.push(...route.path.split(":"));
+      index = route.end - 1;
+      continue;
+    }
+    let token = tokens[index];
+    const mode = /^--(no-)?agent=(true|false)$/i.exec(token);
+    if (mode)
+      token =
+        (mode[1] === undefined) === (mode[2].toLowerCase() === "true") ? "--agent" : "--no-agent";
+    let name = token.split("=", 1)[0];
+    let field = fields.get(name);
+    // Oclif permits attached short values, including after boolean aliases.
+    if (/^-[^-].+/.test(token)) {
+      for (let offset = 1; offset < token.length; offset += 1) {
+        const short = `-${token[offset]}`;
+        const shortField = fields.get(short);
+        if (!shortField) break;
+        if (shortField.kind === "boolean") {
+          if (offset < token.length - 1) normalized.push(short);
+          else token = short;
+          continue;
+        }
+        const attached = token.slice(offset + 1);
+        token = short;
+        if (attached)
+          tokens.splice(index + 1, 0, attached.startsWith("=") ? attached.slice(1) : attached);
+        break;
+      }
+      name = token.split("=", 1)[0];
+      field = fields.get(name);
+    }
+    if (name.startsWith("--no-no-") && fields.has(`--${name.slice(5)}`)) {
+      throw Object.assign(new Error(`Unknown option: ${name}`), {
+        exitCode: 2,
+        code: "UNKNOWN_FLAG",
+      });
+    }
+    // Command-owned aliases take priority over incur's global help shortcut.
+    if (name === "-h" && field) token = `--${field.name}`;
+    if (field && /[A-Z]/.test(name))
+      token = token.replace(
+        name,
+        name.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`),
+      );
+    if (globalValueFlags.has(name) && name !== "--profile" && token.includes("=")) {
+      normalized.push(name, token.slice(token.indexOf("=") + 1));
+    } else normalized.push(token);
+    if ((field && field.kind !== "boolean") || globalValueFlags.has(name)) {
+      if (!token.includes("=") && index + 1 < tokens.length) {
+        const value = tokens[++index];
+        // Keep incur's global flag extraction from interpreting an option value.
+        if (value.startsWith("-") && value !== "--help" && field) {
+          normalized[normalized.length - 1] =
+            `--${field.name.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)}=${value}`;
+        } else if (value.startsWith("--") && name === "--profile") {
+          normalized[normalized.length - 1] = `${name}=${value}`;
+        } else normalized.push(value);
+      }
+      if (field?.multiple) {
+        while (index + 1 < tokens.length && !tokens[index + 1].startsWith("-")) {
+          normalized.push(name, tokens[++index]);
+        }
+      }
+    }
+  }
+  if (delimiter >= 0) {
+    const rest = argv.slice(delimiter + 1);
+    normalized.push(...rest.map(encodePassthroughArgument));
+  }
+  return normalized;
+};
+
+const resolveCommandPath = (argv: string[]): string => resolveRoute(argv).path;
+
+// These routes belong to incur itself, including its singular skill alias.
+const nativeRoutes = new Set(["completions", "mcp", "skills", "skill"]);
+const isNativeRoute = (argv: string[]) => nativeRoutes.has(argv[resolveRoute(argv).start]);
+
+const assertNativeMutationAllowed = (
+  argv: string[],
+  agent: boolean,
+  environment: NodeJS.ProcessEnv,
+) => {
+  if (!isNativeRoute(argv)) return;
+  const rootIndex = resolveRoute(argv).start;
+  const route = argv[rootIndex];
+  const globals: string[] = [];
+  const words: string[] = [];
+  let help = false;
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    const name = token.split("=", 1)[0];
+    // Native option values are opaque, including strings that look like approval.
+    const nativeValue =
+      ["--command", "-c", "--depth"].includes(name) ||
+      (name === "--agent" &&
+        index > rootIndex &&
+        argv[index + 1] &&
+        !argv[index + 1].startsWith("-"));
+    if (nativeValue || globalValueFlags.has(name)) {
+      if (!token.includes("=")) index += 1;
+      continue;
+    }
+    if (["--help", "-h"].includes(token)) help = true;
+    if (/^--(?:no-)?(?:yes|read-only)(?:=|$)/.test(token)) globals.push(token);
+    if (!token.startsWith("-")) words.push(token);
+  }
+  if (help || !["mcp", "skills", "skill"].includes(route) || words[1] !== "add") return;
+  const parsed = Parser.parse(globals, { options: globalOptions }).options;
+  assertMutationAllowed({
+    agent,
+    globals: { ...parsed, readOnly: parsed.readOnly || truthy(environment.PRISM_READ_ONLY) },
+  });
+};
+
+const assertCommandArity = (argv: string[], agent: boolean) => {
+  if (isNativeRoute(argv)) return;
+  const commandPath = resolveCommandPath(argv);
+  const command = Object.entries(Commands).find(([id]) => id === commandPath)?.[1];
+  if (beforeDelimiter(argv).includes("--help")) return;
+  if (
+    optionTokens(argv).some((token) =>
+      ["--help", "-h", "--schema", "--llms", "--llms-full", "--mcp"].includes(token),
+    )
+  )
+    return;
+  if (!command) {
+    const route = resolveRoute(argv);
+    const unexpected = argv[route.end];
+    if (agent && unexpected && !unexpected.startsWith("-")) {
+      throw Object.assign(new Error(`'${unexpected}' is not a command.`), {
+        code: "COMMAND_NOT_FOUND",
+        exitCode: 2,
+      });
+    }
+    return;
+  }
+  const segments = commandPath.split(":");
+  const routeStart = argv.findIndex((_value, index) =>
+    segments.every((segment, offset) => argv[index + offset] === segment),
+  );
+  if (routeStart < 0) return;
+  const fields = new Map<string, { multiple: boolean; name: string; takesValue: boolean }>();
+  for (const [name, field] of Object.entries(command.contract.options)) {
+    const internal = schemaFieldName(name).replace(
+      /[A-Z]/g,
+      (letter) => `-${letter.toLowerCase()}`,
+    );
+    const descriptor = {
+      multiple: field.multiple === true,
+      name,
+      takesValue: field.kind !== "boolean",
+    };
+    fields.set(`--${internal}`, descriptor);
+    if (field.kind === "boolean") fields.set(`--no-${internal}`, descriptor);
+    if (field.char) fields.set(`-${field.char}`, descriptor);
+  }
+  for (const name of ["profile", "format", "filter-output", "token-limit", "token-offset"]) {
+    fields.set(`--${name}`, { multiple: false, name, takesValue: true });
+  }
+  for (const name of [
+    "agent",
+    "print-requests",
+    "quiet",
+    "read-only",
+    "yes",
+    "full-output",
+    "help",
+    "llms",
+    "llms-full",
+    "schema",
+    "token-count",
+  ]) {
+    const descriptor = { multiple: false, name, takesValue: false };
+    fields.set(`--${name}`, descriptor);
+    fields.set(`--no-${name}`, descriptor);
+  }
+  let positionalCount = 0;
+  const seen = new Set<string>();
+  const args = Object.values(command.contract.args);
+  const values = argv.slice(routeStart + segments.length);
+  for (let index = 0; index < values.length; index += 1) {
+    const token = values[index] ?? "";
+    if (!token.startsWith("-")) {
+      positionalCount += 1;
+      continue;
+    }
+    const name = token.split("=", 1)[0] ?? token;
+    const field = fields.get(name);
+    if (!field) {
+      if (["--json", "--mcp", "--version", "--update", "--update-check", "-h"].includes(name))
+        continue;
+      if (token === "--") {
+        positionalCount += values.length - index - 1;
+        break;
+      }
+      throw Object.assign(new Error(`Unknown flag: ${name}`), {
+        code: "UNKNOWN_FLAG",
+        exitCode: 2,
+      });
+    }
+    if (!field.takesValue && token.includes("=")) {
+      const positional = values.find((value) => !value.startsWith("-"));
+      if (args.at(-1)?.multiple || positionalCount < args.length) {
+        const actualIndex = argv.indexOf(token, routeStart + segments.length);
+        if (actualIndex >= 0) {
+          argv.splice(actualIndex, 1, name, token.slice(token.indexOf("=") + 1));
+          positionalCount += 1;
+          continue;
+        }
+      }
+      const argument =
+        args.at(-1)?.kind !== "boolean" && args.length > 0 && positional
+          ? positional
+          : token.slice(token.indexOf("=") + 1);
+      const error = new Error(`Unexpected argument: ${argument}`);
+      Object.assign(error, { exitCode: 2, showHelp: true });
+      throw error;
+    }
+    if (field.takesValue && !field.multiple && seen.has(field.name)) {
+      const error = new Error(`Flag --${field.name} can only be specified once`);
+      Object.assign(error, { exitCode: 2 });
+      throw error;
+    }
+    seen.add(field.name);
+    if (field.takesValue && !token.includes("=")) {
+      if (index + 1 >= values.length) {
+        throw Object.assign(new Error(`Missing value for flag: ${name}`), {
+          code: "VALIDATION_ERROR",
+          exitCode: 2,
+        });
+      }
+      index += 1;
+    }
+  }
+  if (!args.at(-1)?.multiple && positionalCount > args.length) {
+    const error = new Error(`Unexpected argument: ${values.at(-1)}`);
+    Object.assign(error, { exitCode: 2, showHelp: true });
+    throw error;
+  }
+  if (!agent) return;
+  const localArguments: string[] = [];
+  for (let index = 0; index < values.length; index += 1) {
+    const token = values[index];
+    const field = fields.get(token.split("=", 1)[0]);
+    if (!token.startsWith("-") || (field && Object.hasOwn(command.contract.options, field.name))) {
+      localArguments.push(token);
+      if (field?.takesValue && !token.includes("=") && index + 1 < values.length)
+        localArguments.push(values[++index]);
+    } else if (field?.takesValue && !token.includes("=")) index += 1;
+  }
+  try {
+    Parser.parse(localArguments, {
+      alias: command.alias,
+      args: command.args,
+      options: command.options,
+    });
+  } catch (error) {
+    if (error instanceof Error) Object.assign(error, { code: "VALIDATION_ERROR", exitCode: 2 });
+    throw error;
+  }
+};
+
+// Select switches without mistaking the value of another option for a switch.
+const optionTokens = (argv: string[]) => {
+  const tokens = beforeDelimiter(argv);
+  const route = resolveRoute(tokens);
+  const valueFlags = new Set(globalValueFlags);
+  for (const [name, field] of Object.entries(route.command?.contract.options ?? {}) as [
+    string,
+    { kind: string; char?: string },
+  ][]) {
+    if (field.kind === "boolean") continue;
+    valueFlags.add(`--${name}`);
+    valueFlags.add(`--${name.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)}`);
+    if (field.char) valueFlags.add(`-${field.char}`);
+  }
+  const result: string[] = [];
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    if (token.startsWith("-")) result.push(token);
+    if (valueFlags.has(token)) index += 1;
+  }
+  return result;
+};
+
+export const resolveAgentMode = (
+  argv: string[],
+  environment: NodeJS.ProcessEnv = process.env,
+): boolean => {
+  const prismArguments = optionTokens(argv);
+  const explicitModes = prismArguments.flatMap((value) => {
+    const match = /^--(no-)?agent(?:=(true|false))?$/i.exec(value);
+    if (!match) return [];
+    const enabled = (match[1] === undefined) === (match[2]?.toLowerCase() !== "false");
+    return [enabled];
+  });
+  const forceAgent = explicitModes.includes(true);
+  const forceHuman = explicitModes.includes(false);
+  if (forceAgent && forceHuman) throw new Error("--agent and --no-agent cannot be used together");
+  if (forceAgent) return true;
+  if (forceHuman) return false;
+  if (truthy(environment.PRISM_NO_AGENT) || truthy(environment.FORCE_HUMAN_MODE)) return false;
+  return agentEnvironmentVariables.some((name) => truthy(environment[name]));
+};
+
+const writeAgentUsageError = (error: unknown, argv: string[]) => {
+  const tokens = argv;
+  const message = error instanceof Error ? error.message : String(error);
+  const explicitFormat = tokens.find((value) => /^--(?:json|jsonl|yaml|toon|md)$/.test(value));
+  const formatIndex = tokens.indexOf("--format");
+  const inlineFormat = tokens.find((value) => value.startsWith("--format="))?.slice(9);
+  const format = (inlineFormat ??
+    (formatIndex >= 0 ? tokens[formatIndex + 1] : undefined) ??
+    explicitFormat?.slice(2) ??
+    "toon") as Formatter.Format;
+  const code =
+    error && typeof error === "object" && "code" in error ? error.code : "VALIDATION_ERROR";
+  process.stdout.write(Formatter.format({ code, message }, format));
+  process.exitCode = 2;
+};
+
+/** Capture only real launch globals; builtin option values may resemble flags. */
+export const parseMcpLaunchGlobals = (
+  argv: string[],
+  environment: NodeJS.ProcessEnv = process.env,
+) => {
+  const tokens = beforeDelimiter(argv);
+  const selected: string[] = [];
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+    const name = token.split("=", 1)[0];
+    // These are incur output controls, not custom globals. Their values are opaque.
+    if (globalValueFlags.has(name) && name !== "--profile") {
+      if (!token.includes("=")) index += 1;
+      continue;
+    }
+    selected.push(token);
+    if (name === "--profile" && !token.includes("=") && index + 1 < tokens.length)
+      selected.push(tokens[++index]);
+  }
+  const globals = Parser.parseGlobals(selected, globalOptions).parsed;
+  return { ...globals, readOnly: globals.readOnly || truthy(environment.PRISM_READ_ONLY) };
+};
+
+export const serve = async (argv = process.argv.slice(2), environment = process.env) => {
+  // Shell hooks pass an argv-shaped payload after --. It is a completion
+  // protocol, not an invocation; preserve it before any compatibility parsing.
+  if (environment.COMPLETE) {
+    const separator = argv.indexOf("--");
+    const words = separator < 0 ? argv : argv.slice(separator + 1);
+    const index = Number(environment._COMPLETE_INDEX ?? words.length - 1);
+    const current = words[index] ?? "";
+    if (index === 1 && current.includes(":")) {
+      const candidates = Object.entries(Commands)
+        .filter(([id]) => id.startsWith(current))
+        .map(([value, command]) => ({ value, description: command.description }));
+      const output = Completions.format(
+        environment.COMPLETE as Parameters<typeof Completions.format>[0],
+        candidates,
+      );
+      if (output) process.stdout.write(output);
+      return;
+    }
+    let completionArgv = argv;
+    const oldIndex = process.env._COMPLETE_INDEX;
+    try {
+      // A completed legacy colon route still supplies its local flags to incur.
+      if (index > 1 && Object.hasOwn(Commands, words[1] ?? "") && words[1].includes(":")) {
+        const segments = words[1].split(":");
+        completionArgv = ["--", words[0], ...segments, ...words.slice(2)];
+        process.env._COMPLETE_INDEX = String(index + segments.length - 1);
+      }
+      await cli.serve(completionArgv, {
+        env: environment,
+        stdout: (output: string) => process.stdout.write(output),
+        exit: (code: number) => {
+          process.exitCode = code;
+        },
+      });
+    } finally {
+      if (oldIndex === undefined) delete process.env._COMPLETE_INDEX;
+      else process.env._COMPLETE_INDEX = oldIndex;
+    }
+    return;
+  }
+  const agent = resolveAgentMode(argv, environment);
+  let normalized: string[];
+  try {
+    normalized = isNativeRoute(argv) ? argv : normalizeCommandArguments(argv);
+  } catch (error) {
+    if (!agent) throw error;
+    writeAgentUsageError(error, argv);
+    return;
+  }
+  const prismArguments = optionTokens(argv);
+  const commandPath = resolveCommandPath(normalized);
+  const command = Object.entries(Commands).find(([id]) => id === commandPath)?.[1];
+  const hasLocalVersionAlias = Object.values(command?.contract.options ?? {}).some(
+    (field) => field.char === "v",
+  );
+  // Preserve Prism's global short version flag while letting incur render it.
+  if (!hasLocalVersionAlias && prismArguments.includes("-v")) {
+    normalized = normalized.map((token) => (token === "-v" ? "--version" : token));
+  }
+  try {
+    assertNativeMutationAllowed(normalized, agent, environment);
+    assertCommandArity(normalized, agent);
+  } catch (error) {
+    if (!agent) throw error;
+    writeAgentUsageError(error, normalized);
+    return;
+  }
+  const descriptor = Object.getOwnPropertyDescriptor(process.stdout, "isTTY");
+  let usageError = false;
+  Object.defineProperty(process.stdout, "isTTY", {
+    configurable: true,
+    value: !agent,
+  });
+  try {
+    const invoke = () =>
+      cli.serve(normalized, {
+        env: environment,
+        exit: (code: number) => {
+          process.exitCode = code;
+        },
+        stdout: (output: string) => {
+          const renderedOutput =
+            agent && /code: UNKNOWN\b[\s\S]*Unknown flag:/i.test(output)
+              ? output.replace(/code: UNKNOWN\b/, "code: UNKNOWN_FLAG")
+              : output;
+          const humanError = !agent && /^Error(?: \([^\n)]*\))?:/.test(renderedOutput);
+          if (
+            /^Error: (?:.*not a command|Unknown flag|missing required|invalid value|.*cannot also be provided|.* requires |Exactly one)/i.test(
+              renderedOutput,
+            ) ||
+            (agent &&
+              /code: (?:COMMAND_NOT_FOUND|UNKNOWN_FLAG|VALIDATION_ERROR)\b/i.test(renderedOutput))
+          ) {
+            usageError = true;
+          }
+          if (humanError) {
+            process.stderr.write(renderedOutput);
+          } else process.stdout.write(renderedOutput);
+        },
+      });
+    await (prismArguments.includes("--mcp")
+      ? runWithMcpTransport(invoke, parseMcpLaunchGlobals(normalized, environment))
+      : invoke());
+    if (usageError) process.exitCode = 2;
+  } finally {
+    if (descriptor) Object.defineProperty(process.stdout, "isTTY", descriptor);
+  }
+};

--- a/src/commands/profiles/delete.ts
+++ b/src/commands/profiles/delete.ts
@@ -1,35 +1,45 @@
-import { Args } from "@oclif/core";
-import { PrismaticBaseCommand } from "../../baseCommand.js";
+import { z } from "incur";
+import { commandOutput, defineCommand, argsSchema } from "../../command.js";
 import { deleteProfile } from "../../config.js";
+import { resultOutput, warningsOutput } from "../../output.js";
 
-export default class ProfilesDeleteCommand extends PrismaticBaseCommand {
-  static description = "Delete a profile";
-
-  static args = {
-    name: Args.string({
-      required: true,
-      description: "Profile to delete",
+export default defineCommand({
+  mutates: true,
+  output: z.object({
+    profile: z.string(),
+    deleted: z.literal(true),
+    defaultProfile: z.string().nullable(),
+    ...warningsOutput,
+  }),
+  description: "Delete a profile",
+  args: argsSchema(
+    z.object({
+      name: z.string().describe("Profile to delete"),
     }),
-  };
-
-  async run() {
+  ),
+  async run(context) {
     const {
       args: { name },
-    } = await this.parse(ProfilesDeleteCommand);
+    } = context;
 
     const result = await deleteProfile(name);
     if (!result.deleted) {
-      this.error(`Profile '${name}' does not exist.`, { exit: 1 });
+      commandOutput.error(`Profile '${name}' does not exist.`, { exit: 1 });
     }
 
     if (result.isLast) {
-      this.log(`Deleted '${name}'. No profiles remain.`);
-      return;
+      commandOutput.log(`Deleted '${name}'. No profiles remain.`);
+      return resultOutput(context, { profile: name, deleted: true, defaultProfile: null });
     }
 
-    this.log(`Deleted '${name}'.`);
+    commandOutput.log(`Deleted '${name}'.`);
     if (result.defaultChanged) {
-      this.log(`Default profile is now '${result.defaultProfile}'.`);
+      commandOutput.log(`Default profile is now '${result.defaultProfile}'.`);
     }
-  }
-}
+    return resultOutput(context, {
+      profile: name,
+      deleted: true,
+      defaultProfile: result.defaultProfile ?? null,
+    });
+  },
+});

--- a/src/commands/profiles/list.ts
+++ b/src/commands/profiles/list.ts
@@ -1,31 +1,40 @@
-import { PrismaticBaseCommand } from "../../baseCommand.js";
+import { tableOutputSchema } from "../../utils/table.js";
+import { commandOutput, defineCommand, optionsSchema } from "../../command.js";
 import { listProfiles } from "../../config.js";
-import { ux } from "../../utils/legacy-ux.js";
+import { ux } from "../../utils/ux.js";
+import { z } from "incur";
 
-export default class ProfilesListCommand extends PrismaticBaseCommand {
-  static description = "List profiles";
-
-  static flags = {
-    ...ux.table.flags(),
-  };
-
-  async run() {
-    const { flags } = await this.parse(ProfilesListCommand);
+export default defineCommand({
+  outputPolicy: "agent-only",
+  output: tableOutputSchema(["name", "prismaticUrl", "tenantId", "isDefault"]),
+  description: "List profiles",
+  options: optionsSchema(
+    z.object({
+      ...ux.table.flags(),
+    }),
+  ),
+  async run(context) {
+    const { options: flags } = context;
 
     const profiles = await listProfiles();
     if (profiles.length === 0) {
-      this.log("No profiles found.");
-      return;
+      if (context.agent) return { items: [] };
+      commandOutput.log("No profiles found.");
+      return { items: [] };
     }
 
-    ux.table(
+    return ux.table(
       profiles,
       {
-        name: { header: "Profile", get: (p) => (p.isDefault ? `${p.name} (default)` : p.name) },
+        name: {
+          header: "Profile",
+          get: (p) => (!context.agent && p.isDefault ? `${p.name} (default)` : p.name),
+        },
         prismaticUrl: { header: "Endpoint URL" },
+        ...(context.agent ? { isDefault: {} } : {}),
         tenantId: { header: "Tenant ID", get: (p) => p.tenantId ?? "" },
       },
       flags,
     );
-  }
-}
+  },
+});

--- a/src/commands/profiles/profiles.test.ts
+++ b/src/commands/profiles/profiles.test.ts
@@ -1,8 +1,9 @@
+import { runCommand } from "../../test-command.js";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
-import { getStdout } from "../../../vitest.setup.js";
+import { getStdout, getStderr } from "../../../vitest.setup.js";
 import { type Profile, readConfigFile, writeProfile } from "../../config.js";
 import ProfilesDeleteCommand from "./delete.js";
 import ProfilesListCommand from "./list.js";
@@ -48,7 +49,7 @@ describe("profiles commands", () => {
       await writeProfile("default", makeProfile({ tenantId: "t-1" }));
       await writeProfile("staging", makeProfile({ prismaticUrl: "https://staging.example.io" }));
 
-      await ProfilesListCommand.run([]);
+      await runCommand(ProfilesListCommand, []);
 
       const out = getStdout();
       expect(out).toContain("default (default)");
@@ -58,8 +59,9 @@ describe("profiles commands", () => {
     });
 
     it("prints a hint when there are no profiles", async () => {
-      await ProfilesListCommand.run([]);
-      expect(getStdout()).toContain("No profiles found.");
+      const result = await runCommand(ProfilesListCommand, []);
+      expect(result).toEqual({ items: [] });
+      expect(getStderr()).toContain("No profiles found.");
     });
   });
 
@@ -68,12 +70,13 @@ describe("profiles commands", () => {
       await writeProfile("default", makeProfile());
       await writeProfile("staging", makeProfile());
 
-      await ProfilesUseCommand.run(["staging"]);
+      const result = await runCommand(ProfilesUseCommand, ["staging"]);
+      expect(result).toEqual({ profile: "staging" });
 
       const file = await readConfigFile();
       expect(file?.defaultProfile).toBe("staging");
       expect(Object.keys(file?.profiles ?? {})).toEqual(["default", "staging"]);
-      expect(getStdout()).toContain("Using 'staging' by default.");
+      expect(getStderr()).toContain("Using 'staging' by default.");
     });
   });
 
@@ -82,25 +85,29 @@ describe("profiles commands", () => {
       await writeProfile("default", makeProfile());
       await writeProfile("staging", makeProfile());
 
-      await ProfilesDeleteCommand.run(["staging"]);
+      const result = await runCommand(ProfilesDeleteCommand, ["staging"]);
+      expect(result).toEqual({ profile: "staging", deleted: true, defaultProfile: "default" });
 
       const file = await readConfigFile();
       expect(Object.keys(file?.profiles ?? {})).toEqual(["default"]);
-      expect(getStdout()).toContain("Deleted 'staging'.");
+      expect(getStderr()).toContain("Deleted 'staging'.");
     });
 
     it("removes the config file when the last profile is deleted", async () => {
       await writeProfile("default", makeProfile());
 
-      await ProfilesDeleteCommand.run(["default"]);
+      const result = await runCommand(ProfilesDeleteCommand, ["default"]);
+      expect(result).toEqual({ profile: "default", deleted: true, defaultProfile: null });
 
       expect(await readConfigFile()).toBeNull();
-      expect(getStdout()).toContain("No profiles remain.");
+      expect(getStderr()).toContain("No profiles remain.");
     });
 
     it("errors when the profile does not exist", async () => {
       await writeProfile("default", makeProfile());
-      await expect(ProfilesDeleteCommand.run(["missing"])).rejects.toThrow(/does not exist/);
+      await expect(runCommand(ProfilesDeleteCommand, ["missing"])).rejects.toThrow(
+        /does not exist/,
+      );
     });
   });
 });

--- a/src/commands/profiles/use.ts
+++ b/src/commands/profiles/use.ts
@@ -1,23 +1,24 @@
-import { Args } from "@oclif/core";
-import { PrismaticBaseCommand } from "../../baseCommand.js";
+import { commandOutput, defineCommand, argsSchema } from "../../command.js";
 import { useProfile } from "../../config.js";
+import { resourceOutputSchema, resultOutput } from "../../output.js";
+import { z } from "incur";
 
-export default class ProfilesUseCommand extends PrismaticBaseCommand {
-  static description = "Set the default profile";
-
-  static args = {
-    name: Args.string({
-      required: true,
-      description: "Profile to use by default",
+export default defineCommand({
+  mutates: true,
+  output: resourceOutputSchema("profile"),
+  description: "Set the default profile",
+  args: argsSchema(
+    z.object({
+      name: z.string().describe("Profile to use by default"),
     }),
-  };
-
-  async run() {
+  ),
+  async run(context) {
     const {
       args: { name },
-    } = await this.parse(ProfilesUseCommand);
+    } = context;
 
     await useProfile(name);
-    this.log(`Using '${name}' by default.`);
-  }
-}
+    commandOutput.log(`Using '${name}' by default.`);
+    return resultOutput(context, { profile: name });
+  },
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,44 @@
+import LoginCommand from "./commands/login/index.js";
+import LoginSwitchCommand from "./commands/login/switch.js";
+import LogoutCommand from "./commands/logout.js";
+import ComponentsDeleteCommand from "./commands/components/delete.js";
+import ComponentsListCommand from "./commands/components/list.js";
+import ComponentsPublishCommand from "./commands/components/publish.js";
+import CustomersCreateCommand from "./commands/customers/create.js";
+import CustomersDeleteCommand from "./commands/customers/delete.js";
+import CustomersListCommand from "./commands/customers/list.js";
+import CustomersUpdateCommand from "./commands/customers/update.js";
+import InstancesCreateCommand from "./commands/instances/create.js";
+import InstancesDeleteCommand from "./commands/instances/delete.js";
+import InstancesDeployCommand from "./commands/instances/deploy.js";
+import InstancesDisableCommand from "./commands/instances/disable.js";
+import InstancesEnableCommand from "./commands/instances/enable.js";
+import InstancesListCommand from "./commands/instances/list.js";
+import InstancesUpdateCommand from "./commands/instances/update.js";
+import IntegrationsAvailableCommand from "./commands/integrations/available.js";
+import IntegrationsCreateCommand from "./commands/integrations/create.js";
+import IntegrationsDeleteCommand from "./commands/integrations/delete.js";
+import IntegrationsExportCommand from "./commands/integrations/export.js";
+import IntegrationsForkCommand from "./commands/integrations/fork.js";
+import IntegrationsImportCommand from "./commands/integrations/import.js";
+import IntegrationsListCommand from "./commands/integrations/list.js";
+import IntegrationsMarketplaceCommand from "./commands/integrations/marketplace.js";
+import IntegrationsOpenCommand from "./commands/integrations/open.js";
+import IntegrationsPublishCommand from "./commands/integrations/publish.js";
+import IntegrationsSetDebugCommand from "./commands/integrations/set-debug.js";
+import IntegrationsUpdateCommand from "./commands/integrations/update.js";
+import IntegrationsValidateYamlCommand from "./commands/integrations/validate-yaml.js";
+import MeCommand from "./commands/me/index.js";
+import MeTokenCommand from "./commands/me/token.js";
+import ProfilesListCommand from "./commands/profiles/list.js";
+import ProfilesUseCommand from "./commands/profiles/use.js";
+import ProfilesDeleteCommand from "./commands/profiles/delete.js";
+import OnPremResourcesDeleteCommand from "./commands/on-prem-resources/delete.js";
+import OnPremResourcesListCommand from "./commands/on-prem-resources/list.js";
+import OnPremResourcesRegistrationCommand from "./commands/on-prem-resources/registration-jwt.js";
+import OrganizationUpdateCommand from "./commands/organization/update.js";
+import OrganizationUpdateAvatarUrlCommand from "./commands/organization/updateAvatarUrl.js";
+import TranslationsListCommand from "./commands/translations/list.js";
 import AlertsEventsListCommand from "./commands/alerts/events/list.js";
 import AlertsGroupsCreateCommand from "./commands/alerts/groups/create.js";
 import AlertsGroupsDeleteCommand from "./commands/alerts/groups/delete.js";
@@ -12,83 +53,50 @@ import AlertsWebhooksDeleteCommand from "./commands/alerts/webhooks/delete.js";
 import AlertsWebhooksListCommand from "./commands/alerts/webhooks/list.js";
 import ComponentsActionsListCommand from "./commands/components/actions/list.js";
 import ComponentsDataSourcesListCommand from "./commands/components/data-sources/list.js";
-import ComponentsDeleteCommand from "./commands/components/delete.js";
 import ComponentsDevRunCommand from "./commands/components/dev/run.js";
 import ComponentsDevTestCommand from "./commands/components/dev/test.js";
 import ComponentsInitComponentCommand from "./commands/components/init/component.js";
 import ComponentsInitCommand from "./commands/components/init/index.js";
-import ComponentsListCommand from "./commands/components/list.js";
-import ComponentsPublishCommand from "./commands/components/publish.js";
 import ComponentsSignatureCommand from "./commands/components/signature.js";
 import ComponentsTriggersListCommand from "./commands/components/triggers/list.js";
-import CustomersCreateCommand from "./commands/customers/create.js";
-import CustomersDeleteCommand from "./commands/customers/delete.js";
-import CustomersListCommand from "./commands/customers/list.js";
-import CustomersUpdateCommand from "./commands/customers/update.js";
 import CustomersUsersCreateCommand from "./commands/customers/users/create.js";
 import CustomersUsersDeleteCommand from "./commands/customers/users/delete.js";
 import CustomersUsersListCommand from "./commands/customers/users/list.js";
 import CustomersUsersRolesCommand from "./commands/customers/users/roles.js";
 import CustomersUsersUpdateCommand from "./commands/customers/users/update.js";
 import ExecutionsStepResultGetCommand from "./commands/executions/step-result/get.js";
-import GraphqlQueryCommand from "./commands/graphql/query.js";
 import InstancesConfigVarsListCommand from "./commands/instances/config-vars/list.js";
-import InstancesCreateCommand from "./commands/instances/create.js";
-import InstancesDeleteCommand from "./commands/instances/delete.js";
-import InstancesDeployCommand from "./commands/instances/deploy.js";
-import InstancesDisableCommand from "./commands/instances/disable.js";
-import InstancesEnableCommand from "./commands/instances/enable.js";
 import InstancesFlowConfigsListCommand from "./commands/instances/flow-configs/list.js";
 import InstancesFlowConfigsTestCommand from "./commands/instances/flow-configs/test.js";
-import InstancesListCommand from "./commands/instances/list.js";
-import InstancesUpdateCommand from "./commands/instances/update.js";
-import IntegrationsAvailableCommand from "./commands/integrations/available.js";
 import IntegrationConvertCommand from "./commands/integrations/convert/index.js";
-import IntegrationsCreateCommand from "./commands/integrations/create.js";
-import IntegrationsDeleteCommand from "./commands/integrations/delete.js";
-import IntegrationsExportCommand from "./commands/integrations/export.js";
 import IntegrationsFlowsListCommand from "./commands/integrations/flows/list.js";
 import IntegrationsFlowsListenCommand from "./commands/integrations/flows/listen.js";
 import IntegrationsFlowsTestCommand from "./commands/integrations/flows/test.js";
-import IntegrationsForkCommand from "./commands/integrations/fork.js";
-import IntegrationsImportCommand from "./commands/integrations/import.js";
 import IntegrationsInitCommand from "./commands/integrations/init/index.js";
-import IntegrationsListCommand from "./commands/integrations/list.js";
-import IntegrationsMarketplaceCommand from "./commands/integrations/marketplace.js";
-import IntegrationsOpenCommand from "./commands/integrations/open.js";
-import IntegrationsPublishCommand from "./commands/integrations/publish.js";
-import IntegrationsSetDebugCommand from "./commands/integrations/set-debug.js";
-import IntegrationsUpdateCommand from "./commands/integrations/update.js";
-import IntegrationsValidateYamlCommand from "./commands/integrations/validate-yaml.js";
 import IntegrationsVersionsCommand from "./commands/integrations/versions/index.js";
-import LoginCommand from "./commands/login/index.js";
-import LoginSwitchCommand from "./commands/login/switch.js";
-import LogoutCommand from "./commands/logout.js";
 import LogsSeveritiesListCommand from "./commands/logs/severities/list.js";
-import MeCommand from "./commands/me/index.js";
 import MeTokenRevokeCommand from "./commands/me/token/revoke.js";
-import MeTokenCommand from "./commands/me/token.js";
-import OnPremResourcesDeleteCommand from "./commands/on-prem-resources/delete.js";
-import OnPremResourcesListCommand from "./commands/on-prem-resources/list.js";
-import OnPremResourcesRegistrationCommand from "./commands/on-prem-resources/registration-jwt.js";
 import OrganizationConnectionsListCommand from "./commands/organization/connections/list.js";
 import OrganizationSigningKeysDeleteCommand from "./commands/organization/signingKeys/delete.js";
 import OrganizationSigningKeysGenerateCommand from "./commands/organization/signingKeys/generate.js";
 import OrganizationSigningKeysImportCommand from "./commands/organization/signingKeys/import.js";
 import OrganizationSigningKeysListCommand from "./commands/organization/signingKeys/list.js";
-import OrganizationUpdateCommand from "./commands/organization/update.js";
-import OrganizationUpdateAvatarUrlCommand from "./commands/organization/updateAvatarUrl.js";
 import OrganizationUsersCreateCommand from "./commands/organization/users/create.js";
 import OrganizationUsersDeleteCommand from "./commands/organization/users/delete.js";
 import OrganizationUsersListCommand from "./commands/organization/users/list.js";
 import OrganizationUsersRolesCommand from "./commands/organization/users/roles.js";
 import OrganizationUsersUpdateCommand from "./commands/organization/users/update.js";
-import ProfilesDeleteCommand from "./commands/profiles/delete.js";
-import ProfilesListCommand from "./commands/profiles/list.js";
-import ProfilesUseCommand from "./commands/profiles/use.js";
-import TranslationsListCommand from "./commands/translations/list.js";
 import WorkflowsExportCommand from "./commands/workflows/export.js";
 import WorkflowsImportCommand from "./commands/workflows/import.js";
+import GraphqlQueryCommand from "./commands/graphql/query.js";
+import { asOclifCommand } from "./migration-bridge.js";
+
+// During the stack, native commands run through incur while remaining commands keep oclif.
+export const NativeCommands = {
+  "profiles:list": ProfilesListCommand,
+  "profiles:use": ProfilesUseCommand,
+  "profiles:delete": ProfilesDeleteCommand,
+};
 
 export const Commands = {
   login: LoginCommand,
@@ -123,9 +131,6 @@ export const Commands = {
   "integrations:validate-yaml": IntegrationsValidateYamlCommand,
   me: MeCommand,
   "me:token": MeTokenCommand,
-  "profiles:list": ProfilesListCommand,
-  "profiles:use": ProfilesUseCommand,
-  "profiles:delete": ProfilesDeleteCommand,
   "on-prem-resources:delete": OnPremResourcesDeleteCommand,
   "on-prem-resources:list": OnPremResourcesListCommand,
   "on-prem-resources:registration-jwt": OnPremResourcesRegistrationCommand,
@@ -182,4 +187,7 @@ export const Commands = {
   "workflows:export": WorkflowsExportCommand,
   "workflows:import": WorkflowsImportCommand,
   "graphql:query": GraphqlQueryCommand,
+  ...Object.fromEntries(
+    Object.entries(NativeCommands).map(([id, command]) => [id, asOclifCommand(id, command)]),
+  ),
 };

--- a/src/migration-bridge.ts
+++ b/src/migration-bridge.ts
@@ -1,0 +1,40 @@
+import { Args, Command, Flags } from "@oclif/core";
+import type { Field, Fields } from "./compatibility.js";
+
+// Temporary stack seam: keep the installed oclif command catalog working while
+// command families move to incur. The final cutover removes this module.
+export const asOclifCommand = (
+  id: string,
+  definition: { description?: string; contract: { args: Fields; options: Fields } },
+) => {
+  const flag = (field: Field) => {
+    const options = {
+      description: field.description,
+      char: field.char as NonNullable<Parameters<typeof Flags.boolean>[0]>["char"],
+      required: field.required,
+    };
+    if (field.kind === "boolean") return Flags.boolean(options);
+    if (field.kind === "integer") return Flags.integer(options);
+    const choices = field.options?.map(String);
+    return field.multiple
+      ? Flags.string({ ...options, multiple: true, options: choices })
+      : Flags.string({ ...options, options: choices });
+  };
+  return class NativeCommand extends Command {
+    static description = definition.description;
+    static args = Object.fromEntries(
+      Object.entries(definition.contract.args).map(([name, field]) => [
+        name,
+        Args.string({ description: field.description, required: field.required }),
+      ]),
+    );
+    static flags = Object.fromEntries(
+      Object.entries(definition.contract.options).map(([name, field]) => [name, flag(field)]),
+    );
+    async run() {
+      const { serve } = await import("./cli.js");
+      await serve([id, ...this.argv]);
+      this.parsed = true; // Parsing is delegated to incur.
+    }
+  };
+};

--- a/src/migration-contract.test.ts
+++ b/src/migration-contract.test.ts
@@ -1,0 +1,42 @@
+import { readFile } from "node:fs/promises";
+import { describe, expect, it } from "vitest";
+import { cli, normalizeCommandArguments } from "./cli.js";
+import { NativeCommands } from "./index.js";
+
+const published = JSON.parse(
+  await readFile(new URL("../test/fixtures/legacy-cli-contract.json", import.meta.url), "utf8"),
+).commands;
+
+describe("incremental native command contract", () => {
+  for (const [id, command] of Object.entries(NativeCommands)) {
+    it(`${id} retains published inputs and exposes its native output schema`, async () => {
+      const legacy = published[id];
+      if (legacy) {
+        expect(command.description).toBe(legacy.description);
+        for (const [name, field] of Object.entries(legacy.args)) {
+          expect(command.contract.args[name], `${id} positional ${name}`).toBeDefined();
+          expect(command.contract.args[name].required ?? false).toBe(
+            (field as { required?: boolean }).required ?? false,
+          );
+        }
+        for (const [name, field] of Object.entries(legacy.flags)) {
+          if (["quiet", "profile", "print-requests"].includes(name)) continue;
+          expect(command.contract.options[name], `${id} flag ${name}`).toBeDefined();
+          expect(command.contract.options[name].char).toBe((field as { char?: string }).char);
+        }
+      }
+      expect(normalizeCommandArguments([id, "--schema"])).toEqual([...id.split(":"), "--schema"]);
+      expect(command.output).toBeDefined();
+      const output: string[] = [];
+      let status = 0;
+      await cli.serve([...id.split(":"), "--schema", "--format", "json"], {
+        stdout: (text) => output.push(text),
+        exit: (code) => {
+          status = code;
+        },
+      });
+      expect(status).toBe(0);
+      expect(JSON.parse(output.join(""))).toHaveProperty("output");
+    });
+  }
+});

--- a/test/fixtures/legacy-cli-contract.json
+++ b/test/fixtures/legacy-cli-contract.json
@@ -1,0 +1,7482 @@
+{
+  "commands": {
+    "login": {
+      "aliases": [],
+      "args": {},
+      "description": "Log in to your Prismatic account",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "re-authenticate, even if you are already logged in",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "url": {
+          "char": "u",
+          "description": "returns a challenge url without automatically opening a browser",
+          "name": "url",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "login",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "login:switch": {
+      "aliases": [],
+      "args": {},
+      "description": "Switch between organization tenants",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "login:switch",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "logout": {
+      "aliases": [],
+      "args": {},
+      "description": "Log out of your Prismatic account",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "browser": {
+          "char": "b",
+          "description": "additionally log out of your default browser's session",
+          "name": "browser",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "logout",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "components:delete": {
+      "aliases": [],
+      "args": {
+        "component": {
+          "description": "ID of the component to delete",
+          "name": "component",
+          "required": true
+        }
+      },
+      "description": "Delete a Component",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "components:delete",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "components:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List available Components",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "showAllVersions": {
+          "char": "a",
+          "description": "If specified this command returns all versions of all components rather than only the latest version",
+          "name": "showAllVersions",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "search": {
+          "char": "s",
+          "description": "Search components by label first, then by key (case insensitive)",
+          "name": "search",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "components:list",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "components:publish": {
+      "aliases": [],
+      "args": {},
+      "description": "Publish a Component to Prismatic",
+      "examples": [
+        {
+          "description": "Build and publish a component:",
+          "command": "npm run build && <%= config.bin %> <%= command.id %>"
+        }
+      ],
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "comment": {
+          "char": "c",
+          "description": "Comment about changes in this Publish",
+          "name": "comment",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "confirm": {
+          "description": "Interactively confirm publish",
+          "name": "confirm",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "check-signature": {
+          "description": "Check signature of existing component and confirm publish if matched",
+          "name": "check-signature",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "skip-on-signature-match": {
+          "description": "Skips component publish if the new signature matches the existing signature",
+          "name": "skip-on-signature-match",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "customer": {
+          "description": "ID of customer with which to associate the component",
+          "name": "customer",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "commitHash": {
+          "description": "Commit hash corresponding to the component version being published",
+          "name": "commitHash",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "commitUrl": {
+          "description": "URL to the commit details for this component version",
+          "name": "commitUrl",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "repoUrl": {
+          "description": "URL to the repository containing the component definition",
+          "name": "repoUrl",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "pullRequestUrl": {
+          "description": "URL to the pull request that modified this component version",
+          "name": "pullRequestUrl",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "include-source": {
+          "description": "Include source code in the component publish",
+          "name": "include-source",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "components:publish",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "customers:create": {
+      "aliases": [],
+      "args": {},
+      "description": "Create a new Customer",
+      "examples": [
+        {
+          "description": "Apply multiple labels to a customer",
+          "command": "<%= config.bin %> <%= command.id %> --name \"Widgets Inc\" --externalId \"abc-123\" --label \"Prod Customers\" --label \"Beta Testers\""
+        }
+      ],
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "name": {
+          "char": "n",
+          "description": "short name of the new customer",
+          "name": "name",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "description": {
+          "char": "d",
+          "description": "longer description of the customer",
+          "name": "description",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "externalId": {
+          "char": "e",
+          "description": "external ID of the customer from your system",
+          "name": "externalId",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "label": {
+          "char": "l",
+          "description": "a label to apply to the customer",
+          "name": "label",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "customers:create",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "customers:delete": {
+      "aliases": [],
+      "args": {
+        "customer": {
+          "description": "ID of the customer to delete",
+          "name": "customer",
+          "required": true
+        }
+      },
+      "description": "Delete a Customer",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "customers:delete",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "customers:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List your Customers",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "customers:list",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "customers:update": {
+      "aliases": [],
+      "args": {
+        "customer": {
+          "description": "ID of a customer",
+          "name": "customer",
+          "required": true
+        }
+      },
+      "description": "Update a Customer",
+      "examples": [
+        {
+          "description": "Apply multiple labels to a customer (note: previously set labels will be overwritten)",
+          "command": "<%= config.bin %> <%= command.id %> Q3VzdG9tZXI6MmUzZDllOTUtMWIyMy00N2FjLTk3MjUtMzU1OTA2YzgyZWZj --label \"Prod Customers\" --label \"Beta Testers\""
+        }
+      ],
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "name": {
+          "char": "n",
+          "description": "name of the customer",
+          "name": "name",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "description": {
+          "char": "d",
+          "description": "description of the customer",
+          "name": "description",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "externalId": {
+          "char": "e",
+          "description": "external ID of the customer from your system",
+          "name": "externalId",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "label": {
+          "char": "l",
+          "description": "a label to apply to the customer",
+          "name": "label",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "customers:update",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "instances:create": {
+      "aliases": [],
+      "args": {},
+      "description": "Create an Instance",
+      "examples": [
+        {
+          "description": "Get the ID of the integration you want to deploy:",
+          "command": "INTEGRATION_ID=$(prism integrations:list --columns id --no-header --filter 'name=Acme Inc')"
+        },
+        {
+          "description": "Get the version ID of the latest available published version:",
+          "command": "VERSION_ID=$(prism integrations:versions ${INTEGRATION_ID} --latest-available --columns id --no-header)"
+        },
+        {
+          "description": "Set up connection credentials (must be escaped):",
+          "command": "CREDENTIALS='[{\"name\":\"username\",\"type\":\"value\",\"value\":\"my.username\"},{\"name\":\"password\",\"type\":\"value\",\"value\":\"Pa$$W0Rd\"}]'"
+        },
+        {
+          "description": "Create an instance with config variables and labels:",
+          "command": "<%= config.bin %> <%= command.id %> --name 'Acme Inc' --description 'Acme Inc instance for Smith Rocket Co' --integration ${VERSION_ID} --customer ${CUSTOMER_ID} --config-vars '[{\"key\":\"My Endpoint\",\"value\":\"https://example.com/api\"},{\"key\":\"Do Thing?\",\"value\":\"true\"},{\"key\":\"Acme Basic Auth\",\"values\":\"${CREDENTIALS}\"}]' --label 'Production' --label 'Paid'"
+        }
+      ],
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "name": {
+          "char": "n",
+          "description": "name of your new instance.",
+          "name": "name",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "integration": {
+          "char": "i",
+          "description": "ID of the integration or a specific integration version ID this is an instance of",
+          "name": "integration",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "customer": {
+          "char": "c",
+          "description": "ID of customer to deploy to",
+          "name": "customer",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "description": {
+          "char": "d",
+          "description": "longer description of the instance",
+          "name": "description",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "config-vars": {
+          "char": "v",
+          "description": "config variables to bind to steps of your instance",
+          "name": "config-vars",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "label": {
+          "char": "l",
+          "description": "a label or set of labels to apply to the instance",
+          "name": "label",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "instances:create",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "instances:delete": {
+      "aliases": [],
+      "args": {
+        "instance": {
+          "description": "ID of the instance to delete",
+          "name": "instance",
+          "required": true
+        }
+      },
+      "description": "Delete an Instance",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "instances:delete",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "instances:deploy": {
+      "aliases": [],
+      "args": {
+        "instance": {
+          "description": "ID of an instance",
+          "name": "instance",
+          "required": true
+        }
+      },
+      "description": "Deploy an Instance",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "force": {
+          "char": "f",
+          "description": "Force deployment even when there are certain conditions that would normally prevent it",
+          "name": "force",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "instances:deploy",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "instances:disable": {
+      "aliases": [],
+      "args": {
+        "instance": {
+          "description": "ID of an instance",
+          "name": "instance",
+          "required": true
+        }
+      },
+      "description": "Disable an Instance",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "instances:disable",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "instances:enable": {
+      "aliases": [],
+      "args": {
+        "instance": {
+          "description": "ID of an instance",
+          "name": "instance",
+          "required": true
+        }
+      },
+      "description": "Enable an Instance",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "instances:enable",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "instances:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List Instances",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "customer": {
+          "char": "c",
+          "description": "ID of a customer",
+          "name": "customer",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "integration": {
+          "char": "i",
+          "description": "ID of an integration",
+          "name": "integration",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "instances:list",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "instances:update": {
+      "aliases": [],
+      "args": {
+        "instance": {
+          "description": "ID of an instance",
+          "name": "instance",
+          "required": true
+        }
+      },
+      "description": "Update an Instance",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "name": {
+          "char": "n",
+          "description": "Name of the instance",
+          "name": "name",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "description": {
+          "char": "d",
+          "description": "Description for the instance",
+          "name": "description",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "version": {
+          "char": "v",
+          "description": "ID of integration version",
+          "name": "version",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "deploy": {
+          "description": "Deploy the instance after updating",
+          "name": "deploy",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "label": {
+          "char": "l",
+          "description": "a label or set of labels to apply to the instance",
+          "name": "label",
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "instances:update",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "integrations:available": {
+      "aliases": [],
+      "args": {
+        "integration": {
+          "description": "ID of an integration version",
+          "name": "integration",
+          "required": true
+        }
+      },
+      "description": "Mark an Integration version as available or unavailable",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "available": {
+          "char": "a",
+          "description": "Version is available or unavailable",
+          "name": "available",
+          "required": true,
+          "allowNo": true,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "integrations:available",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "integrations:create": {
+      "aliases": [],
+      "args": {},
+      "description": "Create an Integration",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "name": {
+          "char": "n",
+          "description": "name of the integration to create",
+          "name": "name",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "description": {
+          "char": "d",
+          "description": "longer description of the integration",
+          "name": "description",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "customer": {
+          "char": "c",
+          "description": "ID of customer with which to associate the integration",
+          "name": "customer",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "integrations:create",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "integrations:delete": {
+      "aliases": [],
+      "args": {
+        "integration": {
+          "description": "ID of the integration to delete",
+          "name": "integration",
+          "required": true
+        }
+      },
+      "description": "Delete an Integration",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "integrations:delete",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "integrations:export": {
+      "aliases": [],
+      "args": {
+        "integration": {
+          "description": "ID of an integration to export",
+          "name": "integration",
+          "required": true
+        }
+      },
+      "description": "Export an integration to YAML definition",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "latest-components": {
+          "char": "l",
+          "description": "Use the latest available version of each Component upon import",
+          "name": "latest-components",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "version": {
+          "char": "v",
+          "description": "Define the definition version to export.",
+          "name": "version",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "integrations:export",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "integrations:fork": {
+      "aliases": [],
+      "args": {
+        "parent": {
+          "description": "ID of the Integration to fork",
+          "name": "parent",
+          "required": true
+        }
+      },
+      "description": "Fork an Integration",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "name": {
+          "char": "n",
+          "description": "name of the forked integration",
+          "name": "name",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "description": {
+          "char": "d",
+          "description": "longer description of the forked integration",
+          "name": "description",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "integrations:fork",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "integrations:import": {
+      "aliases": [],
+      "args": {},
+      "description": "Import an Integration using a YAML definition file or a Code Native Integration",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "path": {
+          "char": "p",
+          "description": "If supplied, the path to the YAML definition of the integration to import. Not applicable for Code Native Integrations.",
+          "name": "path",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "integrationId": {
+          "char": "i",
+          "description": "The ID of the integration being imported",
+          "name": "integrationId",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "icon-path": {
+          "description": "If supplied, the path to the PNG icon for the integration. Not applicable for Code Native Integrations.",
+          "name": "icon-path",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "open": {
+          "char": "o",
+          "description": "If supplied, open the Designer for the imported integration",
+          "name": "open",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "replace": {
+          "char": "r",
+          "description": "If supplied, allows replacing an existing integration regardless of code-native status. Requires integrationId.",
+          "name": "replace",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "test-api-key": {
+          "description": "Provide test API keys for flows in the format flowName=\"API_KEY\". Can be specified multiple times.",
+          "helpGroup": "GLOBAL",
+          "name": "test-api-key",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": true,
+          "type": "option"
+        },
+        "confirm": {
+          "description": "Interactively confirm the import when using --replace",
+          "name": "confirm",
+          "allowNo": true,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "integrations:import",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "integrations:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List Integrations",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "showAllVersions": {
+          "char": "a",
+          "description": "If specified this command returns all versions of all integrations rather than only the latest version",
+          "name": "showAllVersions",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "customer": {
+          "char": "c",
+          "description": "If specified this command returns only integrations that are available to the specified customer ID",
+          "name": "customer",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "org-only": {
+          "char": "o",
+          "description": "If specified this command returns only org integrations",
+          "name": "org-only",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "search": {
+          "char": "s",
+          "description": "If specified, search for integrations by name (case insensitive).",
+          "name": "search",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "integrations:list",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "integrations:marketplace": {
+      "aliases": [],
+      "args": {
+        "integration": {
+          "description": "ID of an integration version to make marketplace available",
+          "name": "integration",
+          "required": true
+        }
+      },
+      "description": "Make a version of an Integration available in the Marketplace",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "available": {
+          "char": "a",
+          "description": "Mark this Integration version available in the marketplace",
+          "name": "available",
+          "required": true,
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "deployable": {
+          "char": "d",
+          "description": "Mark this Integration version as deployable in the marketplace; does not apply if not also marked available",
+          "name": "deployable",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "allow-multiple-instances": {
+          "char": "m",
+          "description": "Allow a customer to deploy multiple instances of this integration",
+          "name": "allow-multiple-instances",
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "overview": {
+          "char": "o",
+          "description": "Overview to describe the purpose of the integration",
+          "name": "overview",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "integrations:marketplace",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "integrations:open": {
+      "aliases": [],
+      "args": {
+        "integrationId": {
+          "description": "ID of the integration to open",
+          "name": "integrationId",
+          "required": true
+        }
+      },
+      "description": "Open the Designer for the specified Integration",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "integrations:open",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "integrations:publish": {
+      "aliases": [],
+      "args": {
+        "integration": {
+          "description": "ID of an integration to publish",
+          "name": "integration",
+          "required": true
+        }
+      },
+      "description": "Publish a version of an Integration for use in Instances",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "comment": {
+          "char": "c",
+          "description": "comment about changes in this publication",
+          "name": "comment",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "commitHash": {
+          "description": "Commit hash corresponding to the integration version being published",
+          "name": "commitHash",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "commitUrl": {
+          "description": "URL to the commit details corresponding to this integration version",
+          "name": "commitUrl",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "repoUrl": {
+          "description": "URL to the repository containing the definition for this integration",
+          "name": "repoUrl",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "pullRequestUrl": {
+          "description": "URL to the pull request that modified this integration version",
+          "name": "pullRequestUrl",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "integrations:publish",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "integrations:set-debug": {
+      "aliases": [],
+      "args": {
+        "debug": {
+          "description": "Boolean value to set whether globalDebug should be enabled for the given integration",
+          "name": "debug",
+          "required": true
+        }
+      },
+      "description": "Set debug mode on or off for an integration's test instance.",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "integration-id": {
+          "char": "i",
+          "description": "ID of the integration containing the flow to test.",
+          "name": "integration-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "integrations:set-debug",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "integrations:update": {
+      "aliases": [],
+      "args": {
+        "integration": {
+          "description": "ID of an integration",
+          "name": "integration",
+          "required": true
+        }
+      },
+      "description": "Update an Integration's name or description",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "name": {
+          "char": "n",
+          "description": "new name to give the integration",
+          "name": "name",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "description": {
+          "char": "d",
+          "description": "new description to give the integration",
+          "name": "description",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "customer": {
+          "char": "c",
+          "description": "ID of customer with which to associate the integration",
+          "name": "customer",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "test-config-vars": {
+          "description": "JSON-formatted config variables to be used for testing",
+          "name": "test-config-vars",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "integrations:update",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "integrations:validate-yaml": {
+      "aliases": [],
+      "args": {
+        "path": {
+          "description": "Path to YAML file (use '-' for stdin)",
+          "name": "path",
+          "required": true
+        }
+      },
+      "description": "Validate a YAML integration definition without importing it",
+      "examples": [
+        {
+          "description": "Validate a YAML file",
+          "command": "<%= config.bin %> <%= command.id %> path/to/integration.yml"
+        },
+        {
+          "description": "Validate from stdin",
+          "command": "cat integration.yml | <%= config.bin %> <%= command.id %> -"
+        },
+        {
+          "description": "Validate from stdin (alternative)",
+          "command": "<%= config.bin %> <%= command.id %> - < integration.yml"
+        }
+      ],
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "integrations:validate-yaml",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "me": {
+      "aliases": [],
+      "args": {},
+      "description": "Print your user profile information",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "me",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "me:token": {
+      "aliases": [],
+      "args": {},
+      "description": "Print your authorization tokens",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "type": {
+          "char": "t",
+          "description": "Which token type to print",
+          "name": "type",
+          "default": "access",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "access",
+            "refresh"
+          ],
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "me:token",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "profiles:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List profiles",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "profiles:list",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "profiles:use": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "Profile to use by default",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Set the default profile",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "profiles:use",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "profiles:delete": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "Profile to delete",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Delete a profile",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "profiles:delete",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "on-prem-resources:delete": {
+      "aliases": [],
+      "args": {
+        "resource": {
+          "description": "ID of the On-Premise Resource to delete",
+          "name": "resource",
+          "required": true
+        }
+      },
+      "description": "Delete an On-Premise Resource",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "on-prem-resources:delete",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "on-prem-resources:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List On-Premise Resources",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "customer": {
+          "char": "c",
+          "description": "If specified this command returns only On-Premise Resources that are available to the specified customer ID",
+          "name": "customer",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "on-prem-resources:list",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "on-prem-resources:registration-jwt": {
+      "aliases": [],
+      "args": {},
+      "description": "Create a JWT that may be used to register an On-Premise Resource.",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "customerId": {
+          "char": "c",
+          "description": "The ID of the customer for which to create the JWT. Only valid for Organization users.",
+          "name": "customerId",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "orgOnly": {
+          "description": "Register a Resource available to Organization users only. Only valid for Organization users.",
+          "name": "orgOnly",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "resourceId": {
+          "char": "r",
+          "description": "An optional ID of an existing On-Premise Resource for which to generate a new JWT.",
+          "name": "resourceId",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "rotate": {
+          "description": "Invalidate all JWTs for the On-Premise Resource and get a new JWT.",
+          "name": "rotate",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "on-prem-resources:registration-jwt",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "organization:update": {
+      "aliases": [],
+      "args": {},
+      "description": "Update your Organization",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "name": {
+          "char": "n",
+          "description": "name of the organization",
+          "name": "name",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "organization:update",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "organization:updateAvatarUrl": {
+      "aliases": [],
+      "args": {},
+      "description": "Update your Organization Avatar URL",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "organizationId": {
+          "description": "ID of an organization",
+          "name": "organizationId",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "avatarUrl": {
+          "char": "n",
+          "description": "Url of the organization avatar",
+          "name": "avatarUrl",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "organization:updateAvatarUrl",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "translations:list": {
+      "aliases": [],
+      "args": {},
+      "description": "Generate Dynamic Phrases for Embedded Marketplace",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output-file": {
+          "char": "o",
+          "description": "Output the results of the action to a specified file",
+          "name": "output-file",
+          "required": false,
+          "default": "translations_output.json",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "translations:list",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "alerts:events:list": {
+      "aliases": [],
+      "args": {
+        "alertMonitorId": {
+          "description": "ID of an alert monitor",
+          "name": "alertMonitorId",
+          "required": true
+        }
+      },
+      "description": "List Alert Events for an Alert Monitor",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "alerts:events:list",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "alerts:groups:create": {
+      "aliases": [],
+      "args": {},
+      "description": "Create an Alert Group",
+      "examples": [
+        {
+          "description": "Create a group for 'DevOps':",
+          "command": "<%= config.bin %> <%= command.id %> --name DevOps --users \"[\\\"$(prism organization:users:list --columns id --filter 'Name=John Doe' --no-header)\\\"]\""
+        }
+      ],
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "name": {
+          "char": "n",
+          "description": "name of the group to be created",
+          "name": "name",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "users": {
+          "char": "u",
+          "description": "JSON-formatted list of Prismatic user IDs to alert",
+          "name": "users",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "webhooks": {
+          "char": "w",
+          "description": "JSON-formatted list of Alert Webhook IDs to alert",
+          "name": "webhooks",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "alerts:groups:create",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "alerts:groups:delete": {
+      "aliases": [],
+      "args": {
+        "group": {
+          "description": "ID of the group to delete",
+          "name": "group",
+          "required": true
+        }
+      },
+      "description": "Delete an Alert Group",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "alerts:groups:delete",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "alerts:groups:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List Alert Groups in your Organization",
+      "examples": [
+        {
+          "description": "Fetch the ID and Name of all alert groups in JSON format, sorted descending by name:",
+          "command": "<%= config.bin %> <%= command.id %> --columns \"id,name\" --output json --sort name"
+        }
+      ],
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "alerts:groups:list",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "alerts:monitors:clear": {
+      "aliases": [],
+      "args": {
+        "monitor": {
+          "description": "ID of the monitor to clear",
+          "name": "monitor",
+          "required": true
+        }
+      },
+      "description": "Clear an Alert Monitor",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "alerts:monitors:clear",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "alerts:monitors:create": {
+      "aliases": [],
+      "args": {},
+      "description": "Create an Alert Monitor by attaching an Alert Trigger and a set of users and webhooks to an Instance.\nWhile individual users and webhooks can be tied to alert monitors, it is recommended that you create alert groups and attach alert groups to alert monitors. This helps in the case that you need to add a user to a set of monitors: it's simpler to edit a single alert group than to edit dozens of alert monitors.",
+      "examples": [
+        {
+          "description": "Get the ID of an alert group named 'DevOps':",
+          "command": "ALERT_GROUP_ID=$(prism alerts:groups:list --columns id --filter 'name=^DevOps$' --no-header)"
+        },
+        {
+          "description": "Get the ID of an instance named 'My Instance':",
+          "command": "INSTANCE_ID=$(prism instances:list --columns id --filter 'name=^My Instance$' --no-header)"
+        },
+        {
+          "description": "Get the ID of an execution duration trigger:",
+          "command": "TRIGGER_ID=$(prism alerts:triggers:list --columns id --filter 'name=^Execution Duration Matched or Exceeded$' --no-header)"
+        },
+        {
+          "description": "Create an alert monitor that alerts the DevOps group when an instance execution takes longer than 10 seconds:",
+          "command": "<%= config.bin %> <%= command.id %> --name \"Alert Devops of slow execution\" --instance ${INSTANCE_ID} --triggers \"[\\\"${TRIGGER_ID}\\\"]\" --duration 10 --groups \"[\\\"${ALERT_GROUP_ID}\\\"]\""
+        }
+      ],
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "name": {
+          "char": "n",
+          "description": "name of the alert monitor to be created",
+          "name": "name",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "instance": {
+          "char": "i",
+          "description": "ID of the instance to monitor",
+          "name": "instance",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "triggers": {
+          "char": "t",
+          "description": "JSON-formatted list of trigger IDs that should trigger this monitor",
+          "name": "triggers",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "duration": {
+          "char": "d",
+          "description": "greatest time allowed (in seconds) for time-based triggers",
+          "name": "duration",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "log-severity": {
+          "char": "s",
+          "description": "greatest log level {debug, info, warn, error} allowed for log-based triggers",
+          "name": "log-severity",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "groups": {
+          "char": "g",
+          "description": "JSON-formatted list of group IDs to alert",
+          "name": "groups",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "users": {
+          "char": "u",
+          "description": "JSON-formatted list of Prismatic user IDs alert",
+          "name": "users",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "alerts:monitors:create",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "alerts:monitors:delete": {
+      "aliases": [],
+      "args": {
+        "monitor": {
+          "description": "ID of the monitor to delete",
+          "name": "monitor",
+          "required": true
+        }
+      },
+      "description": "Delete an Alert Monitor",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "alerts:monitors:delete",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "alerts:monitors:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List Alert Monitors for Customer Instances",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "alerts:monitors:list",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "alerts:triggers:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List Alert Triggers",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "alerts:triggers:list",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "alerts:webhooks:create": {
+      "aliases": [],
+      "args": {},
+      "description": "Create an Alert Webhook",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "name": {
+          "char": "n",
+          "description": "name of the webhook to be created",
+          "name": "name",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "url": {
+          "char": "u",
+          "description": "URL that will receive a POST request for an alert",
+          "name": "url",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "headers": {
+          "char": "h",
+          "description": "JSON-formatted object of key/value pairs to include in the request header",
+          "name": "headers",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "payloadTemplate": {
+          "char": "p",
+          "description": "template string that will be used as the request body, see documentation for details",
+          "name": "payloadTemplate",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "alerts:webhooks:create",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "alerts:webhooks:delete": {
+      "aliases": [],
+      "args": {
+        "webhook": {
+          "description": "ID of the webhook to delete",
+          "name": "webhook",
+          "required": true
+        }
+      },
+      "description": "Delete an Alert Webhook",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "alerts:webhooks:delete",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "alerts:webhooks:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List Alert Webhooks",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "alerts:webhooks:list",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "components:actions:list": {
+      "aliases": [],
+      "args": {
+        "componentKey": {
+          "description": "The key of the component to show actions for (e.g. 'salesforce')",
+          "name": "componentKey",
+          "required": true
+        }
+      },
+      "description": "List Actions that Components implement",
+      "examples": [
+        {
+          "description": "Get the ID of the GET action of the HTTP component by action key:",
+          "command": "<%= config.bin %> <%= command.id %> --columns id --filter 'key=^httpGet$' --no-header http"
+        },
+        {
+          "description": "Get actions related to the SFTP component:",
+          "command": "<%= config.bin %> <%= command.id %> sftp"
+        }
+      ],
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "public": {
+          "description": "Show actions for the public component with the given key. Use this flag when you have a private component with the same key as a public component.",
+          "name": "public",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "private": {
+          "description": "Show actions for the private component with the given key. Use this flag when you have a private component with the same key as a public component.",
+          "name": "private",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "components:actions:list",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "components:data-sources:list": {
+      "aliases": [],
+      "args": {
+        "componentKey": {
+          "description": "The key of the component to show data sources for (e.g. 'salesforce')",
+          "name": "componentKey",
+          "required": true
+        }
+      },
+      "description": "List Data Sources that Components implement",
+      "examples": [
+        {
+          "description": "Get data sources related to the Salesforce component:",
+          "command": "<%= config.bin %> <%= command.id %> salesforce"
+        }
+      ],
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "public": {
+          "description": "Show data sources for the public component with the given key. Use this flag when you have a private component with the same key as a public component.",
+          "name": "public",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "private": {
+          "description": "Show data sources for the private component with the given key. Use this flag when you have a private component with the same key as a public component.",
+          "name": "private",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "components:data-sources:list",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "components:dev:run": {
+      "aliases": [],
+      "args": {},
+      "description": "Fetch an integration's active connection and execute a CLI command with that connection's fields as an environment variable.\nAfter specifying an integration ID and connection config variable name, this command executes a CLI command with that connection's fields saved as a config variable named PRISMATIC_CONNECTION_VALUE.",
+      "examples": [
+        {
+          "description": "To simply print an integration's basic auth config variable named \"My Connection\" and pipe the resulting JSON to jq, run:",
+          "command": "<%= config.bin %> <%= command.id %> --integrationId SW50ZWexample --connectionKey \"My Connection\" -- printenv PRISMATIC_CONNECTION_VALUE | jq"
+        },
+        {
+          "description": "If one of your integrations has an authenticated OAuth 2.0 config variable \"Slack Connection\", you could run your component's unit tests with that environment variable:",
+          "command": "<%= config.bin %> <%= command.id %> -i SW50ZWexample -c \"Slack Connection\" -- yarn run test"
+        },
+        {
+          "description": "If you would like to fetch a connection from an instance deployed to one of your customers, specify the --instanceId flag instead",
+          "command": "<%= config.bin %> <%= command.id %> --instanceId SW50ZWexample -c \"Slack Connection\" -- yarn run test"
+        }
+      ],
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "integrationId": {
+          "char": "i",
+          "description": "Integration ID",
+          "name": "integrationId",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "instanceId": {
+          "description": "Instance ID. ",
+          "name": "instanceId",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "connectionKey": {
+          "char": "c",
+          "description": "Key of the connection config variable to fetch meta/state for",
+          "name": "connectionKey",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "components:dev:run",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": false,
+      "usage": "components:dev:run -i <value> -c <value> -- /command/to/run",
+      "enableJsonFlag": false,
+      "--": true
+    },
+    "components:dev:test": {
+      "aliases": [],
+      "args": {},
+      "description": "Run an action of a component within a test integration in the integration runner",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "envPath": {
+          "char": "e",
+          "description": "Path to dotenv file to load for supplying testing values",
+          "name": "envPath",
+          "required": false,
+          "default": ".env",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "build": {
+          "char": "b",
+          "description": "Build the component prior to testing",
+          "name": "build",
+          "required": false,
+          "allowNo": true,
+          "type": "boolean"
+        },
+        "output-file": {
+          "char": "o",
+          "description": "Output the results of the action to a specified file",
+          "name": "output-file",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "print-results": {
+          "description": "Print the results of the action to stdout",
+          "name": "print-results",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "clean-up": {
+          "description": "Clean up the integration and temporary component after running the action",
+          "name": "clean-up",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "components:dev:test",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "components:init:component": {
+      "aliases": [],
+      "args": {},
+      "description": "Initialize a new Component",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "name": {
+          "char": "n",
+          "description": "Name of the component",
+          "name": "name",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "description": {
+          "char": "d",
+          "description": "Description for the component",
+          "name": "description",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "toolchain": {
+          "hidden": true,
+          "name": "toolchain",
+          "default": "modern",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "modern",
+            "legacy"
+          ],
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hidden": true,
+      "hiddenAliases": [],
+      "id": "components:init:component",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "components:init": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "Name of the new component to create (alphanumeric characters, hyphens, and underscores)",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Initialize a new Component",
+      "examples": [
+        {
+          "description": "Initialize a new component directory for a component named 'send-customer-invoices':",
+          "command": "<%= config.bin %> <%= command.id %> send-customer-invoices"
+        },
+        {
+          "description": "Initialize a component from a WSDL definition file, then install dependencies, build, and publish it:",
+          "command": "<%= config.bin %> <%= command.id %> --wsdl-path ./example.wsdl \"Example WSDL\"\ncd \"Example WSDL\" && yarn install && yarn build\nprism components:publish"
+        }
+      ],
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "wsdl-path": {
+          "description": "Path to the WSDL definition file used to generate a Component",
+          "name": "wsdl-path",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "open-api-path": {
+          "description": "The path to an OpenAPI Specification file (JSON or YAML) used to generate a Component",
+          "name": "open-api-path",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "verbose": {
+          "description": "Output more verbose logging from Component generation",
+          "name": "verbose",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "toolchain": {
+          "description": "Toolchain to scaffold: 'modern' (tsdown + vitest + Biome) or 'legacy' (webpack + jest + eslint)",
+          "name": "toolchain",
+          "default": "modern",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "modern",
+            "legacy"
+          ],
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "components:init",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "components:signature": {
+      "aliases": [],
+      "args": {},
+      "description": "Generate a Component signature",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "skip-signature-verify": {
+          "description": "This consistently returns a signature, regardless of whether the corresponding component has been published to the platform or not.",
+          "name": "skip-signature-verify",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "components:signature",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "components:triggers:list": {
+      "aliases": [],
+      "args": {
+        "componentKey": {
+          "description": "The key of the component to show triggers for (e.g. 'salesforce')",
+          "name": "componentKey",
+          "required": true
+        }
+      },
+      "description": "List Triggers that Components implement",
+      "examples": [
+        {
+          "description": "Get the ID of the Webhook trigger of the Webhook Triggers component by key:",
+          "command": "<%= config.bin %> <%= command.id %> --columns id --filter 'key=^webhook$' --no-header webhook-triggers"
+        },
+        {
+          "description": "Get triggers related to the Management Triggers component:",
+          "command": "<%= config.bin %> <%= command.id %> management-triggers"
+        }
+      ],
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "public": {
+          "description": "Show actions for the public component with the given key. Use this flag when you have a private component with the same key as a public component.",
+          "name": "public",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "private": {
+          "description": "Show actions for the private component with the given key. Use this flag when you have a private component with the same key as a public component.",
+          "name": "private",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "components:triggers:list",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "customers:users:create": {
+      "aliases": [],
+      "args": {},
+      "description": "Create a User for the specified Customer",
+      "examples": [
+        {
+          "description": "Get the ID of a customer named 'My First Customer':",
+          "command": "CUSTOMER_ID=$(prism customers:list --columns id --no-header --filter 'name=^My First Customer$')"
+        },
+        {
+          "description": "Get the ID of the 'Member' role:",
+          "command": "ROLE_ID=$(prism customers:users:roles --columns id --no-header --filter 'name=^Member$')"
+        },
+        {
+          "description": "Add a new 'Member' user for the customer:",
+          "command": "<%= config.bin %> <%= command.id %> --email 'bar@email.com' --name 'Thomas Bar' --customer ${CUSTOMER_ID} --role ${ROLE_ID}"
+        }
+      ],
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "email": {
+          "char": "e",
+          "description": "email address",
+          "name": "email",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "role": {
+          "char": "r",
+          "description": "ID of the role to assign the user",
+          "name": "role",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "customer": {
+          "char": "c",
+          "description": "ID of the customer this user is associated with",
+          "name": "customer",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "name": {
+          "char": "n",
+          "description": "name of the new user",
+          "name": "name",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "customers:users:create",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "customers:users:delete": {
+      "aliases": [],
+      "args": {
+        "user": {
+          "description": "ID of the user to delete",
+          "name": "user",
+          "required": true
+        }
+      },
+      "description": "Delete a Customer User",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "customers:users:delete",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "customers:users:list": {
+      "aliases": [],
+      "args": {
+        "customer": {
+          "description": "ID of the customer",
+          "name": "customer",
+          "required": true
+        }
+      },
+      "description": "List Customer Users",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "customers:users:list",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "customers:users:roles": {
+      "aliases": [],
+      "args": {},
+      "description": "List Roles you can grant to Customer Users",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "customers:users:roles",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "customers:users:update": {
+      "aliases": [],
+      "args": {
+        "user": {
+          "description": "ID of a user",
+          "name": "user",
+          "required": true
+        }
+      },
+      "description": "Update a User",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "name": {
+          "char": "n",
+          "description": "name of the user",
+          "name": "name",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "phone": {
+          "char": "p",
+          "description": "phone number of the user",
+          "name": "phone",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dark-mode": {
+          "char": "d",
+          "description": "whether the user should have dark mode enabled",
+          "name": "dark-mode",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dark-mode-os-sync": {
+          "char": "o",
+          "description": "whether dark mode should sync with OS settings",
+          "name": "dark-mode-os-sync",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "customers:users:update",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "executions:step-result:get": {
+      "aliases": [],
+      "args": {},
+      "description": "Gets the Result of a specified Step in an Instance Execution.\nThis command can be used to pull down step results for both integration tests and instance executions.",
+      "examples": [
+        {
+          "description": "Run a test of a flow to get an execution ID:",
+          "command": "prism integrations:flows:test ${FLOW_ID}"
+        },
+        {
+          "description": "Get step results from a specific execution:",
+          "command": "<%= config.bin %> <%= command.id %> --executionId SW5zdGFuY2VFeGVjdXRpb25SZXN1bHQ6MWFkZTYwMGQtMjg2Ni00ZTljLWI2N2EtYmUxNzgwOWY4ODI4 --stepName \"Fetch Invoice Info\""
+        }
+      ],
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "executionId": {
+          "char": "e",
+          "description": "ID of an Execution",
+          "name": "executionId",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "stepName": {
+          "char": "s",
+          "description": "Name of an Integration Step",
+          "name": "stepName",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "outputPath": {
+          "char": "p",
+          "description": "Output result to a file. Output will be printed to stdout if this is omitted",
+          "name": "outputPath",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "executions:step-result:get",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "instances:config-vars:list": {
+      "aliases": [],
+      "args": {
+        "instance": {
+          "description": "ID of an instance",
+          "name": "instance",
+          "required": true
+        }
+      },
+      "description": "List Config Variables used on an Instance",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "instances:config-vars:list",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "instances:flow-configs:list": {
+      "aliases": [],
+      "args": {
+        "instance": {
+          "description": "ID of an Instance",
+          "name": "instance",
+          "required": true
+        }
+      },
+      "description": "List Instance Flow Configs",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "instances:flow-configs:list",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "instances:flow-configs:test": {
+      "aliases": [],
+      "args": {
+        "flowConfig": {
+          "description": "ID of a Flow Config to test",
+          "name": "flowConfig",
+          "required": true
+        }
+      },
+      "description": "Test a Flow Config of an Instance",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "tail": {
+          "char": "t",
+          "description": "Tail logs of the flow config test run",
+          "name": "tail",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "payload": {
+          "char": "p",
+          "description": "Optional JSON-formatted data payload to submit with the test",
+          "name": "payload",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "contentType": {
+          "char": "c",
+          "description": "Optional content-type for the test payload",
+          "name": "contentType",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "instances:flow-configs:test",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "integrations:convert": {
+      "aliases": [],
+      "args": {
+        "integration": {
+          "description": "ID of the low-code integration to convert",
+          "name": "integration",
+          "required": true
+        }
+      },
+      "description": "Convert a Low-Code Integration's YAML file into a Code Native Integration",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "registryPrefix": {
+          "char": "r",
+          "description": "The registry prefix to use for the converted integration",
+          "name": "registryPrefix",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "registryUrl": {
+          "char": "u",
+          "description": "The registry URL to use for the converted integration",
+          "name": "registryUrl",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "includeComments": {
+          "char": "c",
+          "description": "Whether to include inline comments in the generated code",
+          "name": "includeComments",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "integrations:convert",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "integrations:flows:list": {
+      "aliases": [],
+      "args": {
+        "integration": {
+          "description": "ID of an Integration",
+          "name": "integration",
+          "required": true
+        }
+      },
+      "description": "List Integration Flows",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "integrations:flows:list",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "integrations:flows:listen": {
+      "aliases": [],
+      "args": {},
+      "description": "Listen for webhook executions on a flow and save the payload to a file",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "integration-id": {
+          "char": "i",
+          "description": "ID of the integration containing the flow to listen to.",
+          "name": "integration-id",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "flow-id": {
+          "char": "f",
+          "description": "ID of the flow to listen to. If not provided, you will be prompted to select.",
+          "exclusive": [
+            "flow-name"
+          ],
+          "name": "flow-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "flow-name": {
+          "char": "n",
+          "description": "Name of the flow to listen to.",
+          "exclusive": [
+            "flow-id"
+          ],
+          "name": "flow-name",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output": {
+          "char": "o",
+          "description": "Output directory for the payload file. Defaults to ./payloads",
+          "name": "output",
+          "default": "./payloads",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "timeout": {
+          "char": "t",
+          "description": "Timeout in seconds to stop listening.",
+          "name": "timeout",
+          "default": 1200,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-prompt": {
+          "char": "n",
+          "description": "For flows using polling triggers, automatically poll without a confirmation prompt.",
+          "name": "no-prompt",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "reset": {
+          "char": "r",
+          "description": "Manually turn off listening mode for a given integration.",
+          "name": "reset",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "integrations:flows:listen",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "integrations:flows:test": {
+      "aliases": [],
+      "args": {},
+      "description": "Run a test execution of a flow",
+      "examples": [
+        {
+          "description": "Test an integration flow with a payload file and tail the logs and step results:",
+          "command": "<%= config.bin %> <%= command.id %> -p=some_payload_file.xml -c=application/xml --tail-logs --tail-results"
+        }
+      ],
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "flow-id": {
+          "char": "f",
+          "description": "ID of the flow to test. Base64 encoded.",
+          "exclusive": [
+            "flow-url",
+            "flow-name"
+          ],
+          "name": "flow-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "flow-name": {
+          "char": "n",
+          "description": "Name of the flow to test.",
+          "exclusive": [
+            "flow-url",
+            "flow-id"
+          ],
+          "name": "flow-name",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "flow-url": {
+          "char": "u",
+          "description": "URL of the flow to test. Prefer to use flow-id instead, if possible.",
+          "exclusive": [
+            "flow-id"
+          ],
+          "name": "flow-url",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "integration-id": {
+          "char": "i",
+          "description": "ID of the integration containing the flow to test. Base64 encoded.",
+          "name": "integration-id",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "payload": {
+          "char": "p",
+          "description": "Optional file containing a payload to run the flow with.",
+          "name": "payload",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "payload-content-type": {
+          "char": "c",
+          "description": "Optional Content-Type for the test payload.",
+          "name": "payload-content-type",
+          "default": "application/json",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "sync": {
+          "description": "Forces the flow to run synchronously.",
+          "name": "sync",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "tail-results": {
+          "description": "Tail step results from the test execution until user interrupt or timeout.",
+          "name": "tail-results",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "tail-logs": {
+          "description": "Tail logs from the test execution until user interrupt or timeout.",
+          "name": "tail-logs",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "cni-auto-end": {
+          "description": "Automatically stop polling activity once an CNI flow execution completes. Some logs & results may not be returned this way. DOES NOT WORK FOR LOW-CODE FLOWS.",
+          "name": "cni-auto-end",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "timeout": {
+          "description": "Optionally set a timeout (in seconds) to stop tail activity. Compatible with both low-code and CNI flows.",
+          "name": "timeout",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "result-file": {
+          "char": "r",
+          "description": "Optional file to append tailed execution result data to. Results are saved into JSON Lines.",
+          "name": "result-file",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "jsonl": {
+          "description": "Optionally format the step and tail results output into JSON Lines.",
+          "name": "jsonl",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "debug": {
+          "description": "Enables debug mode on the test execution.",
+          "name": "debug",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "apiKey": {
+          "description": "Optional API key for flows with secured endpoints.",
+          "name": "apiKey",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "integrations:flows:test",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "integrations:init": {
+      "aliases": [],
+      "args": {
+        "name": {
+          "description": "Name of the new integration to create (alphanumeric characters, hyphens, and underscores)",
+          "name": "name",
+          "required": true
+        }
+      },
+      "description": "Initialize a new Code Native Integration",
+      "examples": [
+        {
+          "description": "Initialize a new directory for a Code Native Integration:",
+          "command": "<%= config.bin %> <%= command.id %> acme-integration"
+        },
+        {
+          "description": "Install dependencies:",
+          "command": "npm install"
+        },
+        {
+          "description": "Build the integration:",
+          "command": "npm run build"
+        },
+        {
+          "description": "Import the integration into Prismatic:",
+          "command": "prism integrations:import"
+        }
+      ],
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "clean": {
+          "description": "Generate clean scaffold without example code",
+          "name": "clean",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "toolchain": {
+          "description": "Toolchain to scaffold: 'modern' (tsdown + vitest + Biome) or 'legacy' (webpack + jest + eslint)",
+          "name": "toolchain",
+          "default": "modern",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "modern",
+            "legacy"
+          ],
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "integrations:init",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "integrations:versions": {
+      "aliases": [],
+      "args": {
+        "integration": {
+          "description": "ID of an integration",
+          "name": "integration",
+          "required": true
+        }
+      },
+      "description": "List Integration versions",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "latest-available": {
+          "char": "l",
+          "description": "Show only the latest available version",
+          "name": "latest-available",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "integrations:versions",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "logs:severities:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List Log Severities for use by Alert Triggers",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "logs:severities:list",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "me:token:revoke": {
+      "aliases": [],
+      "args": {},
+      "description": "Revoke all refresh tokens for your user",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "confirm": {
+          "description": "Prompt for confirmation before revoking tokens. Use --no-confirm to skip.",
+          "name": "confirm",
+          "allowNo": true,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "me:token:revoke",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "organization:connections:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List all integration-agnostic connections available to the organization",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "managed-by": {
+          "description": "Filter connections by management type",
+          "name": "managed-by",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "org",
+            "customer"
+          ],
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "organization:connections:list",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "organization:signing-keys:delete": {
+      "aliases": [],
+      "args": {
+        "signingKeyId": {
+          "description": "ID of the signing key to delete",
+          "name": "signingKeyId",
+          "required": true
+        }
+      },
+      "description": "Delete an embedded marketplace signing key",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "organization:signing-keys:delete",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "organization:signing-keys:generate": {
+      "aliases": [],
+      "args": {},
+      "description": "Generate an embedded marketplace signing key.\nThe RSA public key is saved in Prismatic, and the private key is returned and immediately removed from Prismatic. Once the private key is returned, it cannot be retrieved again.",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "organization:signing-keys:generate",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "organization:signing-keys:import": {
+      "aliases": [],
+      "args": {},
+      "description": "Import a RSA public key for use with embedded marketplace.\nYou can use openssl to generate a new RSA key pair and import the public key.",
+      "examples": [
+        {
+          "description": "Generate an RSA private key using openssl:",
+          "command": "openssl genrsa -out my-private-key.pem 4096"
+        },
+        {
+          "description": "Generate the associated RSA public key:",
+          "command": "openssl rsa -in my-private-key.pem -pubout > my-public-key.pub"
+        },
+        {
+          "description": "Import the public key:",
+          "command": "<%= config.bin %> <%= command.id %> -p my-public-key.pub"
+        }
+      ],
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "public-key-file": {
+          "char": "p",
+          "description": "public key file",
+          "name": "public-key-file",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "organization:signing-keys:import",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "organization:signing-keys:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List embedded signing keys for embedded marketplace",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "organization:signing-keys:list",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "organization:users:create": {
+      "aliases": [],
+      "args": {},
+      "description": "Create a User for your Organization",
+      "examples": [
+        {
+          "description": "Get the ID of the 'Integrator' role:",
+          "command": "ROLE_ID=$(prism organization:users:roles --columns id --no-header --filter 'name=^Integrator$')"
+        },
+        {
+          "description": "Create an organization user and assign the role:",
+          "command": "<%= config.bin %> <%= command.id %> --email 'foo@email.com' --name 'Susan Foo' --role ${ROLE_ID}"
+        }
+      ],
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "name": {
+          "char": "n",
+          "description": "name of the user",
+          "name": "name",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "email": {
+          "char": "e",
+          "description": "email address of the user",
+          "name": "email",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "role": {
+          "char": "r",
+          "description": "role the user should assume",
+          "name": "role",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "organization:users:create",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "organization:users:delete": {
+      "aliases": [],
+      "args": {
+        "user": {
+          "description": "ID of the user to delete",
+          "name": "user",
+          "required": true
+        }
+      },
+      "description": "Delete an Organization User",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "organization:users:delete",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "organization:users:list": {
+      "aliases": [],
+      "args": {},
+      "description": "List Users of your Organization",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "organization:users:list",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "organization:users:roles": {
+      "aliases": [],
+      "args": {},
+      "description": "List Roles you can grant to other users in your Organization",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "columns": {
+          "description": "only show provided columns (comma-separated)",
+          "exclusive": [
+            "extended"
+          ],
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "csv": {
+          "description": "output is csv format [alias: --output=csv]",
+          "exclusive": [
+            "no-truncate"
+          ],
+          "name": "csv",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "extended": {
+          "char": "x",
+          "description": "show extra columns",
+          "exclusive": [
+            "columns"
+          ],
+          "name": "extended",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "filter": {
+          "description": "filter property by regex, ex: name=^foo (prefix key with - to invert)",
+          "name": "filter",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "no-header": {
+          "description": "hide table header from output",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-header",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "no-truncate": {
+          "description": "do not truncate output to fit screen",
+          "exclusive": [
+            "csv"
+          ],
+          "name": "no-truncate",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "output": {
+          "description": "output in a more machine friendly format",
+          "exclusive": [
+            "no-truncate",
+            "csv"
+          ],
+          "name": "output",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "csv",
+            "json",
+            "yaml"
+          ],
+          "type": "option"
+        },
+        "sort": {
+          "description": "property to sort by, comma-separated for multi-key (prepend '-' for descending)",
+          "name": "sort",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "organization:users:roles",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "organization:users:update": {
+      "aliases": [],
+      "args": {
+        "user": {
+          "description": "ID of a user",
+          "name": "user",
+          "required": true
+        }
+      },
+      "description": "Update a User",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "name": {
+          "char": "n",
+          "description": "name of the user",
+          "name": "name",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "phone": {
+          "char": "p",
+          "description": "phone number of the user",
+          "name": "phone",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dark-mode": {
+          "char": "d",
+          "description": "whether the user should have dark mode enabled",
+          "name": "dark-mode",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "dark-mode-os-sync": {
+          "char": "o",
+          "description": "whether dark mode should sync with OS settings",
+          "name": "dark-mode-os-sync",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "organization:users:update",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "workflows:export": {
+      "aliases": [],
+      "args": {
+        "workflow": {
+          "description": "ID of the workflow to export",
+          "name": "workflow",
+          "required": true
+        }
+      },
+      "description": "Export an embedded workflow or workflow template YAML definition",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "latest-components": {
+          "char": "l",
+          "description": "Use the latest available version of each component upon import. Defaults to true.",
+          "name": "latest-components",
+          "allowNo": true,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "workflows:export",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "workflows:import": {
+      "aliases": [],
+      "args": {},
+      "description": "Import an embedded workflow or workflow template YAML definition",
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "path": {
+          "char": "p",
+          "description": "The path to the YAML definition of the workflow to import",
+          "name": "path",
+          "required": true,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "workflow": {
+          "char": "w",
+          "description": "The ID of the workflow being imported. If omitted, a new workflow will be created.",
+          "name": "workflow",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "customer": {
+          "char": "c",
+          "description": "The ID of the customer to associate with the imported workflow. This will overwrite the existing workflow. If omitted, the workflow will be imported as a template.",
+          "name": "customer",
+          "required": false,
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "workflows:import",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    },
+    "graphql:query": {
+      "aliases": [],
+      "args": {
+        "query": {
+          "description": "GraphQL query string (omit to read from stdin)",
+          "name": "query",
+          "required": false
+        }
+      },
+      "description": "Execute an arbitrary GraphQL query against the Prismatic API",
+      "examples": [
+        {
+          "description": "Direct query string",
+          "command": "<%= config.bin %> <%= command.id %> 'query { customers { nodes { id name } } }'"
+        },
+        {
+          "description": "From file",
+          "command": "<%= config.bin %> <%= command.id %> --file query.graphql"
+        },
+        {
+          "description": "From stdin",
+          "command": "cat query.graphql | <%= config.bin %> <%= command.id %>"
+        },
+        {
+          "description": "With variables",
+          "command": "<%= config.bin %> <%= command.id %> --file query.graphql --variables '{\"id\":\"Q3VzdG9tZXI6...\"}'"
+        },
+        {
+          "description": "Variables from file",
+          "command": "<%= config.bin %> <%= command.id %> 'query($id: ID!) { customer(id: $id) { name } }' --variables @vars.json"
+        },
+        {
+          "description": "YAML output",
+          "command": "<%= config.bin %> <%= command.id %> 'query { customers { nodes { id name } } }' --output yaml"
+        },
+        {
+          "description": "Table output with nested data",
+          "command": "<%= config.bin %> <%= command.id %> 'query { customers { nodes { id name } } }' --output table --data-path customers.nodes --columns id,name"
+        }
+      ],
+      "flags": {
+        "print-requests": {
+          "description": "Print all GraphQL requests that are issued",
+          "helpGroup": "GLOBAL",
+          "name": "print-requests",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "quiet": {
+          "description": "Reduce helpful notes and text",
+          "helpGroup": "GLOBAL",
+          "name": "quiet",
+          "required": false,
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "profile": {
+          "description": "Use a profile",
+          "env": "PRISM_PROFILE",
+          "helpGroup": "GLOBAL",
+          "name": "profile",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "file": {
+          "char": "f",
+          "description": "Treat query argument as file path",
+          "name": "file",
+          "allowNo": false,
+          "type": "boolean"
+        },
+        "variables": {
+          "char": "v",
+          "description": "JSON string or @file.json containing query variables",
+          "name": "variables",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "output": {
+          "char": "o",
+          "description": "Output format",
+          "name": "output",
+          "default": "json",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "options": [
+            "json",
+            "yaml",
+            "table"
+          ],
+          "type": "option"
+        },
+        "columns": {
+          "char": "c",
+          "description": "Comma-separated field paths for table columns (required for table output)",
+          "name": "columns",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "data-path": {
+          "char": "d",
+          "description": "Dot-notation path to array data in result (e.g., 'customers.nodes')",
+          "name": "data-path",
+          "hasDynamicHelp": false,
+          "multiple": false,
+          "type": "option"
+        },
+        "raw": {
+          "char": "r",
+          "description": "Output raw JSON without pretty-printing",
+          "name": "raw",
+          "allowNo": false,
+          "type": "boolean"
+        }
+      },
+      "hasDynamicHelp": false,
+      "hiddenAliases": [],
+      "id": "graphql:query",
+      "pluginAlias": "@prismatic-io/prism",
+      "pluginName": "@prismatic-io/prism",
+      "pluginType": "core",
+      "strict": true,
+      "enableJsonFlag": false
+    }
+  },
+  "version": "10.2.0"
+}


### PR DESCRIPTION
Mount native incur commands and migrate profiles.

Part **9/24** of the native incur migration. This PR targets `incur-08-subprocess-streams`; the stack integrates into the long-lived `agent` branch. Review this diff against its immediate base.

Validation: format/lint, TypeScript, bundle, and **349 passing tests** (3 skipped) on Node 24. CI also checks Node 22/24/26 and Windows.

Review size: **995 handwritten changed lines**, plus 7,482 generated or captured artifact lines (marked for GitHub collapsing); counts include additions and deletions.

The temporary migration bridge keeps unmigrated commands on oclif and delegates migrated commands to incur. It is removed by the native-cutover PR. Contract coverage grows with each migrated command family.

[Stack review guide](https://github.com/prismatic-io/prism/blob/incur-24-review-evidence/docs/incur-pr-stack.md). Merge bottom-up; rebase descendants after a squash merge.
