### PR TITLE
[incur 10/24] Migrate login and identity commands to native incur schemas

### DIFF
--- a/src/commands/login/index.test.ts
+++ b/src/commands/login/index.test.ts
@@ -1,0 +1,84 @@
+import { Cli } from "incur";
+import { beforeEach, expect, it, vi } from "vitest";
+import { isLoggedIn, login } from "../../auth.js";
+import {
+  commandMiddleware,
+  commandVars,
+  environmentOptions,
+  globalOptions,
+  runWithMcpTransport,
+} from "../../command.js";
+import LoginCommand from "./index.js";
+
+vi.mock("../../auth.js", () => ({ isLoggedIn: vi.fn(), login: vi.fn() }));
+vi.mock("../../config.js", () => ({ getActiveProfileName: vi.fn(async () => "default") }));
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(isLoggedIn).mockResolvedValue(false);
+});
+const native = () =>
+  Cli.create("prism", { globals: globalOptions, vars: commandVars, env: environmentOptions })
+    .use(commandMiddleware)
+    .command("login", LoginCommand);
+const run = async (args: string[]) => {
+  const output: string[] = [];
+  await native().serve(["login", "--yes", ...args], {
+    stdout: (chunk) => output.push(chunk),
+    exit: () => {},
+  });
+  return output.join("");
+};
+it("rejects buffered authentication before opening the callback listener", async () => {
+  expect(await run(["--json"])).toContain("AUTHENTICATION_REQUIRED");
+  expect(login).not.toHaveBeenCalled();
+});
+it("rejects unauthenticated MCP login before opening the callback listener", async () => {
+  expect(await runWithMcpTransport(() => run(["--format", "jsonl"]))).toContain(
+    "AUTHENTICATION_REQUIRED",
+  );
+  expect(login).not.toHaveBeenCalled();
+});
+it("allows already-authenticated profiles in buffered mode", async () => {
+  vi.mocked(isLoggedIn).mockResolvedValue(true);
+  expect(await run(["--json"])).toContain('"alreadyAuthenticated": true');
+  expect(login).not.toHaveBeenCalled();
+});
+it("emits the native challenge before authentication completes", async () => {
+  let finish!: () => void;
+  let challengeSeen!: () => void;
+  const seen = new Promise<void>((resolve) => {
+    challengeSeen = resolve;
+  });
+  const output: string[] = [];
+  vi.mocked(login).mockImplementation(async (options) => {
+    options?.onChallenge?.("https://auth.example.com/challenge");
+    await new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+  });
+  const serving = native().serve(["login", "--yes", "--format", "jsonl"], {
+    stdout(chunk) {
+      output.push(chunk);
+      if (chunk.includes("authentication-challenge")) challengeSeen();
+    },
+    exit: () => {},
+  });
+  await seen;
+  expect(output.join("")).not.toContain('"type":"authenticated"');
+  finish();
+  await serving;
+  const chunks = output.flatMap((text) =>
+    text
+      .trim()
+      .split("\n")
+      .map((line) => JSON.parse(line)),
+  );
+  expect(chunks.filter((value) => value.type === "chunk").map((value) => value.data)).toEqual([
+    {
+      type: "authentication-challenge",
+      profile: "default",
+      url: "https://auth.example.com/challenge",
+    },
+    { type: "authenticated", profile: "default", alreadyAuthenticated: false },
+  ]);
+});

--- a/src/commands/login/index.ts
+++ b/src/commands/login/index.ts
@@ -1,44 +1,84 @@
-import { Flags } from "@oclif/core";
+import { Errors, z } from "incur";
 import { isLoggedIn, login } from "../../auth.js";
-import { PrismaticBaseCommand } from "../../baseCommand.js";
+import { defineCommand, isCommandTransportExecution, optionsSchema } from "../../command.js";
 import { getActiveProfileName } from "../../config.js";
-import { ux } from "../../utils/legacy-ux.js";
 
