### PR TITLE
[incur 18/24] Migrate scaffolding commands and isolate generator directories

### DIFF
--- a/src/commands/components/init/component.ts
+++ b/src/commands/components/init/component.ts
@@ -1,86 +1,104 @@
-import { type Config, Flags } from "@oclif/core";
-import { PrismaticBaseCommand } from "../../../baseCommand.js";
+import { z } from "incur";
 import inquirer from "inquirer";
 import { camelCase } from "lodash-es";
 import path from "path";
-import { template, toArgv } from "../../../generate/util.js";
+import { defineCommand, requireInteractiveInput, optionsSchema } from "../../../command.js";
+import { template } from "../../../generate/util.js";
+import { resultOutput, warningsOutput } from "../../../output.js";
 import {
   DEFAULT_TOOLCHAIN,
   getToolchain,
   TOOLCHAIN_NAMES,
 } from "../../../utils/toolchain/index.js";
 
-export default class GenerateComponentCommand extends PrismaticBaseCommand {
-  static hidden = true;
-  static description = "Initialize a new Component";
-  static flags = {
-    name: Flags.string({
-      char: "n",
-      description: "Name of the component",
+export default defineCommand({
+  mutates: true,
+  output: z.object({
+    name: z.string(),
+    path: z.string(),
+    toolchain: z.string(),
+    ...warningsOutput,
+  }),
+  hidden: true,
+  description: "Initialize a new Component",
+  options: optionsSchema(
+    z.object({
+      name: z
+        .string()
+        .optional()
+        .describe("Name of the component")
+        .meta({ cli: { char: "n" } }),
+      description: z
+        .string()
+        .optional()
+        .describe("Description for the component")
+        .meta({ cli: { char: "d" } }),
+      toolchain: z
+        .enum(TOOLCHAIN_NAMES)
+        .default(DEFAULT_TOOLCHAIN)
+        .meta({ cli: { hidden: true } }),
     }),
-    description: Flags.string({
-      char: "d",
-      description: "Description for the component",
-    }),
-    toolchain: Flags.option({
-      options: TOOLCHAIN_NAMES,
-      default: DEFAULT_TOOLCHAIN,
-      hidden: true,
-    })(),
-  };
+  ),
+  async run(context) {
+    return resultOutput(context, await generateComponent(context.options));
+  },
+});
 
-  async run() {
-    const { flags } = await this.parse(GenerateComponentCommand);
-    const toolchain = getToolchain(flags.toolchain);
-    const { name, description } = await inquirer.prompt<{
-      name: string;
-      description: string;
-    }>(
-      [
-        {
-          type: "input",
-          name: "name",
-          message: "Name of the component",
-          when: () => !flags.name,
-        },
-        {
-          type: "input",
-          name: "description",
-          message: "Description for the component",
-          when: () => !flags.description,
-        },
-      ],
-      flags,
+export async function generateComponent(
+  flags: { name?: string; description?: string; toolchain?: "modern" | "legacy" },
+  directory = process.cwd(),
+) {
+  const toolchain = getToolchain(flags.toolchain ?? DEFAULT_TOOLCHAIN);
+  if (!flags.name || !flags.description) {
+    requireInteractiveInput(
+      "Agent mode requires both --name and --description for components:init:component",
     );
+  }
+  const { name, description } = await inquirer.prompt<{
+    name: string;
+    description: string;
+  }>(
+    [
+      {
+        type: "input",
+        name: "name",
+        message: "Name of the component",
+        when: () => !flags.name,
+      },
+      {
+        type: "input",
+        name: "description",
+        message: "Description for the component",
+        when: () => !flags.description,
+      },
+    ],
+    flags,
+  );
 
-    const context = { component: { name, description, key: camelCase(name) } };
-    const sharedFiles = [
-      path.join("assets", "icon.png"),
-      path.join("src", "actions.test.ts"),
-      path.join("src", "actions.ts"),
-      path.join("src", "client.ts"),
-      path.join("src", "connections.ts"),
-      path.join("src", "dataSources.test.ts"),
-      path.join("src", "dataSources.ts"),
-      path.join("src", "index.ts"),
-      path.join("src", "triggers.test.ts"),
-      path.join("src", "triggers.ts"),
-      ".env.testing",
-      "package.json",
-    ];
-    await Promise.all([
-      ...sharedFiles.map((file) =>
-        template(
-          path.join("component", file.endsWith("icon.png") ? file : `${file}.ejs`),
-          file,
-          context,
-        ),
+  const context = { component: { name, description, key: camelCase(name) } };
+  const sharedFiles = [
+    path.join("assets", "icon.png"),
+    path.join("src", "actions.test.ts"),
+    path.join("src", "actions.ts"),
+    path.join("src", "client.ts"),
+    path.join("src", "connections.ts"),
+    path.join("src", "dataSources.test.ts"),
+    path.join("src", "dataSources.ts"),
+    path.join("src", "index.ts"),
+    path.join("src", "triggers.test.ts"),
+    path.join("src", "triggers.ts"),
+    ".env.testing",
+    "package.json",
+  ];
+  await Promise.all([
+    ...sharedFiles.map((file) =>
+      template(
+        path.join("component", file.endsWith("icon.png") ? file : `${file}.ejs`),
+        path.join(directory, file),
+        context,
       ),
-      toolchain.renderTemplates(context),
-    ]);
-  }
-
-  static async invoke(args: { [K in keyof typeof this.flags]+?: unknown }, config: Config) {
-    await GenerateComponentCommand.run(toArgv(args), config);
-  }
+    ),
+    toolchain.renderTemplates(context, directory),
+  ]);
+  return { name, path: directory, toolchain: toolchain.name };
 }

--- a/src/commands/components/init/formats.ts
+++ b/src/commands/components/init/formats.ts
@@ -1,69 +1,97 @@
-import { type Config, Flags } from "@oclif/core";
-import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { copy } from "fs-extra";
+import { z } from "incur";
 import { camelCase } from "lodash-es";
 import path, { extname } from "path";
+import { commandOutput, defineCommand, optionsSchema } from "../../../command.js";
 import { read } from "../../../generate/formats/readers/openapi/index.js";
 import { write } from "../../../generate/formats/writer/index.js";
-import { template, toArgv } from "../../../generate/util.js";
+import { template } from "../../../generate/util.js";
+import { resultOutput, warningsOutput } from "../../../output.js";
 import {
   DEFAULT_TOOLCHAIN,
   getToolchain,
   TOOLCHAIN_NAMES,
 } from "../../../utils/toolchain/index.js";
 
-export default class GenerateFormatsCommand extends PrismaticBaseCommand {
-  static hidden = true;
-  static description = "Initialize a new Component from a format";
-  static flags = {
-    name: Flags.string({
-      char: "n",
-      description: "Name of the component",
-      required: true,
+export default defineCommand({
+  output: z.object({
+    name: z.string(),
+    path: z.string(),
+    toolchain: z.string(),
+    ...warningsOutput,
+  }),
+  hidden: true,
+  description: "Initialize a new Component from a format",
+  options: optionsSchema(
+    z.object({
+      name: z
+        .string()
+        .describe("Name of the component")
+        .meta({ cli: { char: "n" } }),
+      icon: z
+        .string()
+        .optional()
+        .describe("Path to png icon for the component")
+        .meta({ cli: { char: "i" } }),
+      openapi: z
+        .string()
+        .describe("Path to OpenAPI file for the component")
+        .meta({ cli: { char: "o" } }),
+      public: z
+        .boolean()
+        .optional()
+        .meta({ cli: { hidden: true } }),
+      toolchain: z
+        .enum(TOOLCHAIN_NAMES)
+        .default(DEFAULT_TOOLCHAIN)
+        .meta({ cli: { hidden: true } }),
     }),
-    icon: Flags.string({
-      char: "i",
-      description: "Path to png icon for the component",
-    }),
-    openapi: Flags.string({
-      char: "o",
-      description: "Path to OpenAPI file for the component",
-      required: true,
-    }),
-    public: Flags.boolean({
-      hidden: true,
-    }),
-    toolchain: Flags.option({
-      options: TOOLCHAIN_NAMES,
-      default: DEFAULT_TOOLCHAIN,
-      hidden: true,
-    })(),
-  };
+  ),
+  async run(context) {
+    return resultOutput(context, await generateFormats(context.options));
+  },
+});
 
-  async run() {
-    const {
-      flags: { name, icon, openapi, public: isPublic = false, toolchain: toolchainName },
-    } = await this.parse(GenerateFormatsCommand);
-    const toolchain = getToolchain(toolchainName);
-    const key = camelCase(name);
+export async function generateFormats(
+  options: {
+    name: string;
+    openapi: string;
+    icon?: string;
+    public?: boolean;
+    toolchain?: "modern" | "legacy";
+  },
+  directory = process.cwd(),
+) {
+  const {
+    name,
+    icon,
+    openapi,
+    public: isPublic = false,
+    toolchain: toolchainName = DEFAULT_TOOLCHAIN,
+  } = options;
+  const toolchain = getToolchain(toolchainName);
+  const key = camelCase(name);
 
-    const sharedFiles = [path.join("assets", "icon.png")];
-    await Promise.all([
-      ...sharedFiles.map((f) =>
-        template(path.join("formats", f.endsWith("icon.png") ? f : `${f}.ejs`), f),
+  const sharedFiles = [path.join("assets", "icon.png")];
+  await Promise.all([
+    ...sharedFiles.map((f) =>
+      template(
+        path.join("formats", f.endsWith("icon.png") ? f : `${f}.ejs`),
+        path.join(directory, f),
       ),
-      toolchain.renderTemplates(),
-    ]);
+    ),
+    toolchain.renderTemplates({}, directory),
+  ]);
 
-    const result = await read(openapi);
-    await write(key, isPublic, result);
-    await copy(openapi, `${key}-openapi-spec${extname(openapi)}`);
+  const result = await read(openapi);
+  await write(key, isPublic, result, directory);
+  await copy(openapi, path.join(directory, `${key}-openapi-spec${extname(openapi)}`));
 
-    if (icon) {
-      await copy(icon, path.join("assets", "icon.png"));
-    }
+  if (icon) {
+    await copy(icon, path.join(directory, "assets", "icon.png"));
+  }
 
-    this.log(`
+  commandOutput.log(`
 "${name}" is ready for development.
 To install dependencies, run either "npm install" or "yarn install"
 To test the component, run "npm run test" or "yarn test"
@@ -72,9 +100,5 @@ To publish the component, run "prism components:publish"
 
 For documentation on writing custom components, visit https://prismatic.io/docs/custom-connectors/
     `);
-  }
-
-  static async invoke(args: { [K in keyof typeof this.flags]+?: unknown }, config: Config) {
-    await GenerateFormatsCommand.run(toArgv(args), config);
-  }
+  return { name, path: directory, toolchain: toolchain.name };
 }

--- a/src/commands/components/init/index.test.ts
+++ b/src/commands/components/init/index.test.ts
@@ -1,4 +1,6 @@
-import fs from "fs";
+import { runCommand } from "../../../test-command.js";
+import { existsSync } from "node:fs";
+import { mkdir, readdir } from "node:fs/promises";
 import { readFile } from "fs-extra";
 import { kebabCase } from "lodash-es";
 import path from "path";
@@ -15,22 +17,21 @@ interface SpecMeta {
   name: string;
 }
 
+const componentsPath = path.resolve("src/commands/components");
+const tempPath = path.resolve(`${componentsPath}/init/temp`);
+
+if (!existsSync(tempPath)) {
+  await mkdir(tempPath);
+}
+
+const specs = (await readdir(`${componentsPath}/init/fixtures/specs`)).map<SpecMeta>((fileName) => {
+  const type = fileName.endsWith(".wsdl") ? "wsdl" : "openApi";
+  const [name] = fileName.toLowerCase().split(".");
+  return { type, fileName, name };
+});
+
 describe("component generation tests", () => {
   const basePath = process.env.PWD ?? process.cwd();
-  const componentsPath = path.resolve("src/commands/components");
-  const tempPath = path.resolve(`${componentsPath}/init/temp`);
-
-  if (!fs.existsSync(tempPath)) {
-    fs.mkdirSync(tempPath);
-  }
-
-  const specs = fs
-    .readdirSync(`${componentsPath}/init/fixtures/specs`)
-    .map<SpecMeta>((fileName) => {
-      const type = fileName.endsWith(".wsdl") ? "wsdl" : "openApi";
-      const [name] = fileName.toLowerCase().split(".");
-      return { type, fileName, name };
-    });
 
   for (const toolchain of TOOLCHAIN_NAMES) {
     for (const { type, fileName, name } of specs) {
@@ -42,7 +43,7 @@ describe("component generation tests", () => {
           async () => {
             process.chdir(tempPath);
 
-            await InitializeComponent.run([
+            await runCommand(InitializeComponent, [
               projectName,
               `--${kebabCase(type)}-path=../fixtures/specs/${fileName}`,
               "--toolchain",

--- a/src/commands/components/init/index.ts
+++ b/src/commands/components/init/index.ts
@@ -1,173 +1,169 @@
-import { Args, Flags } from "@oclif/core";
-import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import { promises as fs } from "fs";
+import { z } from "incur";
 import * as path from "path";
 import { parseAndGenerate } from "wsdl-tsclient";
-import { Logger as WsdlTsClientLogger } from "wsdl-tsclient/dist/src/utils/logger.js";
+import { commandOutput, defineCommand, argsSchema, optionsSchema } from "../../../command.js";
 import { generate } from "../../../generate/index.js";
 import { updatePackageJson } from "../../../generate/util.js";
+import { resultOutput, warningsOutput } from "../../../output.js";
 import { formatSourceFiles, getFilesToFormat, VALID_NAME_REGEX } from "../../../utils/generate.js";
 import {
   DEFAULT_TOOLCHAIN,
   getToolchain,
   TOOLCHAIN_NAMES,
 } from "../../../utils/toolchain/index.js";
-import GenerateComponentCommand from "./component.js";
-import GenerateFormatsCommand from "./formats.js";
+import { generateComponent } from "./component.js";
+import { generateFormats } from "./formats.js";
 
-export default class InitializeComponent extends PrismaticBaseCommand {
-  static description = "Initialize a new Component";
-
-  static examples = [
+export default defineCommand({
+  mutates: true,
+  output: z.object({
+    name: z.string(),
+    path: z.string(),
+    toolchain: z.string(),
+    ...warningsOutput,
+  }),
+  description: "Initialize a new Component",
+  examples: [
     {
       description:
         "Initialize a new component directory for a component named 'send-customer-invoices':",
-      command: "<%= config.bin %> <%= command.id %> send-customer-invoices",
+      args: { name: "send-customer-invoices" },
     },
     {
       description:
         "Initialize a component from a WSDL definition file, then install dependencies, build, and publish it:",
-      command: `<%= config.bin %> <%= command.id %> --wsdl-path ./example.wsdl "Example WSDL"
-cd "Example WSDL" && yarn install && yarn build
-prism components:publish`,
+      args: { name: "Example WSDL" },
+      options: { "wsdl-path": "./example.wsdl" },
     },
-  ];
-
-  static flags = {
-    "wsdl-path": Flags.string({
-      required: false,
-      description: "Path to the WSDL definition file used to generate a Component",
+  ],
+  options: optionsSchema(
+    z.object({
+      "wsdl-path": z
+        .string()
+        .optional()
+        .describe("Path to the WSDL definition file used to generate a Component"),
+      "open-api-path": z
+        .string()
+        .optional()
+        .describe(
+          "The path to an OpenAPI Specification file (JSON or YAML) used to generate a Component",
+        ),
+      verbose: z
+        .boolean()
+        .default(false)
+        .describe("Output more verbose logging from Component generation"),
+      toolchain: z
+        .enum(TOOLCHAIN_NAMES)
+        .default(DEFAULT_TOOLCHAIN)
+        .describe(
+          "Toolchain to scaffold: 'modern' (tsdown + vitest + Biome) or 'legacy' (webpack + jest + eslint)",
+        ),
     }),
-    "open-api-path": Flags.string({
-      required: false,
-      description:
-        "The path to an OpenAPI Specification file (JSON or YAML) used to generate a Component",
+  ),
+  args: argsSchema(
+    z.object({
+      name: z
+        .string()
+        .describe(
+          "Name of the new component to create (alphanumeric characters, hyphens, and underscores)",
+        ),
     }),
-    verbose: Flags.boolean({
-      required: false,
-      default: false,
-      description: "Output more verbose logging from Component generation",
-    }),
-    toolchain: Flags.option({
-      options: TOOLCHAIN_NAMES,
-      default: DEFAULT_TOOLCHAIN,
-      description:
-        "Toolchain to scaffold: 'modern' (tsdown + vitest + Biome) or 'legacy' (webpack + jest + eslint)",
-    })(),
-  };
-  static args = {
-    name: Args.string({
-      required: true,
-      description:
-        "Name of the new component to create (alphanumeric characters, hyphens, and underscores)",
-    }),
-  };
-
-  async run() {
+  ),
+  async run(context) {
     const cwd = process.cwd();
 
-    try {
-      const {
-        args: { name },
-        flags: {
-          verbose,
-          "wsdl-path": rawWsdlPath,
-          "open-api-path": rawOpenApiPath,
-          toolchain: toolchainName,
+    const {
+      args: { name },
+      options: {
+        verbose,
+        "wsdl-path": rawWsdlPath,
+        "open-api-path": rawOpenApiPath,
+        toolchain: toolchainName,
+      },
+    } = context;
+
+    const toolchain = getToolchain(toolchainName);
+    const wsdlPath = rawWsdlPath ? path.resolve(rawWsdlPath) : undefined;
+    const openApiPath = rawOpenApiPath ? path.resolve(rawOpenApiPath) : undefined;
+
+    if (!VALID_NAME_REGEX.test(name)) {
+      const regexUrl = new URL("https://regex101.com");
+      regexUrl.searchParams.set("regex", VALID_NAME_REGEX.source);
+      commandOutput.error(
+        `'${name}' contains invalid characters. Please select a component name that starts and ends with alphanumeric characters, and contains only alphanumeric characters, hyphens, and underscores. See ${regexUrl}`,
+        { exit: 1 },
+      );
+    }
+    if (wsdlPath && !wsdlPath?.includes(".wsdl")) {
+      commandOutput.error("If a WSDL is provided it must have an extension of '.wsdl'", {
+        exit: 1,
+      });
+    }
+    commandOutput.log(`Creating component directory for "${name}"...`);
+
+    const directory = path.resolve(cwd, name);
+    await fs.mkdir(directory);
+
+    if (openApiPath) {
+      await generateFormats(
+        {
+          name,
+          openapi: openApiPath,
+          toolchain: toolchain.name,
         },
-      } = await this.parse(InitializeComponent);
+        directory,
+      );
+    } else {
+      await generateComponent(
+        {
+          name,
+          description: "Prism-generated Component",
+          toolchain: toolchain.name,
+        },
+        directory,
+      );
 
-      const toolchain = getToolchain(toolchainName);
-      const wsdlPath = rawWsdlPath ? path.resolve(rawWsdlPath) : undefined;
-      const openApiPath = rawOpenApiPath ? path.resolve(rawOpenApiPath) : undefined;
+      if (wsdlPath) {
+        const [wsdlName] = path.basename(wsdlPath).split(".wsdl");
+        await parseAndGenerate(wsdlPath, directory, {
+          caseInsensitiveNames: true,
+          quiet: context.agent || !verbose,
+        });
 
-      if (!VALID_NAME_REGEX.test(name)) {
-        const regexUrl = new URL("https://regex101.com");
-        regexUrl.searchParams.set("regex", VALID_NAME_REGEX.source);
-        this.error(
-          `'${name}' contains invalid characters. Please select a component name that starts and ends with alphanumeric characters, and contains only alphanumeric characters, hyphens, and underscores. See ${regexUrl}`,
-          { exit: 1 },
-        );
-      }
-      if (wsdlPath && !wsdlPath?.includes(".wsdl")) {
-        this.error("If a WSDL is provided it must have an extension of '.wsdl'", {
-          exit: 1,
+        await generate({
+          projectRoot: directory,
+          projectTemplateName: wsdlName,
+          projectTemplatePath: wsdlPath,
         });
       }
-      this.log(`Creating component directory for "${name}"...`);
+    }
 
-      await fs.mkdir(name);
-      process.chdir(name);
+    await updatePackageJson({
+      path: path.join(directory, "package.json"),
+      scripts: {
+        build: toolchain.scripts.build,
+        publish: "npm run build && prism components:publish",
+        "generate:manifest": "npm run build && npx @prismatic-io/spectral component-manifest",
+        "generate:manifest:dev":
+          "npm run build && npx @prismatic-io/spectral component-manifest --skip-signature-verify",
+        test: toolchain.scripts.test,
+        lint: toolchain.scripts.lint,
+        typecheck: toolchain.scripts.typecheck,
+        format: toolchain.scripts.format,
+      },
+      ...toolchain.packageJson,
+      dependencies: {
+        "@prismatic-io/spectral": "*",
+        ...(wsdlPath ? { soap: "1.1.10" } : {}),
+      },
+      devDependencies: toolchain.devDependencies,
+    });
 
-      if (openApiPath) {
-        await GenerateFormatsCommand.invoke(
-          {
-            name,
-            openapi: openApiPath,
-            toolchain: toolchain.name,
-          },
-          this.config,
-        );
-      } else {
-        await GenerateComponentCommand.invoke(
-          {
-            name,
-            description: "Prism-generated Component",
-            toolchain: toolchain.name,
-          },
-          this.config,
-        );
+    const filesToFormat = await getFilesToFormat(path.join(directory, "package.json"));
+    await formatSourceFiles(path.join(directory, "package.json"), filesToFormat);
 
-        // Need to pop back as the WSDL generator assumes it's a directory up
-        process.chdir(cwd);
-
-        if (wsdlPath) {
-          if (!verbose) {
-            // wsdl-tsclient emits pretty noisy logs that aren't particularly useful
-            WsdlTsClientLogger.disabled();
-          }
-
-          const [wsdlName] = path.basename(wsdlPath).split(".wsdl");
-          await parseAndGenerate(wsdlPath, name, {
-            caseInsensitiveNames: true,
-          });
-
-          await generate({
-            projectRoot: name,
-            projectTemplateName: wsdlName,
-            projectTemplatePath: wsdlPath,
-          });
-        }
-      }
-
-      // Return to new project's directory
-      process.chdir(path.join(cwd, name));
-
-      await updatePackageJson({
-        path: "package.json",
-        scripts: {
-          build: toolchain.scripts.build,
-          publish: "npm run build && prism components:publish",
-          "generate:manifest": "npm run build && npx @prismatic-io/spectral component-manifest",
-          "generate:manifest:dev":
-            "npm run build && npx @prismatic-io/spectral component-manifest --skip-signature-verify",
-          test: toolchain.scripts.test,
-          lint: toolchain.scripts.lint,
-          typecheck: toolchain.scripts.typecheck,
-          format: toolchain.scripts.format,
-        },
-        ...toolchain.packageJson,
-        dependencies: {
-          "@prismatic-io/spectral": "*",
-          ...(wsdlPath ? { soap: "1.1.10" } : {}),
-        },
-        devDependencies: toolchain.devDependencies,
-      });
-
-      const filesToFormat = await getFilesToFormat(name);
-      await formatSourceFiles(name, filesToFormat);
-
-      this.log(`
+    commandOutput.log(`
 "${name}" is ready for development.
 To install dependencies, run either "npm install" or "yarn install"
 To test the component, run "npm run test" or "yarn test"
@@ -176,8 +172,6 @@ To publish the component, run "prism components:publish"
 
 For documentation on writing custom components, visit https://prismatic.io/docs/custom-connectors/
         `);
-    } finally {
-      process.chdir(cwd);
-    }
-  }
-}
+    return resultOutput(context, { name, path: directory, toolchain: toolchain.name });
+  },
+});

--- a/src/commands/components/init/isolation.test.ts
+++ b/src/commands/components/init/isolation.test.ts
@@ -1,0 +1,43 @@
+import { mkdtemp, mkdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { generateComponent } from "./component.js";
+
+it("generates independent component scaffolds concurrently without changing cwd", async () => {
+  const originalDirectory = process.cwd();
+  const root = await mkdtemp(path.join(tmpdir(), "prism-scaffold-isolation-"));
+  const directories = [path.join(root, "alpha"), path.join(root, "beta")];
+  try {
+    await Promise.all(directories.map((directory) => mkdir(directory)));
+    await Promise.all(
+      directories.map((directory, index) =>
+        generateComponent(
+          {
+            name: `component-${index}`,
+            description: `Description ${index}`,
+            toolchain: index === 0 ? "modern" : "legacy",
+          },
+          directory,
+        ),
+      ),
+    );
+    for (const [index, directory] of directories.entries()) {
+      expect(JSON.parse(await readFile(path.join(directory, "package.json"), "utf8")).name).toBe(
+        `component-${index}`,
+      );
+      expect(await readFile(path.join(directory, "src", "index.ts"), "utf8")).toContain(
+        `Description ${index}`,
+      );
+      expect(
+        await readFile(
+          path.join(directory, index === 0 ? "tsdown.config.mts" : "webpack.config.js"),
+          "utf8",
+        ),
+      ).not.toBe("");
+    }
+    expect(process.cwd()).toBe(originalDirectory);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/src/commands/integrations/init/index.test.ts
+++ b/src/commands/integrations/init/index.test.ts
@@ -1,4 +1,6 @@
-import fs from "fs";
+import { runCommand } from "../../../test-command.js";
+import { existsSync } from "node:fs";
+import { mkdir, rm } from "node:fs/promises";
 import { readFile } from "fs-extra";
 import path from "path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -27,9 +29,9 @@ describe("integrations:init", () => {
   const basePath = process.env.PWD ?? process.cwd();
   const tempPath = path.resolve("src/commands/integrations/init/temp");
 
-  beforeEach(() => {
-    if (!fs.existsSync(tempPath)) {
-      fs.mkdirSync(tempPath, { recursive: true });
+  beforeEach(async () => {
+    if (!existsSync(tempPath)) {
+      await mkdir(tempPath, { recursive: true });
     }
   });
 
@@ -42,11 +44,11 @@ describe("integrations:init", () => {
       describe("scaffold generation", () => {
         const integrationName = `test-integration-${toolchain}`;
 
-        afterEach(() => {
+        afterEach(async () => {
           // Clean up generated directory
           const integrationPath = path.join(tempPath, integrationName);
-          if (fs.existsSync(integrationPath)) {
-            fs.rmSync(integrationPath, { recursive: true, force: true });
+          if (existsSync(integrationPath)) {
+            await rm(integrationPath, { recursive: true, force: true });
           }
         });
 
@@ -55,7 +57,7 @@ describe("integrations:init", () => {
           async () => {
             process.chdir(tempPath);
 
-            await InitializeIntegration.run([integrationName, "--toolchain", toolchain]);
+            await runCommand(InitializeIntegration, [integrationName, "--toolchain", toolchain]);
 
             // The init command chdir's into the created directory, so go back to tempPath
             process.chdir(tempPath);
@@ -73,11 +75,11 @@ describe("integrations:init", () => {
       describe("clean scaffold generation", () => {
         const cleanIntegrationName = `clean-test-integration-${toolchain}`;
 
-        afterEach(() => {
+        afterEach(async () => {
           // Clean up generated directory
           const integrationPath = path.join(tempPath, cleanIntegrationName);
-          if (fs.existsSync(integrationPath)) {
-            fs.rmSync(integrationPath, { recursive: true, force: true });
+          if (existsSync(integrationPath)) {
+            await rm(integrationPath, { recursive: true, force: true });
           }
         });
 
@@ -86,7 +88,7 @@ describe("integrations:init", () => {
           async () => {
             process.chdir(tempPath);
 
-            await InitializeIntegration.run([
+            await runCommand(InitializeIntegration, [
               cleanIntegrationName,
               "--clean",
               "--toolchain",

--- a/src/commands/integrations/init/index.ts
+++ b/src/commands/integrations/init/index.ts
@@ -1,11 +1,12 @@
-import { Args, Flags } from "@oclif/core";
-import { PrismaticBaseCommand } from "../../../baseCommand.js";
 import fs from "fs/promises";
+import { z } from "incur";
 import { camelCase } from "lodash-es";
 import path from "path";
 import { v4 as uuid4 } from "uuid";
-import { template, updatePackageJson } from "../../../generate/util.js";
+import { commandOutput, defineCommand, argsSchema, optionsSchema } from "../../../command.js";
 import { getPrismaticUrl } from "../../../context.js";
+import { template, updatePackageJson } from "../../../generate/util.js";
+import { resultOutput, warningsOutput } from "../../../output.js";
 import { VALID_NAME_REGEX } from "../../../utils/generate.js";
 import {
   DEFAULT_TOOLCHAIN,
@@ -20,70 +21,66 @@ const CLEANABLE_TEMPLATES = [
   "src/configPages.ts",
 ];
 
-export default class InitializeIntegration extends PrismaticBaseCommand {
-  static description = "Initialize a new Code Native Integration";
-
-  static examples = [
+export default defineCommand({
+  mutates: true,
+  output: z.object({
+    name: z.string(),
+    path: z.string(),
+    toolchain: z.string(),
+    ...warningsOutput,
+  }),
+  description: "Initialize a new Code Native Integration",
+  examples: [
     {
       description: "Initialize a new directory for a Code Native Integration:",
-      command: "<%= config.bin %> <%= command.id %> acme-integration",
+      args: { name: "acme-integration" },
     },
-    {
-      description: "Install dependencies:",
-      command: "npm install",
-    },
-    {
-      description: "Build the integration:",
-      command: "npm run build",
-    },
-    {
-      description: "Import the integration into Prismatic:",
-      command: "prism integrations:import",
-    },
-  ];
-
-  static args = {
-    name: Args.string({
-      required: true,
-      description:
-        "Name of the new integration to create (alphanumeric characters, hyphens, and underscores)",
+    { description: "Install dependencies:", args: { name: "npm" } },
+    { description: "Build the integration:", args: { name: "npm" } },
+    { description: "Import the integration into Prismatic:" },
+  ],
+  args: argsSchema(
+    z.object({
+      name: z
+        .string()
+        .describe(
+          "Name of the new integration to create (alphanumeric characters, hyphens, and underscores)",
+        ),
     }),
-  };
-  static flags = {
-    clean: Flags.boolean({
-      description: "Generate clean scaffold without example code",
-      default: false,
+  ),
+  options: optionsSchema(
+    z.object({
+      clean: z.boolean().default(false).describe("Generate clean scaffold without example code"),
+      toolchain: z
+        .enum(TOOLCHAIN_NAMES)
+        .default(DEFAULT_TOOLCHAIN)
+        .describe(
+          "Toolchain to scaffold: 'modern' (tsdown + vitest + Biome) or 'legacy' (webpack + jest + eslint)",
+        ),
     }),
-    toolchain: Flags.option({
-      options: TOOLCHAIN_NAMES,
-      default: DEFAULT_TOOLCHAIN,
-      description:
-        "Toolchain to scaffold: 'modern' (tsdown + vitest + Biome) or 'legacy' (webpack + jest + eslint)",
-    })(),
-  };
-
-  async run() {
+  ),
+  async run(context) {
     const {
       args: { name },
-      flags: { clean, toolchain: toolchainName },
-    } = await this.parse(InitializeIntegration);
+      options: { clean, toolchain: toolchainName },
+    } = context;
 
     const toolchain = getToolchain(toolchainName);
 
     if (!VALID_NAME_REGEX.test(name)) {
       const regexUrl = new URL("https://regex101.com");
       regexUrl.searchParams.set("regex", VALID_NAME_REGEX.source);
-      this.error(
+      commandOutput.error(
         `'${name}' contains invalid characters. Please select an integration name that starts and ends with alphanumeric characters, and contains only alphanumeric characters, hyphens, and underscores. See ${regexUrl}`,
         { exit: 1 },
       );
     }
 
-    await fs.mkdir(name);
-    process.chdir(name);
+    const directory = path.resolve(name);
+    await fs.mkdir(directory);
 
     const registryUrl = new URL("/packages/npm", await getPrismaticUrl()).toString();
-    const context = {
+    const templateContext = {
       integration: { name, description: "Prism-generated Integration", key: camelCase(name) },
       flow: {
         stableKey: uuid4(),
@@ -131,13 +128,17 @@ export default class InitializeIntegration extends PrismaticBaseCommand {
     ];
     await Promise.all([
       ...sharedFiles.map((file) =>
-        template(path.join("integration", resolveTemplateSource(file)), file, context),
+        template(
+          path.join("integration", resolveTemplateSource(file)),
+          path.join(directory, file),
+          templateContext,
+        ),
       ),
-      toolchain.renderTemplates(context),
+      toolchain.renderTemplates(templateContext, directory),
     ]);
 
     await updatePackageJson({
-      path: "package.json",
+      path: path.join(directory, "package.json"),
       scripts: {
         build: toolchain.scripts.build,
         import: "npm run build && prism integrations:import",
@@ -153,7 +154,7 @@ export default class InitializeIntegration extends PrismaticBaseCommand {
       devDependencies: toolchain.devDependencies,
     });
 
-    this.log(`
+    commandOutput.log(`
 "${name}" is ready for development.
 To install dependencies, run either "npm install" or "yarn install"
 To run unit tests for the integration, run "npm run test" or "yarn test"
@@ -162,5 +163,6 @@ To import the integration, run "prism integrations:import"
 
 For documentation on writing code-native integrations, visit https://prismatic.io/docs/integrations/code-native/
     `);
-  }
-}
+    return resultOutput(context, { name, path: directory, toolchain: toolchain.name });
+  },
+});

--- a/src/generate/formats/writer/index.ts
+++ b/src/generate/formats/writer/index.ts
@@ -1,3 +1,4 @@
+import { outputFile } from "fs-extra";
 import { minBy } from "lodash-es";
 import path from "path";
 import { Project, ScriptKind, type SourceFile } from "ts-morph";
@@ -214,8 +215,9 @@ export const write = async (
   key: string,
   isPublic: boolean,
   { baseUrl, component, actions, connections }: Result,
+  directory = process.cwd(),
 ): Promise<Project> => {
-  const project = new Project();
+  const project = new Project({ useInMemoryFileSystem: true });
   project.createDirectory("src");
 
   writeConnections(project, connections);
@@ -229,6 +231,17 @@ export const write = async (
   }
 
   await project.save();
+  const virtualRoot = project.getFileSystem().getCurrentDirectory();
+  await Promise.all(
+    project
+      .getSourceFiles()
+      .map((file) =>
+        outputFile(
+          path.resolve(directory, path.relative(virtualRoot, file.getFilePath())),
+          file.getFullText(),
+        ),
+      ),
+  );
 
   return project;
 };

--- a/src/generate/parse.ts
+++ b/src/generate/parse.ts
@@ -18,8 +18,10 @@ const getWSDLClientMethods = (
 
     return wsdlClientInterface?.getMethods();
   } catch (_error) {
-    console.error("Unable to find methods for Action Generation.");
-    process.exit(1);
+    writeCommandOutput("Unable to find methods for Action Generation.", "stderr");
+    throw Object.assign(new Error("Unable to find methods for Action Generation."), {
+      exitCode: 1,
+    });
   }
 };
 
@@ -53,3 +55,4 @@ export const getActionMethods = (projectStructure: ProjectStructure): ServiceMet
     ),
   };
 };
+import { writeCommandOutput } from "../command.js";

--- a/src/generate/sourceFile.ts
+++ b/src/generate/sourceFile.ts
@@ -38,7 +38,7 @@ const copyTemplateFileToProject = (
 ) => {
   componentProject.addSourceFileAtPath(projectTemplatePath);
   const templateFile = componentProject.getSourceFileOrThrow(projectTemplatePath);
-  templateFile.copy(path.join(process.cwd(), projectRoot, fileName));
+  templateFile.copy(path.resolve(projectRoot, fileName));
 };
 
 const initializeWSDL = ({

--- a/src/generate/util.ts
+++ b/src/generate/util.ts
@@ -55,13 +55,18 @@ export const template = async (
 export const templateDirectory = async (
   sourceDir: string,
   data: Record<string, unknown> = {},
+  destinationDirectory = process.cwd(),
 ): Promise<void> => {
   const absoluteDir = path.join(templatesRoot(), sourceDir);
   const files = await walkDir(absoluteDir);
   await Promise.all(
     files.map((file) => {
       const relativePath = path.relative(absoluteDir, file);
-      return template(path.join(sourceDir, relativePath), relativePath.replace(/\.ejs$/, ""), data);
+      return template(
+        path.join(sourceDir, relativePath),
+        path.join(destinationDirectory, relativePath.replace(/\.ejs$/, "")),
+        data,
+      );
     }),
   );
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,6 +149,8 @@ export const NativeCommands = {
   "components:actions:list": ComponentsActionsListCommand,
   "components:data-sources:list": ComponentsDataSourcesListCommand,
   "components:dev:test": ComponentsDevTestCommand,
+  "components:init:component": ComponentsInitComponentCommand,
+  "components:init": ComponentsInitCommand,
   "components:signature": ComponentsSignatureCommand,
   "components:triggers:list": ComponentsTriggersListCommand,
   "customers:users:create": CustomersUsersCreateCommand,
@@ -161,6 +163,7 @@ export const NativeCommands = {
   "instances:flow-configs:list": InstancesFlowConfigsListCommand,
   "integrations:convert": IntegrationConvertCommand,
   "integrations:flows:list": IntegrationsFlowsListCommand,
+  "integrations:init": IntegrationsInitCommand,
   "integrations:versions": IntegrationsVersionsCommand,
   "logs:severities:list": LogsSeveritiesListCommand,
   "me:token:revoke": MeTokenRevokeCommand,
@@ -180,12 +183,9 @@ export const NativeCommands = {
 
 export const Commands = {
   "components:dev:run": ComponentsDevRunCommand,
-  "components:init:component": ComponentsInitComponentCommand,
-  "components:init": ComponentsInitCommand,
   "instances:flow-configs:test": InstancesFlowConfigsTestCommand,
   "integrations:flows:listen": IntegrationsFlowsListenCommand,
   "integrations:flows:test": IntegrationsFlowsTestCommand,
-  "integrations:init": IntegrationsInitCommand,
   "graphql:query": GraphqlQueryCommand,
   ...Object.fromEntries(
     Object.entries(NativeCommands).map(([id, command]) => [id, asOclifCommand(id, command)]),

--- a/src/utils/toolchain/types.ts
+++ b/src/utils/toolchain/types.ts
@@ -25,7 +25,7 @@ export abstract class Toolchain {
   abstract readonly devDependencies: Record<string, string>;
 
   /** Render this toolchain's config files (templates/<name>/) into the project. */
-  renderTemplates(data: Record<string, unknown> = {}): Promise<void> {
-    return templateDirectory(this.name, data);
+  renderTemplates(data: Record<string, unknown> = {}, directory = process.cwd()): Promise<void> {
+    return templateDirectory(this.name, data, directory);
   }
 }


### PR DESCRIPTION
Migrate scaffolding commands and isolate generator directories.

Part **18/24** of the native incur migration. This PR targets `incur-17-file-commands`; the stack integrates into the long-lived `agent` branch. Review this diff against its immediate base.

Validation: format/lint, TypeScript, bundle, and **452 passing tests** (3 skipped) on Node 24. CI also checks Node 22/24/26 and Windows.

Review size: **847 handwritten changed lines**; counts include additions and deletions.

The temporary migration bridge keeps unmigrated commands on oclif and delegates migrated commands to incur. It is removed by the native-cutover PR. Contract coverage grows with each migrated command family.

[Stack review guide](https://github.com/prismatic-io/prism/blob/incur-24-review-evidence/docs/incur-pr-stack.md). Merge bottom-up; rebase descendants after a squash merge.
