### PR TITLE
[incur 21/24] Migrate component dev-run to native subprocess streams

### DIFF
--- a/src/commands/components/dev/run.test.ts
+++ b/src/commands/components/dev/run.test.ts
@@ -1,0 +1,52 @@
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { expect, it, vi } from "vitest";
+import { gqlRequest } from "../../../graphql.js";
+import { runCommand } from "../../../test-command.js";
+import RunCommand from "./run.js";
+
+vi.mock("../../../graphql.js", () => ({ gqlRequest: vi.fn() }));
+
+it("returns native subprocess stream events with a schema-valid completion", async () => {
+  vi.mocked(gqlRequest).mockResolvedValue({
+    integration: {
+      testConfigVariables: {
+        nodes: [
+          {
+            requiredConfigVariable: { key: "connection" },
+            inputs: { nodes: [{ name: "token", value: "test-token" }] },
+            meta: "{}",
+          },
+        ],
+      },
+    },
+  });
+  const directory = await mkdtemp(path.join(tmpdir(), "prism-dev-run-stream-"));
+  const script = path.join(directory, "child.cjs");
+  try {
+    await writeFile(
+      script,
+      'console.log(JSON.parse(process.env.PRISMATIC_CONNECTION_VALUE).fields.token); setTimeout(() => console.error("diagnostic"), 50);',
+    );
+    const events = await runCommand(RunCommand, [
+      "--agent",
+      "--yes",
+      "--integrationId",
+      "integration-id",
+      "--connectionKey",
+      "connection",
+      process.execPath,
+      script,
+    ]);
+    expect(events).toEqual([
+      { type: "stdout", data: "test-token\n" },
+      { type: "stderr", data: "diagnostic\n" },
+      { type: "completed", exitCode: 0 },
+    ]);
+    for (const event of events as unknown[])
+      expect(RunCommand.output?.safeParse(event).success).toBe(true);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/src/commands/components/dev/run.ts
+++ b/src/commands/components/dev/run.ts
@@ -1,11 +1,10 @@
-import type { ResultOf } from "@graphql-typed-document-node/core";
-import { InstanceDocument as INSTANCE } from "../../../graphql/operations/instance.generated.js";
 import { IntegrationDocument as INTEGRATION } from "../../../graphql/operations/integration.generated.js";
-import { Flags, ux } from "@oclif/core";
-import { isEmpty } from "lodash-es";
-import { PrismaticBaseCommand } from "../../../baseCommand.js";
+import { InstanceDocument as INSTANCE } from "../../../graphql/operations/instance.generated.js";
+import { commandOutput, defineCommand, argsSchema, optionsSchema } from "../../../command.js";
 import { gqlRequest } from "../../../graphql.js";
-import { spawnProcess } from "../../../utils/process.js";
+import { spawnProcess, streamProcess } from "../../../utils/process.js";
+import { ux } from "../../../utils/ux.js";
+import { z } from "incur";
 
 interface ConfigVariable {
   requiredConfigVariable: {
@@ -18,53 +17,63 @@ interface ConfigVariable {
   meta: unknown;
 }
 
-export default class RunCommand extends PrismaticBaseCommand {
-  static description =
-    "Fetch an integration's active connection and execute a CLI command with that connection's fields as an environment variable.\nAfter specifying an integration ID and connection config variable name, this command executes a CLI command with that connection's fields saved as a config variable named PRISMATIC_CONNECTION_VALUE.";
-  static usage = "components:dev:run -i <value> -c <value> -- /command/to/run";
-  static examples = [
+export default defineCommand({
+  mutates: true,
+  output: z.discriminatedUnion("type", [
+    z.object({ type: z.literal("stdout"), data: z.string() }),
+    z.object({ type: z.literal("stderr"), data: z.string() }),
+    z.object({ type: z.literal("completed"), exitCode: z.literal(0) }),
+  ]),
+  description:
+    "Fetch an integration's active connection and execute a CLI command with that connection's fields as an environment variable.\nAfter specifying an integration ID and connection config variable name, this command executes a CLI command with that connection's fields saved as a config variable named PRISMATIC_CONNECTION_VALUE.",
+  hint: "Pass the local command after -- (for example: -- yarn run test).",
+  examples: [
     {
-      description: `To simply print an integration's basic auth config variable named "My Connection" and pipe the resulting JSON to jq, run:`,
-      command: `<%= config.bin %> <%= command.id %> --integrationId SW50ZWexample --connectionKey "My Connection" -- printenv PRISMATIC_CONNECTION_VALUE | jq`,
+      description:
+        'To simply print an integration\'s basic auth config variable named "My Connection" and pipe the resulting JSON to jq, run:',
+      args: { command: ["printenv"] },
+      options: { integrationId: "SW50ZWexample", connectionKey: "My Connection" },
     },
     {
-      description: `If one of your integrations has an authenticated OAuth 2.0 config variable "Slack Connection", you could run your component's unit tests with that environment variable:`,
-      command: `<%= config.bin %> <%= command.id %> -i SW50ZWexample -c "Slack Connection" -- yarn run test`,
+      description:
+        'If one of your integrations has an authenticated OAuth 2.0 config variable "Slack Connection", you could run your component\'s unit tests with that environment variable:',
+      args: { command: ["yarn"] },
+      options: { integrationId: "SW50ZWexample", connectionKey: "Slack Connection" },
     },
     {
       description:
         "If you would like to fetch a connection from an instance deployed to one of your customers, specify the --instanceId flag instead",
-      command: `<%= config.bin %> <%= command.id %> --instanceId SW50ZWexample -c "Slack Connection" -- yarn run test`,
+      args: { command: ["yarn"] },
+      options: { instanceId: "SW50ZWexample", connectionKey: "Slack Connection" },
     },
-  ];
-
-  static strict = false; // Manual capture of argv so we can get the wrapped command
-  static "--" = true; // Stop parsing flags if -- is encountered as an arg
-
-  static flags = {
-    integrationId: Flags.string({
-      char: "i",
-      description: "Integration ID",
-      exactlyOne: ["instanceId", "integrationId"],
+  ],
+  args: argsSchema(
+    z.object({
+      command: z.array(z.string()).optional().describe("Local command and arguments to run"),
     }),
-    instanceId: Flags.string({
-      description: "Instance ID. ",
+  ),
+  options: optionsSchema(
+    z.object({
+      integrationId: z
+        .string()
+        .optional()
+        .describe("Integration ID")
+        .meta({ cli: { char: "i", exactlyOne: ["instanceId", "integrationId"] } }),
+      instanceId: z.string().optional().describe("Instance ID. "),
+      connectionKey: z
+        .string()
+        .describe("Key of the connection config variable to fetch meta/state for")
+        .meta({ cli: { char: "c" } }),
     }),
-    connectionKey: Flags.string({
-      required: true,
-      char: "c",
-      description: "Key of the connection config variable to fetch meta/state for",
-    }),
-  };
-
-  async run() {
+  ),
+  async *run(context) {
     const {
-      argv,
-      flags: { integrationId, instanceId, connectionKey },
-    } = await this.parse(RunCommand);
+      args: { command: argv },
+      options: { integrationId, instanceId, connectionKey },
+    } = context;
 
-    if (isEmpty(argv)) {
-      this.error(
+    if (!argv?.length) {
+      commandOutput.error(
         "A command to run must be supplied after a double dash (--) delimiter. See examples in this command's help for details.",
       );
     }
@@ -73,7 +82,7 @@ export default class RunCommand extends PrismaticBaseCommand {
 
     // Get connection from the integration's test instance
     if (integrationId) {
-      const result: ResultOf<typeof INTEGRATION> = await gqlRequest({
+      const result = await gqlRequest({
         document: INTEGRATION,
         variables: {
           id: integrationId,
@@ -81,18 +90,20 @@ export default class RunCommand extends PrismaticBaseCommand {
       });
 
       configVariables =
-        result.integration?.testConfigVariables.nodes ?? this.error("Integration was not found");
+        result.integration?.testConfigVariables.nodes ??
+        commandOutput.error("Integration was not found");
     } else {
+      if (!instanceId) commandOutput.error("Either integrationId or instanceId is required");
       // Get the config variable from an instance
-      const result: ResultOf<typeof INSTANCE> = await gqlRequest({
+      const result = await gqlRequest({
         document: INSTANCE,
         variables: {
-          id: instanceId ?? this.error("Instance ID is required"),
+          id: instanceId,
         },
       });
 
       configVariables =
-        result.instance?.configVariables.nodes ?? this.error("Instance was not found");
+        result.instance?.configVariables.nodes ?? commandOutput.error("Instance was not found");
     }
 
     const [connection] = configVariables.filter(
@@ -121,6 +132,11 @@ export default class RunCommand extends PrismaticBaseCommand {
       fields,
     });
 
-    await spawnProcess(argv as string[], { PRISMATIC_CONNECTION_VALUE: value });
-  }
-}
+    const environment = { PRISMATIC_CONNECTION_VALUE: value };
+    if (context.agent) {
+      yield* streamProcess(argv, environment, { signal: context.var.signal });
+    } else {
+      await spawnProcess(argv, environment, { signal: context.var.signal });
+    }
+  },
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,6 +148,7 @@ export const NativeCommands = {
   "alerts:webhooks:list": AlertsWebhooksListCommand,
   "components:actions:list": ComponentsActionsListCommand,
   "components:data-sources:list": ComponentsDataSourcesListCommand,
+  "components:dev:run": ComponentsDevRunCommand,
   "components:dev:test": ComponentsDevTestCommand,
   "components:init:component": ComponentsInitComponentCommand,
   "components:init": ComponentsInitCommand,
@@ -185,7 +186,6 @@ export const NativeCommands = {
 };
 
 export const Commands = {
-  "components:dev:run": ComponentsDevRunCommand,
   "graphql:query": GraphqlQueryCommand,
   ...Object.fromEntries(
     Object.entries(NativeCommands).map(([id, command]) => [id, asOclifCommand(id, command)]),


### PR DESCRIPTION
Migrate component dev-run to native subprocess streams.

Part **21/24** of the native incur migration. This PR targets `incur-20-listener`; the stack integrates into the long-lived `agent` branch. Review this diff against its immediate base.

Validation: format/lint, TypeScript, bundle, and **467 passing tests** (3 skipped) on Node 24. CI also checks Node 22/24/26 and Windows.

Review size: **172 handwritten changed lines**; counts include additions and deletions.

The temporary migration bridge keeps unmigrated commands on oclif and delegates migrated commands to incur. It is removed by the native-cutover PR. Contract coverage grows with each migrated command family.

[Stack review guide](https://github.com/prismatic-io/prism/blob/incur-24-review-evidence/docs/incur-pr-stack.md). Merge bottom-up; rebase descendants after a squash merge.