-export default class LoginCommand extends PrismaticBaseCommand {
-  static description = "Log in to your Prismatic account";
-
-  static flags = {
-    force: Flags.boolean({
-      char: "f",
-      default: false,
-      description: "re-authenticate, even if you are already logged in",
+export const loginEventSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("authentication-challenge"), profile: z.string(), url: z.string() }),
+  z.object({
+    type: z.literal("authenticated"),
+    profile: z.string(),
+    alreadyAuthenticated: z.boolean(),
+  }),
+]);
+export default defineCommand({
+  mutates: true,
+  output: loginEventSchema,
+  description: "Log in to your Prismatic account",
+  options: optionsSchema(
+    z.object({
+      force: z
+        .boolean()
+        .default(false)
+        .describe("re-authenticate, even if you are already logged in")
+        .meta({ cli: { char: "f" } }),
+      url: z
+        .boolean()
+        .default(false)
+        .describe("returns a challenge url without automatically opening a browser")
+        .meta({ cli: { char: "u" } }),
+      "tenant-id": z
+        .string()
+        .optional()
+        .describe("Select this tenant without prompting after authentication"),
     }),
-    url: Flags.boolean({
-      char: "u",
-      default: false,
-      description: "returns a challenge url without automatically opening a browser",
-    }),
-  };
-
-  protected authContext = "profile" as const;
-
-  async run() {
-    const {
-      flags: { force, url },
-    } = await this.parse(LoginCommand);
-
-    const profileName = await getActiveProfileName();
-
+  ),
+  authContext: "profile" as const,
+  async *run(context): AsyncGenerator<z.infer<typeof loginEventSchema>> {
+    const { force, url, "tenant-id": tenantId } = context.options;
+    const profile = await getActiveProfileName();
     if (!force && (await isLoggedIn())) {
-      this.log(`Already logged in to '${profileName}'.`);
+      yield { type: "authenticated", profile, alreadyAuthenticated: true };
       return;
     }
-
-    if (!url) {
-      await ux.anykey("Press any key to open prismatic.io in your default browser");
+    if (
+      context.agent &&
+      (isCommandTransportExecution() || (context.formatExplicit && context.format !== "jsonl"))
+    ) {
+      throw new Errors.IncurError({
+        code: "AUTHENTICATION_REQUIRED",
+        exitCode: 2,
+        message:
+          "Authentication requires a browser challenge. Run prism login --url in a terminal, or prism login --agent --yes --format jsonl to receive the challenge immediately. Then retry with the authenticated profile.",
+      });
     }
-
-    await login({ url, profileName });
-    this.log(`Logged in to '${profileName}'.`);
-  }
-}
+    const abort = new AbortController();
+    const signal = context.var.signal
+      ? AbortSignal.any([context.var.signal, abort.signal])
+      : abort.signal;
+    let showChallenge!: (url: string) => void;
+    const challenge = new Promise<string>((resolve) => {
+      showChallenge = resolve;
+    });
+    const authentication = login({
+      nonInteractive: context.agent,
+      url: url || context.agent,
+      profileName: profile,
+      tenantId,
+      signal,
+      onChallenge: showChallenge,
+    });
+    try {
+      const first = await Promise.race([
+        challenge.then((url) => ({ url })),
+        authentication.then(() => ({ url: undefined })),
+      ]);
+      if (first.url) yield { type: "authentication-challenge", profile, url: first.url };
+      await authentication;
+      yield { type: "authenticated", profile, alreadyAuthenticated: false };
+    } finally {
+      abort.abort();
+      await authentication.catch(() => {});
+    }
+  },
+});

--- a/src/commands/login/switch.ts
+++ b/src/commands/login/switch.ts
@@ -1,21 +1,34 @@
+import { commandOutput, defineCommand, optionsSchema } from "../../command.js";
 import { fetchUserTenants, isLoggedIn, refresh, selectTenant } from "../../auth.js";
-import { PrismaticBaseCommand } from "../../baseCommand.js";
 import { getActiveProfileName, readProfile, writeActiveProfile } from "../../config.js";
 import { whoAmI } from "../../utils/user/query.js";
+import { z } from "incur";
 
