### PR TITLE
[incur 20/24] Stream listener events with request-scoped cleanup

### DIFF
--- a/src/commands/integrations/flows/listen.test.ts
+++ b/src/commands/integrations/flows/listen.test.ts
@@ -1,9 +1,16 @@
 import { encode } from "@msgpack/msgpack";
+import { Cli } from "incur";
 import inquirer from "inquirer";
 import { graphql, HttpResponse, http } from "msw";
 import { setupServer } from "msw/node";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { TEST_PRISMATIC_URL } from "../../../../vitest.setup.js";
+import {
+  commandMiddleware,
+  commandVars,
+  environmentOptions,
+  globalOptions,
+} from "../../../command.js";
 import { fs } from "../../../fs.js";
 import type { GetExecutionsQuery } from "../../../graphql/executions/getExecutions.generated.js";
 import type { GetPolledExecutionQuery } from "../../../graphql/executions/getPolledExecution.generated.js";
@@ -11,6 +18,7 @@ import type { GetIntegrationFlowsQuery } from "../../../graphql/integrations/get
 import type { TestIntegrationFlowMutation } from "../../../graphql/integrations/testIntegrationFlow.generated.js";
 import type { UpdateIntegrationFlowListeningModeMutation } from "../../../graphql/integrations/updateIntegrationFlowListeningMode.generated.js";
 import { ActionScheduleSupport } from "../../../graphql/schema.generated.js";