-export default class LoginSwitchCommand extends PrismaticBaseCommand {
-  static description = "Switch between organization tenants";
-
-  protected authContext = "profile" as const;
-
-  async run() {
-    await this.parse(LoginSwitchCommand);
-    const profileName = this.profileName ?? (await getActiveProfileName());
+export default defineCommand({
+  output: z.object({
+    profile: z.string(),
+    tenantId: z.string().optional(),
+    switched: z.boolean(),
+    authenticated: z.boolean(),
+  }),
+  mutates: true,
+  description: "Switch between organization tenants",
+  authContext: "profile" as const,
+  options: optionsSchema(
+    z.object({
+      "tenant-id": z.string().optional().describe("Tenant ID to select without prompting"),
+    }),
+  ),
+  async run(context) {
+    const {
+      options: { "tenant-id": tenantId },
+    } = context;
+    const profileName = context.globals.profile ?? (await getActiveProfileName());
     const config = await readProfile(profileName);
     const loggedIn = (await isLoggedIn()) && config;
     if (!loggedIn) {
-      this.log("Not logged in. Run 'prism login'.");
-      return;
+      commandOutput.log("Not logged in. Run 'prism login'.");
+      return { profile: profileName, switched: false, authenticated: false };
     }
 
     const tenants = await fetchUserTenants();
@@ -35,18 +48,39 @@ export default class LoginSwitchCommand extends PrismaticBaseCommand {
         activeTenants.length === 1
           ? "This is the only tenant available to this profile."
           : "No tenants are available to this profile.";
-      this.log(message);
-      return;
+      commandOutput.log(message);
+      return {
+        profile: profileName,
+        tenantId: currentTenantId,
+        switched: false,
+        authenticated: true,
+      };
     }
 
     if (!currentTenantSuspended && currentTenant) {
-      this.log(`Current tenant: ${currentTenant.orgName} (${currentTenant.url})\n`);
+      commandOutput.log(`Current tenant: ${currentTenant.orgName} (${currentTenant.url})\n`);
     }
 
-    const selectedTenantId = await selectTenant(tenants, {
-      currentTenantId,
-      message: "Select a tenant to switch to:",
-    });
+    const requestedTenant = tenantId
+      ? activeTenants.find((tenant) => tenant.tenantId === tenantId)
+      : undefined;
+    if (tenantId && !requestedTenant) {
+      commandOutput.error(`Tenant '${tenantId}' is not available to this profile.`, { exit: 2 });
+    }
+    if (context.agent && !requestedTenant) {
+      commandOutput.error(
+        "Agent mode requires --tenant-id when more than one tenant is available.",
+        {
+          exit: 2,
+        },
+      );
+    }
+    const selectedTenantId =
+      requestedTenant?.tenantId ??
+      (await selectTenant(tenants, {
+        currentTenantId,
+        message: "Select a tenant to switch to:",
+      }));
 
     if (!selectedTenantId || selectedTenantId === currentTenantId) {
       if (currentTenantId && !currentTenantSuspended) {
@@ -57,15 +91,26 @@ export default class LoginSwitchCommand extends PrismaticBaseCommand {
           },
           profileName,
         );
-        this.log(`Active tenant: ${currentTenant?.orgName} (${currentTenant?.url})`);
+        commandOutput.log(`Active tenant: ${currentTenant?.orgName} (${currentTenant?.url})`);
       }
-      return;
+      return {
+        profile: profileName,
+        tenantId: currentTenantId,
+        switched: false,
+        authenticated: true,
+      };
     }
 
-    this.log("\nSwitching tenant...");
+    commandOutput.log("\nSwitching tenant...");
     await refresh(config.refreshToken, selectedTenantId, profileName);
 
     const selectedTenant = tenants.find((t) => t.tenantId === selectedTenantId);
-    this.log(`Switched to: ${selectedTenant?.orgName} (${selectedTenant?.url})`);
-  }
-}
+    commandOutput.log(`Switched to: ${selectedTenant?.orgName} (${selectedTenant?.url})`);
+    return {
+      profile: profileName,
+      tenantId: selectedTenantId,
+      switched: true,
+      authenticated: true,
+    };
+  },
+});

--- a/src/commands/logout.test.ts
+++ b/src/commands/logout.test.ts
@@ -1,9 +1,11 @@
+import { runCommand } from "../test-command.js";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { logout } from "../auth.js";
 import { type Profile, readConfigFile, selectProfile, writeProfile } from "../config.js";
+import { getStderr } from "../../vitest.setup.js";
 import LogoutCommand from "./logout.js";
 
 const profile: Profile = {
@@ -41,7 +43,12 @@ describe("logout", () => {
     await writeProfile("default", profile);
     await writeProfile("staging", { ...profile, prismaticUrl: "https://staging.example.io" });
 
-    await LogoutCommand.run(["--browser"]);
+    const result = await runCommand(LogoutCommand, ["--browser"]);
+    expect(result).toEqual({
+      profile: "default",
+      loggedOut: true,
+      environmentCredentialsActive: false,
+    });
 
     expect(logout).toHaveBeenCalledOnce();
     const config = await readConfigFile();
@@ -49,11 +56,16 @@ describe("logout", () => {
     expect(config?.defaultProfile).toBe("staging");
   });
 
-  it("uses oclif's inherited profile flag without changing the default", async () => {
+  it("uses the global profile flag without changing the default", async () => {
     await writeProfile("default", profile);
     await writeProfile("staging", { ...profile, prismaticUrl: "https://staging.example.io" });
 
-    await LogoutCommand.run(["--profile", "staging"]);
+    const result = await runCommand(LogoutCommand, ["--profile", "staging"]);
+    expect(result).toEqual({
+      profile: "staging",
+      loggedOut: true,
+      environmentCredentialsActive: false,
+    });
 
     const config = await readConfigFile();
     expect(Object.keys(config?.profiles ?? {})).toEqual(["default"]);
@@ -64,12 +76,18 @@ describe("logout", () => {
     await writeProfile("default", profile);
     vi.stubEnv("PRISM_ACCESS_TOKEN", "environment-token");
 
-    await LogoutCommand.run([]);
-
+    const result = await runCommand(LogoutCommand, []);
+    expect(result).toMatchObject({
+      profile: "default",
+      loggedOut: true,
+      environmentCredentialsActive: true,
+      warnings: [expect.stringContaining("Environment credentials")],
+    });
+    expect(getStderr()).toContain("Environment credentials are still active");
     await expect(readConfigFile()).resolves.toBeNull();
   });
 
   it("does not report a successful logout when the profile does not exist", async () => {
-    await expect(LogoutCommand.run([])).rejects.toThrow(/does not exist/);
+    await expect(runCommand(LogoutCommand, [])).rejects.toThrow(/does not exist/);
   });
 });

--- a/src/commands/logout.ts
+++ b/src/commands/logout.ts
@@ -1,24 +1,32 @@
-import { Flags } from "@oclif/core";
+import { commandOutput, defineCommand, optionsSchema } from "../command.js";
 import { logout } from "../auth.js";
-import { PrismaticBaseCommand } from "../baseCommand.js";
 import { deleteProfile, getActiveProfileName } from "../config.js";
 import { hasEnvironmentCredentials } from "../context.js";
+import { z } from "incur";
 
-export default class LogoutCommand extends PrismaticBaseCommand {
-  static description = "Log out of your Prismatic account";
-  static flags = {
-    browser: Flags.boolean({
-      char: "b",
-      description: "additionally log out of your default browser's session",
+export default defineCommand({
+  output: z.object({
+    profile: z.string(),
+    loggedOut: z.literal(true),
+    environmentCredentialsActive: z.boolean(),
+    warnings: z.array(z.string()).optional(),
+  }),
+  mutates: true,
+  description: "Log out of your Prismatic account",
+  options: optionsSchema(
+    z.object({
+      browser: z
+        .boolean()
+        .optional()
+        .describe("additionally log out of your default browser's session")
+        .meta({ cli: { char: "b" } }),
     }),
-  };
-
-  protected authContext = "profile" as const;
-
-  async run() {
+  ),
+  authContext: "profile" as const,
+  async run(context) {
     const {
-      flags: { browser },
-    } = await this.parse(LogoutCommand);
+      options: { browser },
+    } = context;
 
     const profileName = await getActiveProfileName();
     const environmentCredentialsActive = hasEnvironmentCredentials();
@@ -32,13 +40,23 @@ export default class LogoutCommand extends PrismaticBaseCommand {
       const environmentHint = environmentCredentialsActive
         ? " Environment credentials remain active until you unset PRISM_ACCESS_TOKEN and PRISM_REFRESH_TOKEN."
         : "";
-      this.error(`Profile '${profileName}' does not exist.${environmentHint}`, { exit: 1 });
+      commandOutput.error(`Profile '${profileName}' does not exist.${environmentHint}`, {
+        exit: 1,
+      });
     }
-    this.log(`Logged out of '${profileName}'.`);
+    commandOutput.log(`Logged out of '${profileName}'.`);
     if (environmentCredentialsActive) {
-      this.warn(
+      commandOutput.warn(
         "Environment credentials are still active. Unset PRISM_ACCESS_TOKEN and PRISM_REFRESH_TOKEN to stop using them.",
       );
     }
-  }
-}
+    return {
+      profile: profileName,
+      loggedOut: true as const,
+      environmentCredentialsActive,
+      ...(environmentCredentialsActive
+        ? { warnings: ["Environment credentials remain active until unset."] }
+        : {}),
+    };
+  },
+});

--- a/src/commands/me/index.ts
+++ b/src/commands/me/index.ts
@@ -1,30 +1,54 @@
-import { PrismaticBaseCommand } from "../../baseCommand.js";
+import { z } from "incur";
+import { commandOutput, defineCommand } from "../../command.js";
 import { getAuthContext } from "../../context.js";
+import { resultOutput, warningsOutput } from "../../output.js";
 import { whoAmI } from "../../utils/user/query.js";
 
-export default class WhoAmICommand extends PrismaticBaseCommand {
-  static description = "Print your user profile information";
-
-  async run() {
-    await this.parse(WhoAmICommand);
+export default defineCommand({
+  output: z.object({
+    ...warningsOutput,
+    name: z.string(),
+    email: z.string(),
+    organization: z.object({ id: z.string(), name: z.string() }).optional(),
+    customer: z.object({ id: z.string(), name: z.string() }).optional(),
+    tenantId: z.string().optional(),
+    endpointUrl: z.string(),
+    authentication: z.enum(["environment", "profile"]),
+    profile: z.string().optional(),
+  }),
+  description: "Print your user profile information",
+  async run(_context) {
     const authContext = await getAuthContext();
     const me = await whoAmI();
     const { name, email, org, customer, tenantId } = me;
-    this.log("Name:", name);
-    this.log("Email:", email);
+    commandOutput.log("Name:", name);
+    commandOutput.log("Email:", email);
     if (org) {
-      this.log("Organization:", org.name);
-      this.log("Organization ID:", org.id);
+      commandOutput.log("Organization:", org.name);
+      commandOutput.log("Organization ID:", org.id);
     } else if (customer) {
-      this.log("Customer:", customer.name);
+      commandOutput.log("Customer:", customer.name);
     }
     if (tenantId) {
-      this.log("Tenant ID:", tenantId);
+      commandOutput.log("Tenant ID:", tenantId);
     }
-    this.log("Endpoint URL:", authContext.url);
-    this.log("Authentication:", authContext.source === "environment" ? "Environment" : "Profile");
+    commandOutput.log("Endpoint URL:", authContext.url);
+    commandOutput.log(
+      "Authentication:",
+      authContext.source === "environment" ? "Environment" : "Profile",
+    );
     if (authContext.profileName) {
-      this.log("Profile:", authContext.profileName);
+      commandOutput.log("Profile:", authContext.profileName);
     }
-  }
-}
+    return resultOutput(_context, {
+      name,
+      email,
+      organization: org,
+      customer,
+      tenantId,
+      endpointUrl: authContext.url,
+      authentication: authContext.source,
+      profile: authContext.profileName,
+    });
+  },
+});

--- a/src/commands/me/token.test.ts
+++ b/src/commands/me/token.test.ts
@@ -1,18 +1,18 @@
+import { runCommand } from "../../test-command.js";
 import { describe, expect, it, vi } from "vitest";
 import { getAuthContext } from "../../context.js";
-import { getStdout } from "../../../vitest.setup.js";
 import PrintTokenCommand from "./token.js";
 
 describe("me:token", () => {
-  it("prints the refresh token from the active environment session", async () => {
+  it("returns the refresh token from the active environment session", async () => {
     vi.mocked(getAuthContext).mockResolvedValue({
       source: "environment",
       url: "https://ci.example.io",
       refreshToken: "environment-refresh-token",
     });
 
-    await PrintTokenCommand.run(["--type", "refresh"]);
-
-    expect(getStdout()).toContain("environment-refresh-token");
+    const result = await runCommand(PrintTokenCommand, ["--type", "refresh"]);
+    expect(result).toEqual({ token: "environment-refresh-token", type: "refresh" });
+    expect(PrintTokenCommand.output.safeParse(result).success).toBe(true);
   });
 });

--- a/src/commands/me/token.ts
+++ b/src/commands/me/token.ts
@@ -1,26 +1,32 @@
-import { Flags } from "@oclif/core";
+import { z } from "incur";
 import { getAccessToken } from "../../auth.js";
-import { PrismaticBaseCommand } from "../../baseCommand.js";
+import { commandOutput, defineCommand, optionsSchema } from "../../command.js";
 import { getAuthContext } from "../../context.js";
-export default class PrintTokenCommand extends PrismaticBaseCommand {
-  static description = "Print your authorization tokens";
-
-  static flags = {
-    type: Flags.string({
-      char: "t",
-      description: "Which token type to print",
-      options: ["access", "refresh"],
-      default: "access",
+import { resultOutput, warningsOutput } from "../../output.js";
+export default defineCommand({
+  output: z.object({
+    ...warningsOutput,
+    token: z.string().nullable(),
+    type: z.enum(["access", "refresh"]),
+  }),
+  description: "Print your authorization tokens",
+  options: optionsSchema(
+    z.object({
+      type: z
+        .enum(["access", "refresh"])
+        .default("access")
+        .describe("Which token type to print")
+        .meta({ cli: { char: "t" } }),
     }),
-  };
-
-  async run() {
+  ),
+  async run(context) {
     const {
-      flags: { type: tokenType },
-    } = await this.parse(PrintTokenCommand);
+      options: { type: tokenType },
+    } = context;
 
     const token =
       tokenType === "access" ? await getAccessToken() : (await getAuthContext()).refreshToken;
-    this.log(token);
-  }
-}
+    commandOutput.log(token);
+    return resultOutput(context, { token: token ?? null, type: tokenType });
+  },
+});

--- a/src/commands/me/token/revoke.ts
+++ b/src/commands/me/token/revoke.ts
@@ -1,39 +1,47 @@
-import { Flags } from "@oclif/core";
+import { z } from "incur";
 import { revokeRefreshToken } from "../../../auth.js";
-import { PrismaticBaseCommand } from "../../../baseCommand.js";
-import { ux } from "../../../utils/legacy-ux.js";
+import { commandOutput, defineCommand, optionsSchema } from "../../../command.js";
+import { resultOutput, warningsOutput } from "../../../output.js";
+import { ux } from "../../../utils/ux.js";
 
-export default class RevokeTokenCommand extends PrismaticBaseCommand {
-  static description = "Revoke all refresh tokens for your user";
-
-  static flags = {
-    confirm: Flags.boolean({
-      allowNo: true,
-      default: true,
-      description: "Prompt for confirmation before revoking tokens. Use --no-confirm to skip.",
+export default defineCommand({
+  mutates: true,
+  output: z.object({
+    revoked: z.literal(true),
+    authentication: z.enum(["environment", "profile"]),
+    ...warningsOutput,
+  }),
+  description: "Revoke all refresh tokens for your user",
+  options: optionsSchema(
+    z.object({
+      confirm: z
+        .boolean()
+        .default(true)
+        .describe("Prompt for confirmation before revoking tokens. Use --no-confirm to skip.")
+        .meta({ cli: { allowNo: true } }),
     }),
-  };
-
-  async run() {
+  ),
+  async run(context) {
     const {
-      flags: { confirm },
-    } = await this.parse(RevokeTokenCommand);
+      options: { confirm },
+    } = context;
 
     if (confirm) {
       const shouldContinue = await ux.confirm(
         "This will revoke all refresh tokens for the current user. Continue? (yes/no)",
       );
       if (!shouldContinue) {
-        this.error("Operation canceled", { exit: 1 });
+        commandOutput.error("Operation canceled", { exit: 1 });
       }
     }
 
     const source = await revokeRefreshToken();
-    this.log("All refresh tokens for your user have been revoked.");
+    commandOutput.log("All refresh tokens for your user have been revoked.");
     if (source === "environment") {
-      this.warn(
+      commandOutput.warn(
         "Remove PRISM_ACCESS_TOKEN and PRISM_REFRESH_TOKEN from your environment before running more commands.",
       );
     }
-  }
-}
+    return resultOutput(context, { revoked: true, authentication: source });
+  },
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,15 +93,18 @@ import { asOclifCommand } from "./migration-bridge.js";
 
 // During the stack, native commands run through incur while remaining commands keep oclif.
 export const NativeCommands = {
-  "profiles:list": ProfilesListCommand,
-  "profiles:use": ProfilesUseCommand,
-  "profiles:delete": ProfilesDeleteCommand,
-};
-
-export const Commands = {
   login: LoginCommand,
   "login:switch": LoginSwitchCommand,
   logout: LogoutCommand,
+  me: MeCommand,
+  "me:token": MeTokenCommand,
+  "profiles:list": ProfilesListCommand,
+  "profiles:use": ProfilesUseCommand,
+  "profiles:delete": ProfilesDeleteCommand,
+  "me:token:revoke": MeTokenRevokeCommand,
+};
+
+export const Commands = {
   "components:delete": ComponentsDeleteCommand,
   "components:list": ComponentsListCommand,
   "components:publish": ComponentsPublishCommand,
@@ -129,8 +132,6 @@ export const Commands = {
   "integrations:set-debug": IntegrationsSetDebugCommand,
   "integrations:update": IntegrationsUpdateCommand,
   "integrations:validate-yaml": IntegrationsValidateYamlCommand,
-  me: MeCommand,
-  "me:token": MeTokenCommand,
   "on-prem-resources:delete": OnPremResourcesDeleteCommand,
   "on-prem-resources:list": OnPremResourcesListCommand,
   "on-prem-resources:registration-jwt": OnPremResourcesRegistrationCommand,
@@ -173,7 +174,6 @@ export const Commands = {
   "integrations:init": IntegrationsInitCommand,
   "integrations:versions": IntegrationsVersionsCommand,
   "logs:severities:list": LogsSeveritiesListCommand,
-  "me:token:revoke": MeTokenRevokeCommand,
   "organization:connections:list": OrganizationConnectionsListCommand,
   "organization:signing-keys:delete": OrganizationSigningKeysDeleteCommand,
   "organization:signing-keys:generate": OrganizationSigningKeysGenerateCommand,


### PR DESCRIPTION
Migrate login and identity commands to native incur schemas.

Part **10/24** of the native incur migration. This PR targets `incur-09-cli-profiles`; the stack integrates into the long-lived `agent` branch. Review this diff against its immediate base.

Validation: format/lint, TypeScript, bundle, and **359 passing tests** (3 skipped) on Node 24. CI also checks Node 22/24/26 and Windows.

Review size: **561 handwritten changed lines**; counts include additions and deletions.

The temporary migration bridge keeps unmigrated commands on oclif and delegates migrated commands to incur. It is removed by the native-cutover PR. Contract coverage grows with each migrated command family.

[Stack review guide](https://github.com/prismatic-io/prism/blob/incur-24-review-evidence/docs/incur-pr-stack.md). Merge bottom-up; rebase descendants after a squash merge.