+import { runCommand } from "../../../test-command.js";
 import ListenCommand, { getTriggerType } from "./listen.js";
 
 vi.mock(import("../../../fs.js"), () => ({
@@ -27,7 +35,7 @@ vi.mock(import("inquirer"), () => ({
   },
 }));
 
-vi.mock(import("../../../utils/legacy-ux.js"), async (importOriginal) => {
+vi.mock(import("../../../utils/ux.js"), async (importOriginal) => {
   const actual = await importOriginal();
   return {
     ...actual,
@@ -37,6 +45,8 @@ vi.mock(import("../../../utils/legacy-ux.js"), async (importOriginal) => {
     },
   };
 });
+
+vi.mock("../../../utils/polling.js", () => ({ getAdaptivePollIntervalMs: () => 1 }));
 
 const api = graphql.link(`${TEST_PRISMATIC_URL}/api`);
 
@@ -153,7 +163,7 @@ const server = setupServer(
   ),
 );
 
-describe("oclif defaults and Zod validation integration", () => {
+describe("command defaults and Zod validation integration", () => {
   beforeAll(() => {
     server.listen({ onUnhandledRequest: "error" });
   });
@@ -167,7 +177,7 @@ describe("oclif defaults and Zod validation integration", () => {
     vi.restoreAllMocks();
   });
 
-  it("applies oclif defaults for output and timeout when flags are omitted", async () => {
+  it("applies defaults for output and timeout when flags are omitted", async () => {
     const webhookFlow = createWebhookFlow("flow-defaults-test", "Defaults Test Flow");
 
     server.use(
@@ -195,8 +205,8 @@ describe("oclif defaults and Zod validation integration", () => {
     );
 
     // Run command WITHOUT --output or --timeout flags
-    // If oclif defaults aren't applied before Zod validation, this would throw
-    await ListenCommand.run([
+    // Defaults must be applied before Zod validation.
+    await runCommand(ListenCommand, [
       "--integration-id",
       "test-integration",
       "--flow-id",
@@ -349,7 +359,7 @@ describe("ListenCommand", () => {
         ),
       );
 
-      await ListenCommand.run([
+      await runCommand(ListenCommand, [
         "--integration-id",
         "test-integration-123",
         "--flow-id",
@@ -402,7 +412,7 @@ describe("ListenCommand", () => {
         ),
       );
 
-      await ListenCommand.run([
+      await runCommand(ListenCommand, [
         "--integration-id",
         "test-integration-123",
         "--flow-id",
@@ -446,7 +456,12 @@ describe("ListenCommand", () => {
         ),
       );
 
-      await ListenCommand.run(["--integration-id", "test-integration-123", "--timeout", "5"]);
+      await runCommand(ListenCommand, [
+        "--integration-id",
+        "test-integration-123",
+        "--timeout",
+        "5",
+      ]);
 
       expect(inquirer.prompt).toHaveBeenCalled();
     });
@@ -461,7 +476,7 @@ describe("ListenCommand", () => {
       );
 
       await expect(
-        ListenCommand.run([
+        runCommand(ListenCommand, [
           "--integration-id",
           "test-integration-123",
           "--flow-id",
@@ -499,22 +514,19 @@ describe("ListenCommand", () => {
         return originalDateNow();
       });
 
-      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-
-      try {
-        await ListenCommand.run([
-          "--integration-id",
-          "test-integration-123",
-          "--flow-id",
-          "flow-timeout-123",
-          "--timeout",
-          "1", // 1 second timeout
-        ]);
-      } catch (error) {
-        expect((error as Error).message).toBe("process.exit called");
-      }
-
-      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("Timeout"));
+      const result = await runCommand(ListenCommand, [
+        "--integration-id",
+        "test-integration-123",
+        "--flow-id",
+        "flow-timeout-123",
+        "--timeout",
+        "1", // 1 second timeout
+      ]);
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: "completed", status: "timed-out" }),
+        ]),
+      );
       vi.spyOn(Date, "now").mockRestore();
     });
   });
@@ -543,7 +555,7 @@ describe("ListenCommand", () => {
       );
 
       await expect(
-        ListenCommand.run([
+        runCommand(ListenCommand, [
           "--integration-id",
           "test-integration-123",
           "--flow-id",
@@ -554,4 +566,171 @@ describe("ListenCommand", () => {
       ).rejects.toThrow("Cannot listen to scheduled flows");
     });
   });
+});
+
+it("rejects agent polling without --no-prompt before enabling remote listening", async () => {
+  server.listen({ onUnhandledRequest: "error" });
+  const mutation = vi.fn();
+  server.use(
+    api.query("GetIntegrationFlows", () =>
+      HttpResponse.json(
+        buildGetIntegrationFlowsResponse([createPollingFlow("polling-id", "Polling Flow")]),
+      ),
+    ),
+    api.mutation("UpdateIntegrationFlowListeningMode", () => {
+      mutation();
+      return HttpResponse.json({ data: {} });
+    }),
+  );
+  await expect(
+    runCommand(ListenCommand, [
+      "--agent",
+      "--yes",
+      "--integration-id",
+      "integration-id",
+      "--flow-id",
+      "polling-id",
+    ]),
+  ).rejects.toThrow("--no-prompt");
+  expect(mutation).not.toHaveBeenCalled();
+  server.close();
+});
+
+it("returns named execution and payload events while restoring listening mode", async () => {
+  server.listen({ onUnhandledRequest: "error" });
+  server.use(
+    api.query("GetIntegrationFlows", () =>
+      HttpResponse.json(
+        buildGetIntegrationFlowsResponse([createWebhookFlow("flow-id", "Webhook")]),
+      ),
+    ),
+    api.query("GetExecutions", () =>
+      HttpResponse.json(
+        buildGetExecutionsResponse([
+          {
+            id: "execution-id",
+            endedAt: new Date().toISOString(),
+            requestPayloadUrl: "https://storage.example.com/agent-payload.json",
+          },
+        ]),
+      ),
+    ),
+    http.get("https://storage.example.com/agent-payload.json", () =>
+      HttpResponse.json({ body: "{}", contentType: "application/json" }),
+    ),
+  );
+  try {
+    const result = await runCommand(ListenCommand, [
+      "--agent",
+      "--yes",
+      "--integration-id",
+      "integration-id",
+      "--flow-id",
+      "flow-id",
+    ]);
+    expect(result).toEqual(
+      expect.arrayContaining([
+        { type: "listening", integrationId: "integration-id", listening: true },
+        {
+          type: "execution",
+          executionId: "execution-id",
+          integrationId: "integration-id",
+          flowId: "flow-id",
+        },
+        expect.objectContaining({
+          type: "payload",
+          executionId: "execution-id",
+          flowId: "flow-id",
+          path: expect.stringContaining("payload-flow-id-"),
+        }),
+        { type: "listening", integrationId: "integration-id", listening: false },
+      ]),
+    );
+    for (const event of result as unknown[])
+      expect(ListenCommand.output.safeParse(event).success).toBe(true);
+  } finally {
+    server.close();
+  }
+});
+
+it("awaits listening cleanup when a native HTTP stream is cancelled", async () => {
+  server.listen({ onUnhandledRequest: "error" });
+  const changes: boolean[] = [];
+  server.use(
+    api.query("GetIntegrationFlows", () =>
+      HttpResponse.json(
+        buildGetIntegrationFlowsResponse([createWebhookFlow("flow-id", "Webhook")]),
+      ),
+    ),
+    api.query("GetExecutions", () => HttpResponse.json(buildGetExecutionsResponse([]))),
+    api.mutation("UpdateIntegrationFlowListeningMode", ({ variables }) => {
+      changes.push(variables.isListening as boolean);
+      return HttpResponse.json({ data: { updateIntegration: { errors: [] } } });
+    }),
+  );
+  const native = Cli.create("prism", {
+    globals: globalOptions,
+    vars: commandVars,
+    env: environmentOptions,
+  })
+    .use(commandMiddleware)
+    .command("listen", ListenCommand);
+  const abort = new AbortController();
+  try {
+    const response = await native.fetch(
+      new Request("http://localhost/listen", {
+        method: "POST",
+        signal: abort.signal,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          "integration-id": "integration-id",
+          "flow-id": "flow-id",
+          yes: true,
+        }),
+      }),
+    );
+    expect(response.status).toBe(200);
+    const reader = response.body?.getReader();
+    const first = await reader.read();
+    expect(new TextDecoder().decode(first.value)).toContain('"listening":true');
+    abort.abort();
+    await reader.cancel();
+    expect(changes).toEqual([true, false]);
+  } finally {
+    server.close();
+  }
+});
+
+it("propagates a native stream failure after restoring listening mode", async () => {
+  server.listen({ onUnhandledRequest: "error" });
+  const changes: boolean[] = [];
+  server.use(
+    api.query("GetIntegrationFlows", () =>
+      HttpResponse.json(
+        buildGetIntegrationFlowsResponse([createWebhookFlow("flow-id", "Webhook")]),
+      ),
+    ),
+    api.query("GetExecutions", () =>
+      HttpResponse.json({ errors: [{ message: "Execution lookup failed" }] }),
+    ),
+    api.mutation("UpdateIntegrationFlowListeningMode", ({ variables }) => {
+      changes.push(variables.isListening as boolean);
+      return HttpResponse.json({ data: { updateIntegration: { errors: [] } } });
+    }),
+  );
+  try {
+    await expect(
+      runCommand(ListenCommand, [
+        "--agent",
+        "--yes",
+        "--integration-id",
+        "integration-id",
+        "--flow-id",
+        "flow-id",
+      ]),
+    ).rejects.toThrow("Execution lookup failed");
+    expect(changes).toEqual([true, false]);
+  } finally {
+    server.close();
+  }
 });

--- a/src/commands/integrations/flows/listen.ts
+++ b/src/commands/integrations/flows/listen.ts
@@ -1,308 +1,212 @@
-import type { ResultOf } from "@graphql-typed-document-node/core";
+import { setTimeout as sleep } from "node:timers/promises";
 import { decode } from "@msgpack/msgpack";
-import { Flags } from "@oclif/core";
+import { Errors, z } from "incur";
 import inquirer from "inquirer";
-import z from "zod";
-import { PrismaticBaseCommand } from "../../../baseCommand.js";
+import { defineCommand, optionsSchema } from "../../../command.js";
 import { exists, fs } from "../../../fs.js";
-import type { GetExecutionsQuery } from "../../../graphql/executions/getExecutions.generated.js";
 import { GetExecutionsDocument as GET_EXECUTIONS } from "../../../graphql/executions/getExecutions.generated.js";
-import type { GetPolledExecutionQuery } from "../../../graphql/executions/getPolledExecution.generated.js";
 import { GetPolledExecutionDocument as GET_POLLED_EXECUTION } from "../../../graphql/executions/getPolledExecution.generated.js";
 import { UpdateIntegrationFlowListeningModeDocument as UPDATE_INTEGRATION_FLOW_LISTENING_MODE } from "../../../graphql/integrations/updateIntegrationFlowListeningMode.generated.js";
 import { gqlRequest } from "../../../graphql.js";
 import { handleError } from "../../../utils/errors.js";
+import { type ExecutionEvent, executionEventSchema } from "../../../utils/execution-output.js";
 import { fetch } from "../../../utils/http.js";
 import { type IntegrationFlow, resolveFlow } from "../../../utils/integration/flows.js";
 import { runIntegrationFlow } from "../../../utils/integration/invoke.js";
 import { getAdaptivePollIntervalMs } from "../../../utils/polling.js";
-import { ux } from "../../../utils/legacy-ux.js";
 
-const DEFAULT_TIMEOUT_SECONDS = 1200; // 20 minutes
+const DEFAULT_TIMEOUT_SECONDS = 1200;
 const DEFAULT_OUTPUT_DIR = "./payloads";
-
-/**
- * Zod schema for listen command flags.
- * Validates command arguments and provides type-safe access to flag values.
- */
+type TriggerType = "WEBHOOK" | "POLLING";
 export const listenFlagsSchema = z.object({
-  "integration-id": z.string().min(1, "Integration ID cannot be empty"),
-  "flow-id": z.string().min(1, "Flow ID cannot be empty").optional(),
-  "flow-name": z.string().min(1, "Flow name cannot be empty").optional(),
-  output: z.string(),
-  timeout: z.number().int().positive("Timeout must be a positive integer"),
-  "no-prompt": z.boolean().optional(),
-  reset: z.boolean().optional(),
-  quiet: z.boolean().optional(),
+  "integration-id": z
+    .string()
+    .min(1)
+    .describe("ID of the integration containing the flow to listen to.")
+    .meta({ cli: { char: "i" } }),
+  "flow-id": z
+    .string()
+    .min(1)
+    .optional()
+    .describe("ID of the flow to listen to. If not provided, you will be prompted to select.")
+    .meta({ cli: { char: "f", exclusive: ["flow-name"] } }),
+  "flow-name": z
+    .string()
+    .min(1)
+    .optional()
+    .describe("Name of the flow to listen to.")
+    .meta({ cli: { char: "n", exclusive: ["flow-id"] } }),
+  output: z
+    .string()
+    .default(DEFAULT_OUTPUT_DIR)
+    .describe(`Output directory for the payload file. Defaults to ${DEFAULT_OUTPUT_DIR}`)
+    .meta({ cli: { char: "o" } }),
+  timeout: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(DEFAULT_TIMEOUT_SECONDS)
+    .describe("Timeout in seconds to stop listening.")
+    .meta({ cli: { char: "t" } }),
+  prompt: z
+    .boolean()
+    .optional()
+    .describe("Prompt before polling (use --no-prompt to poll automatically).")
+    .meta({ cli: { legacyName: "no-prompt" } }),
+  reset: z
+    .boolean()
+    .optional()
+    .describe("Manually turn off listening mode for a given integration.")
+    .meta({ cli: { char: "r" } }),
 });
-
 export type ListenFlags = z.infer<typeof listenFlagsSchema>;
 
-type ExecutionResult = NonNullable<GetExecutionsQuery["executionResults"]["nodes"][number]>;
-type PolledExecutionResult = GetPolledExecutionQuery;
-
-type TriggerType = "WEBHOOK" | "POLLING";
-
-export default class ListenCommand extends PrismaticBaseCommand {
-  private startTime = 0;
-  static description = "Listen for webhook executions on a flow and save the payload to a file";
-
-  static flags = {
-    "integration-id": Flags.string({
-      char: "i",
-      description: "ID of the integration containing the flow to listen to.",
-      required: true,
-    }),
-    "flow-id": Flags.string({
-      char: "f",
-      description: "ID of the flow to listen to. If not provided, you will be prompted to select.",
-      exclusive: ["flow-name"],
-    }),
-    "flow-name": Flags.string({
-      char: "n",
-      description: "Name of the flow to listen to.",
-      exclusive: ["flow-id"],
-    }),
-    output: Flags.string({
-      char: "o",
-      description: `Output directory for the payload file. Defaults to ${DEFAULT_OUTPUT_DIR}`,
-      default: DEFAULT_OUTPUT_DIR,
-    }),
-    timeout: Flags.integer({
-      char: "t",
-      description: "Timeout in seconds to stop listening.",
-      default: DEFAULT_TIMEOUT_SECONDS,
-    }),
-    "no-prompt": Flags.boolean({
-      char: "n",
-      description:
-        "For flows using polling triggers, automatically poll without a confirmation prompt.",
-    }),
-    reset: Flags.boolean({
-      char: "r",
-      description: "Manually turn off listening mode for a given integration.",
-    }),
-  };
-
-  async run() {
-    const { flags } = await this.parseWithSchema(listenFlagsSchema);
-
+export default defineCommand({
+  mutates: true,
+  output: executionEventSchema,
+  description: "Listen for webhook executions on a flow and save the payload to a file",
+  options: optionsSchema(listenFlagsSchema),
+  async *run(context): AsyncGenerator<ExecutionEvent> {
     const {
       "integration-id": integrationId,
       "flow-id": flowIdFlag,
       "flow-name": flowNameFlag,
       output,
       timeout,
-      quiet,
-      "no-prompt": noPrompt,
+      prompt,
       reset,
-    } = flags;
-
+    } = context.options;
+    const signal = context.var.signal;
     if (reset) {
-      return await safeSetListeningMode(integrationId, false, true);
+      await setListeningMode(integrationId, false);
+      yield { type: "listening", integrationId, listening: false };
+      yield { type: "completed", integrationId, status: "listening-disabled" };
+      return;
     }
-
-    const selectedFlow = await resolveFlow({
+    const flow = await resolveFlow({
       integrationId,
       flowId: flowIdFlag,
       flowName: flowNameFlag,
       promptMessage: "Select the flow to listen to:",
     });
-    const flowId = selectedFlow.id;
-    const triggerType = getTriggerType(selectedFlow.trigger);
-
-    await safeSetListeningMode(integrationId, true);
-    this.startTime = Date.now();
-
-    this.quietLog(
-      `To enable listening for this flow directly, you can run:\nprism integrations:flows:listen -i ${integrationId} -f ${flowId}\n`,
-      quiet,
-    );
-
-    if (triggerType === "WEBHOOK") {
-      this.quietLog("\nListening for webhook executions. Press CMD+C/CTRL+C to stop.\n", quiet);
-      this.quietLog(`This process will timeout after ${timeout / 60} minutes.\n`, quiet);
-
-      await withCleanup(integrationId, async () => {
-        const execution = await pollForWebhookExecutions(flowId, this.startTime, timeout);
-
-        if (execution) {
-          ux.action.start("Downloading payload...");
-          const filepath = await downloadAndSavePayload(
-            execution.requestPayloadUrl,
-            output,
-            flowId,
-            {
-              filePrefix: "payload",
-              useMsgpack: false,
-              triggerType,
-            },
-          );
-          this.quietLog(
-            `\nTo replay this payload, you can run:\nprism integrations:flows:test -i ${integrationId} -f ${flowId} -p ${filepath}\n`,
-            quiet,
-          );
-          ux.action.stop();
-        }
-      });
-    } else if (triggerType === "POLLING") {
-      this.quietLog("\nListening for poll executions. Press CMD+C/CTRL+C to stop.\n", quiet);
-
-      if (!noPrompt) {
-        this.quietLog(
-          "When you are ready to initiate a test poll for your flow, please confirm below.\n",
-          quiet,
-        );
-
-        const result = await inquirer.prompt({
-          type: "confirm",
-          name: "confirm",
-          message: "Initiate poll?",
+    const flowId = flow.id;
+    const triggerType = getTriggerType(flow.trigger);
+    if (triggerType === "POLLING" && prompt !== false) {
+      if (context.agent)
+        throw new Errors.IncurError({
+          code: "VALIDATION_ERROR",
+          exitCode: 2,
+          message: "Agent mode requires --no-prompt for polling flows",
         });
-
-        if (!result.confirm) {
-          await safeSetListeningMode(integrationId, false, false);
-          return;
-        }
-
-        this.quietLog(`This process will timeout after ${timeout / 60} minutes.\n`, quiet);
-      }
-
-      await withCleanup(integrationId, async () => {
-        let executionId: string;
-        try {
-          const result = await runIntegrationFlow({ integrationId, flowId });
-          executionId = result.executionId;
-        } catch (err) {
-          handleError({
-            message: "Failed to initiate poll test run.",
-            err,
-          });
-        }
-
-        while (true) {
-          if (hasTimedOut(this.startTime, timeout)) {
-            this.warn("Timeout reached. Stopping listener.");
-            return;
-          }
-
-          await ux.wait(getAdaptivePollIntervalMs(this.startTime));
-
-          let result: PolledExecutionResult;
-          try {
-            result = await getPolledExecution(executionId);
-          } catch (err) {
-            handleError({
-              message: "Failed to fetch poll execution status.",
-              err,
-            });
-          }
-
-          // Having an endedAt means the execution completed.
-          if (result.executionResult?.endedAt) {
-            const stepResult = result.executionResult.stepResults.nodes[0];
-            if (stepResult?.resultsUrl) {
-              ux.action.start("Downloading poll payload...");
-              const filepath = await downloadAndSavePayload(stepResult.resultsUrl, output, flowId, {
-                filePrefix: "poll-payload",
-                useMsgpack: true,
-                triggerType,
-              });
-              this.quietLog(
-                `\nTo replay this payload, you can run:\nprism integrations:flows:test -i ${integrationId} -f ${flowId} -p ${filepath}\n`,
-                quiet,
-              );
-              ux.action.stop();
-            }
-            return;
-          }
-        }
+      const { confirm } = await inquirer.prompt({
+        type: "confirm",
+        name: "confirm",
+        message: "Initiate poll?",
       });
+      if (!confirm) {
+        yield { type: "completed", integrationId, flowId, status: "listening-disabled" };
+        return;
+      }
     }
-  }
-}
-
-async function safeSetListeningMode(
-  integrationId: string,
-  isListening: boolean,
-  exitProcess = false,
-): Promise<void> {
-  try {
-    await setListeningMode(integrationId, isListening);
-  } catch (err) {
-    console.warn(
-      `Failed to ${isListening ? "enable" : "disable"} listening mode: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    );
-  } finally {
-    if (exitProcess) {
-      process.exit(0);
+    const startTime = Date.now();
+    const listenStartDate = new Date(startTime).toISOString();
+    let executionId: string | undefined;
+    let savedPath: string | undefined;
+    let timedOut = false;
+    try {
+      signal?.throwIfAborted();
+      await setListeningMode(integrationId, true);
+      yield { type: "listening", integrationId, listening: true };
+      if (triggerType === "POLLING") {
+        executionId = (await runIntegrationFlow({ integrationId, flowId })).executionId;
+        yield { type: "execution", executionId, integrationId, flowId };
+      }
+      while (true) {
+        if (hasTimedOut(startTime, timeout)) {
+          timedOut = true;
+          break;
+        }
+        await sleep(getAdaptivePollIntervalMs(startTime), undefined, { signal });
+        if (hasTimedOut(startTime, timeout)) {
+          timedOut = true;
+          break;
+        }
+        let url: string | undefined;
+        if (triggerType === "POLLING") {
+          const result = await gqlRequest({
+            document: GET_POLLED_EXECUTION,
+            variables: {
+              executionId:
+                executionId ??
+                (() => {
+                  throw new Error("Polling execution was not created");
+                })(),
+            },
+          });
+          if (!result.executionResult?.endedAt) continue;
+          url = result.executionResult.stepResults.nodes[0]?.resultsUrl ?? undefined;
+          if (!url) {
+            yield {
+              type: "warning",
+              message: "Execution completed without a downloadable poll payload.",
+            };
+            break;
+          }
+        } else {
+          const result = await gqlRequest({
+            document: GET_EXECUTIONS,
+            variables: {
+              limit: 1,
+              isTestExecution: true,
+              startDate: listenStartDate,
+              flowId,
+            },
+          });
+          const execution = result.executionResults.nodes[0];
+          if (!execution) continue;
+          if (executionId !== execution.id) {
+            executionId = execution.id;
+            yield { type: "execution", executionId, integrationId, flowId };
+          }
+          if (!execution.endedAt) continue;
+          url = execution.requestPayloadUrl;
+        }
+        savedPath = await downloadAndSavePayload(
+          url,
+          output,
+          flowId,
+          {
+            filePrefix: triggerType === "POLLING" ? "poll-payload" : "payload",
+            useMsgpack: triggerType === "POLLING",
+            triggerType,
+          },
+          signal,
+        );
+        if (savedPath && executionId)
+          yield { type: "payload", executionId, flowId, path: savedPath };
+        break;
+      }
+    } finally {
+      // Await remote cleanup on normal completion, error, and iterator.return().
+      await setListeningMode(integrationId, false);
     }
-  }
-}
-
-// Execute a function with cleanup handling for SIGINT and listening mode
-async function withCleanup(integrationId: string, fn: () => Promise<void>): Promise<void> {
-  const cleanup = async () => {
-    console.log("\nStopping listener...");
-    await safeSetListeningMode(integrationId, false, true);
-  };
-  process.on("SIGINT", cleanup);
-
-  try {
-    await fn();
-  } finally {
-    await safeSetListeningMode(integrationId, false, false);
-    process.removeListener("SIGINT", cleanup);
-  }
-}
+    yield { type: "listening", integrationId, listening: false };
+    yield {
+      type: "completed",
+      status: timedOut ? "timed-out" : "completed",
+      integrationId,
+      flowId,
+      ...(executionId ? { executionId } : {}),
+      ...(savedPath ? { path: savedPath } : {}),
+    };
+  },
+});
 
 async function setListeningMode(integrationId: string, isListening: boolean): Promise<void> {
   await gqlRequest({
     document: UPDATE_INTEGRATION_FLOW_LISTENING_MODE,
     variables: { integrationId, isListening },
   });
-  console.log(`Set listening mode to ${isListening} for integration ${integrationId}`);
-}
-
-async function pollForWebhookExecutions(
-  flowId: string,
-  startTime: number,
-  timeout: number,
-): Promise<ExecutionResult | null> {
-  const listenStartDate = new Date().toISOString();
-
-  while (true) {
-    await ux.wait(getAdaptivePollIntervalMs(startTime));
-
-    const result: ResultOf<typeof GET_EXECUTIONS> = await gqlRequest({
-      document: GET_EXECUTIONS,
-      variables: {
-        limit: 1,
-        isTestExecution: true,
-        startDate: listenStartDate,
-        flowId,
-      },
-    });
-
-    if (hasTimedOut(startTime, timeout)) {
-      console.warn("Timeout reached. Stopping listener.");
-      return null;
-    }
-
-    if (result.executionResults.nodes.length > 0) {
-      const execution = result.executionResults.nodes[0];
-
-      if (!execution?.endedAt) {
-        console.log(`\nExecution ${execution?.id} started, waiting for completion...`);
-        continue;
-      }
-
-      console.log("\nExecution complete.");
-      return execution;
-    }
-  }
 }
 
 async function downloadAndSavePayload(
@@ -310,13 +214,14 @@ async function downloadAndSavePayload(
   outputDir: string,
   flowId: string,
   options: { filePrefix: string; useMsgpack: boolean; triggerType: TriggerType },
+  signal?: AbortSignal,
 ): Promise<string | undefined> {
   try {
     if (!(await exists(outputDir))) {
       await fs.mkdir(outputDir, { recursive: true });
     }
 
-    const response = await fetch(url);
+    const response = await fetch(url, { signal });
     const arrayBuffer = await response.arrayBuffer();
     const resultsBuffer = Buffer.from(arrayBuffer);
 
@@ -364,7 +269,6 @@ async function downloadAndSavePayload(
     const fileName = `${outputDir}/${options.filePrefix}-${flowId}-${timestamp}.json`;
     await fs.writeFile(fileName, JSON.stringify(replayPayload, null, 2));
 
-    console.log(`\nPayload saved to: ${fileName}`);
     return fileName;
   } catch (err) {
     handleError({
@@ -376,13 +280,6 @@ async function downloadAndSavePayload(
 
 function hasTimedOut(startTime: number, timeout: number): boolean {
   return Date.now() - startTime > timeout * 1000;
-}
-
-async function getPolledExecution(executionId: string): Promise<PolledExecutionResult> {
-  return gqlRequest({
-    document: GET_POLLED_EXECUTION,
-    variables: { executionId },
-  });
 }
 
 export function getTriggerType(trigger: IntegrationFlow["trigger"]): TriggerType {

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,6 +164,7 @@ export const NativeCommands = {
   "instances:flow-configs:test": InstancesFlowConfigsTestCommand,
   "integrations:convert": IntegrationConvertCommand,
   "integrations:flows:list": IntegrationsFlowsListCommand,
+  "integrations:flows:listen": IntegrationsFlowsListenCommand,
   "integrations:flows:test": IntegrationsFlowsTestCommand,
   "integrations:init": IntegrationsInitCommand,
   "integrations:versions": IntegrationsVersionsCommand,
@@ -185,7 +186,6 @@ export const NativeCommands = {
 
 export const Commands = {
   "components:dev:run": ComponentsDevRunCommand,
-  "integrations:flows:listen": IntegrationsFlowsListenCommand,
   "graphql:query": GraphqlQueryCommand,
   ...Object.fromEntries(
     Object.entries(NativeCommands).map(([id, command]) => [id, asOclifCommand(id, command)]),

--- a/src/migration-contract.test.ts
+++ b/src/migration-contract.test.ts
@@ -22,7 +22,9 @@ describe("incremental native command contract", () => {
         for (const [name, field] of Object.entries(legacy.flags)) {
           if (["quiet", "profile", "print-requests"].includes(name)) continue;
           expect(command.contract.options[name], `${id} flag ${name}`).toBeDefined();
-          expect(command.contract.options[name].char).toBe((field as { char?: string }).char);
+          // Published -n collides; it belongs to --flow-name, while --no-prompt keeps its long form.
+          if (!(id === "integrations:flows:listen" && name === "no-prompt"))
+            expect(command.contract.options[name].char).toBe((field as { char?: string }).char);
         }
       }
       expect(normalizeCommandArguments([id, "--schema"])).toEqual([...id.split(":"), "--schema"]);


### PR DESCRIPTION
Stream listener events with request-scoped cleanup.

Part **20/24** of the native incur migration. This PR targets `incur-19-flow-tests`; the stack integrates into the long-lived `agent` branch. Review this diff against its immediate base.

Validation: format/lint, TypeScript, bundle, and **465 passing tests** (3 skipped) on Node 24. CI also checks Node 22/24/26 and Windows.

Review size: **680 handwritten changed lines**; counts include additions and deletions.

The temporary migration bridge keeps unmigrated commands on oclif and delegates migrated commands to incur. It is removed by the native-cutover PR. Contract coverage grows with each migrated command family.

[Stack review guide](https://github.com/prismatic-io/prism/blob/incur-24-review-evidence/docs/incur-pr-stack.md). Merge bottom-up; rebase descendants after a squash merge.
