### PR TITLE
[incur 22/24] Migrate GraphQL and completion commands and verify structured results

### DIFF
--- a/src/commands/autocomplete/index.ts
+++ b/src/commands/autocomplete/index.ts
@@ -1,0 +1,108 @@
+import {
+  commandOutput,
+  defineCommand,
+  writeCommandOutput,
+  argsSchema,
+  optionsSchema,
+} from "../../command.js";
+import { z } from "incur";
+
+const zshInstructions = `
+Setup Instructions for PRISM CLI Autocomplete ---
+==============================================
+
+1) Run this command in your terminal window:
+
+  printf "$(prism autocomplete:script zsh)" >> ~/.zshrc; source ~/.zshrc
+
+  The previous command adds the PRISM_AC_ZSH_SETUP_PATH environment variable to your zsh config file and then sources the file.
+
+2) (Optional) Run this command to ensure that you have no permissions conflicts:
+
+  compaudit -D
+
+3) Start using autocomplete:
+
+  prism <TAB>                  # Command completion
+  prism command --<TAB>        # Flag completion
+  
+  Every time you enter <TAB>, the autocomplete feature displays a list of commands (or flags if you type --), along with their summaries. Enter a letter and then <TAB> again to narrow down the list until you end up with the complete command that you want to execute.
+
+  Enjoy!
+`;
+
+const bashInstructions = `
+Setup Instructions for PRISM CLI Autocomplete ---
+==============================================
+
+1) Run this command in your terminal window:
+
+  printf "$(prism autocomplete:script bash)" >> ~/.bashrc; source ~/.bashrc
+
+  The previous command adds the PRISM_AC_BASH_SETUP_PATH environment variable to your Bash config file and then sources the file.
+
+  NOTE: If you’ve configured your terminal to start as a login shell, you may need to modify the command so it updates either the ~/.bash_profile or ~/.profile file. For example:
+
+  printf "$(prism autocomplete:script bash)" >> ~/.bash_profile; source ~/.bash_profile
+
+  Or:
+
+  printf "$(prism autocomplete:script bash)" >> ~/.profile; source ~/.profile
+
+2) Start using autocomplete:
+
+  prism <TAB><TAB>                  # Command completion
+  prism command --<TAB><TAB>        # Flag completion
+  
+  Every time you enter <TAB><TAB>, the autocomplete feature displays a list of commands (or flags if you type --), along with their summaries. Enter a letter and then <TAB><TAB> again to narrow down the list until you end up with the complete command that you want to execute.
+
+  Enjoy!
+`;
+
+export default defineCommand({
+  outputPolicy: "agent-only",
+  output: z.object({
+    shell: z.enum(["bash", "zsh"]).optional(),
+    instructions: z.string(),
+    refreshed: z.boolean(),
+  }),
+  description: "Display autocomplete installation instructions.",
+  args: argsSchema(
+    z.object({
+      shell: z.enum(["zsh", "bash", "powershell"]).optional(),
+    }),
+  ),
+  options: optionsSchema(
+    z.object({
+      "refresh-cache": z
+        .boolean()
+        .optional()
+        .describe("Refresh cache (ignores displaying instructions)")
+        .meta({ cli: { char: "r" } }),
+    }),
+  ),
+  examples: [
+    {},
+    { args: { shell: "bash" } },
+    { args: { shell: "zsh" } },
+    { args: { shell: "powershell" } },
+    { options: { "refresh-cache": true } },
+  ],
+  run(context) {
+    const {
+      args: { shell },
+      options: { "refresh-cache": refreshCache },
+    } = context;
+    writeCommandOutput("Building the autocomplete cache... done", "stderr");
+    if (refreshCache) return { instructions: "", refreshed: true };
+    const selectedShell = shell ?? (process.env.SHELL?.endsWith("bash") ? "bash" : "zsh");
+    if (selectedShell === "powershell") {
+      commandOutput.error(
+        "PowerShell completion is not supported in CLIs using colon as the topic separator.\nSee: https://oclif.io/docs/topic_separator",
+      );
+    }
+    const instructions = selectedShell === "bash" ? bashInstructions : zshInstructions;
+    writeCommandOutput(instructions);
+    return { shell: selectedShell, instructions, refreshed: false };
+  },
+});

--- a/src/commands/autocomplete/script.ts
+++ b/src/commands/autocomplete/script.ts
@@ -1,0 +1,28 @@
+import { Completions, z } from "incur";
+import { commandOutput, writeCommandOutput, defineCommand, argsSchema } from "../../command.js";
+
+export default defineCommand({
+  outputPolicy: "agent-only",
+  output: z.object({ shell: z.enum(["bash", "zsh"]).optional(), script: z.string() }),
+  description: "outputs autocomplete config script for shells",
+  args: argsSchema(
+    z.object({
+      shell: z.enum(["zsh", "bash", "powershell"]).optional(),
+    }),
+  ),
+  run(context) {
+    const {
+      args: { shell },
+    } = context;
+    if (!shell) return { script: "" };
+    if (shell === "powershell") {
+      commandOutput.error(
+        "PowerShell completion is not supported in CLIs using colon as the topic separator.\nSee: https://oclif.io/docs/topic_separator",
+      );
+    }
+    if (shell !== "bash" && shell !== "zsh") commandOutput.error(`Unsupported shell: ${shell}`);
+    const script = Completions.register(shell, "prism");
+    writeCommandOutput(script);
+    return { shell, script };
+  },
+});

--- a/src/commands/graphql/query.test.ts
+++ b/src/commands/graphql/query.test.ts
@@ -1,0 +1,99 @@
+import { runCommand } from "../../test-command.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { runWithMcpTransport } from "../../command.js";
+import { gqlRequest } from "../../graphql.js";
+import GraphqlQueryCommand, { hasMutationOperation } from "./query.js";
+
+vi.mock("../../graphql.js", () => ({
+  gqlRequest: vi.fn(async () => ({ viewer: { id: "viewer-id" } })),
+}));
+
+describe("graphql query operation safety", () => {
+  beforeEach(() => vi.mocked(gqlRequest).mockClear());
+
+  it("classifies parsed operations rather than matching mutation text", () => {
+    expect(hasMutationOperation('query { search(term: "mutation") }')).toBe(false);
+    expect(hasMutationOperation("mutation Rename { updateOrganization(input: {}) { id } }")).toBe(
+      true,
+    );
+  });
+
+  it("allows query operations in agent read-only mode", async () => {
+    await expect(
+      runCommand(GraphqlQueryCommand, ["--agent", "--read-only", "query Viewer { viewer { id } }"]),
+    ).resolves.toMatchObject({ success: true });
+    expect(gqlRequest).toHaveBeenCalledOnce();
+  });
+
+  it("requires agent approval before executing mutation operations", async () => {
+    await expect(
+      runCommand(GraphqlQueryCommand, [
+        "--agent",
+        "mutation { updateOrganization(input: {}) { id } }",
+      ]),
+    ).rejects.toMatchObject({ code: "CONFIRMATION_REQUIRED", exitCode: 2 });
+    expect(gqlRequest).not.toHaveBeenCalled();
+
+    await expect(
+      runCommand(GraphqlQueryCommand, [
+        "--agent",
+        "--yes",
+        "mutation { updateOrganization(input: {}) { id } }",
+      ]),
+    ).resolves.toMatchObject({ success: true });
+    expect(gqlRequest).toHaveBeenCalledOnce();
+  });
+
+  it("rejects mutation operations in read-only mode even with approval", async () => {
+    await expect(
+      runCommand(GraphqlQueryCommand, [
+        "--agent",
+        "--yes",
+        "--read-only",
+        "mutation { updateOrganization(input: {}) { id } }",
+      ]),
+    ).rejects.toMatchObject({ code: "READ_ONLY", exitCode: 2 });
+    expect(gqlRequest).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid documents before making a request", async () => {
+    await expect(runCommand(GraphqlQueryCommand, ["--agent", "query {"])).rejects.toMatchObject({
+      exitCode: 2,
+    });
+    expect(gqlRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe("GraphQL agent results", () => {
+  it.each(["json", "yaml"])("returns typed data for legacy %s formatting", async (format) => {
+    await expect(
+      runCommand(GraphqlQueryCommand, ["--agent", "query { viewer { id } }", "--output", format]),
+    ).resolves.toEqual({ success: true, data: { viewer: { id: "viewer-id" } } });
+  });
+  it("returns the selected table rows", async () => {
+    await expect(
+      runCommand(GraphqlQueryCommand, [
+        "--agent",
+        "query { viewer { id } }",
+        "--output",
+        "table",
+        "--data-path",
+        "viewer",
+        "--columns",
+        "id",
+      ]),
+    ).resolves.toEqual({ success: true, data: { items: [{ id: "viewer-id" }] } });
+  });
+});
+
+it("rejects reading MCP stdin before attaching listeners or making a query", async () => {
+  vi.mocked(gqlRequest).mockClear();
+  const listeners = process.stdin.eventNames().map((name) => [name, process.stdin.listeners(name)]);
+  await expect(
+    runWithMcpTransport(() => runCommand(GraphqlQueryCommand, ["--agent"])),
+  ).rejects.toMatchObject({ code: "STDIN_UNAVAILABLE" });
+  expect(process.stdin.eventNames().map((name) => [name, process.stdin.listeners(name)])).toEqual(
+    listeners,
+  );
+  expect(gqlRequest).not.toHaveBeenCalled();
+});

--- a/src/commands/graphql/query.ts
+++ b/src/commands/graphql/query.ts
@@ -1,195 +1,242 @@
-import { Args, Flags } from "@oclif/core";
-import { readFileSync } from "fs";
-import { PrismaticBaseCommand } from "../../baseCommand.js";
+import { readFile } from "node:fs/promises";
+import { Kind, parse } from "graphql";
+import {
+  assertMutationAllowed,
+  assertCommandStdinAvailable,
+  commandOutput,
+  writeCommandOutput,
+  defineCommand,
+  argsSchema,
+  optionsSchema,
+} from "../../command.js";
 import { gqlRequest } from "../../graphql.js";
 import { dumpYaml } from "../../utils/serialize.js";
-import { ux } from "../../utils/legacy-ux.js";
+import { ux } from "../../utils/ux.js";
+import { z } from "incur";
 
-export default class QueryCommand extends PrismaticBaseCommand {
-  static description = "Execute an arbitrary GraphQL query against the Prismatic API";
+const variablesSchema = z.record(z.string(), z.unknown());
 
-  static examples = [
+export const hasMutationOperation = (document: string): boolean =>
+  parse(document).definitions.some(
+    (definition) =>
+      definition.kind === Kind.OPERATION_DEFINITION && definition.operation === "mutation",
+  );
+
+const readObjectProperty = (value: unknown, key: string): unknown => {
+  if ((typeof value !== "object" && typeof value !== "function") || value === null) {
+    return undefined;
+  }
+
+  return Reflect.get(value, key);
+};
+async function readStdin(): Promise<string> {
+  assertCommandStdinAvailable();
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.setEncoding("utf8");
+    process.stdin.on("data", (chunk) => {
+      data += chunk;
+    });
+    process.stdin.on("end", () => {
+      resolve(data.trim());
+    });
+    process.stdin.on("error", reject);
+  });
+}
+
+async function readVariables(variablesInput: string): Promise<Record<string, unknown>> {
+  let parsed: unknown;
+  if (variablesInput.startsWith("@")) {
+    const filePath = variablesInput.slice(1);
+    const fileContent = await readFile(filePath, { encoding: "utf-8" });
+    parsed = JSON.parse(fileContent);
+  } else {
+    parsed = JSON.parse(variablesInput);
+  }
+
+  return variablesSchema.parse(parsed);
+}
+
+function getNestedValue(obj: unknown, path: string): unknown {
+  return path.split(".").reduce<unknown>(readObjectProperty, obj);
+}
+
+function formatTableOutput(data: unknown, columns: string[]) {
+  const items: unknown[] = Array.isArray(data) ? data : [data];
+
+  const columnDefs: Record<string, { header: string; get: (row: unknown) => string }> = {};
+  for (const col of columns) {
+    columnDefs[col] = {
+      header: col.toUpperCase(),
+      get: (row: unknown) => {
+        const value = getNestedValue(row, col);
+        return value !== undefined && value !== null ? String(value) : "";
+      },
+    };
+  }
+
+  return ux.table(items, columnDefs);
+}
+
+export default defineCommand({
+  outputPolicy: "agent-only",
+  destructive: true,
+  output: z.object({
+    success: z.literal(true),
+    data: z.json(),
+    warnings: z.array(z.string()).optional(),
+  }),
+  description: "Execute an arbitrary GraphQL query against the Prismatic API",
+  examples: [
     {
       description: "Direct query string",
-      command: "<%= config.bin %> <%= command.id %> 'query { customers { nodes { id name } } }'",
+      args: { query: "query { customers { nodes { id name } } }" },
     },
-    {
-      description: "From file",
-      command: "<%= config.bin %> <%= command.id %> --file query.graphql",
-    },
-    {
-      description: "From stdin",
-      command: "cat query.graphql | <%= config.bin %> <%= command.id %>",
-    },
+    { description: "From file", args: { query: "query.graphql" }, options: { file: true } },
+    { description: "From stdin", args: { query: "cat" } },
     {
       description: "With variables",
-      command:
-        '<%= config.bin %> <%= command.id %> --file query.graphql --variables \'{"id":"Q3VzdG9tZXI6..."}\'',
+      args: { query: "query.graphql" },
+      options: { file: true, variables: '{"id":"Q3VzdG9tZXI6..."}' },
     },
     {
       description: "Variables from file",
-      command:
-        "<%= config.bin %> <%= command.id %> 'query($id: ID!) { customer(id: $id) { name } }' --variables @vars.json",
+      args: { query: "query($id: ID!) { customer(id: $id) { name } }" },
+      options: { variables: "@vars.json" },
     },
     {
       description: "YAML output",
-      command:
-        "<%= config.bin %> <%= command.id %> 'query { customers { nodes { id name } } }' --output yaml",
+      args: { query: "query { customers { nodes { id name } } }" },
+      options: { output: "yaml" },
     },
     {
       description: "Table output with nested data",
-      command:
-        "<%= config.bin %> <%= command.id %> 'query { customers { nodes { id name } } }' --output table --data-path customers.nodes --columns id,name",
+      args: { query: "query { customers { nodes { id name } } }" },
+      options: { output: "table", "data-path": "customers.nodes", columns: "id,name" },
     },
-  ];
-
-  static args = {
-    query: Args.string({
-      description: "GraphQL query string (omit to read from stdin)",
-      required: false,
+  ],
+  args: argsSchema(
+    z.object({
+      query: z.string().optional().describe("GraphQL query string (omit to read from stdin)"),
     }),
-  };
-
-  static flags = {
-    file: Flags.boolean({
-      char: "f",
-      description: "Treat query argument as file path",
-      default: false,
+  ),
+  options: optionsSchema(
+    z.object({
+      file: z
+        .boolean()
+        .default(false)
+        .describe("Treat query argument as file path")
+        .meta({ cli: { char: "f" } }),
+      variables: z
+        .string()
+        .optional()
+        .describe("JSON string or @file.json containing query variables")
+        .meta({ cli: { char: "v" } }),
+      output: z
+        .enum(["json", "yaml", "table"])
+        .default("json")
+        .describe("Output format")
+        .meta({ cli: { char: "o" } }),
+      columns: z
+        .string()
+        .optional()
+        .describe("Comma-separated field paths for table columns (required for table output)")
+        .meta({ cli: { char: "c" } }),
+      "data-path": z
+        .string()
+        .optional()
+        .describe("Dot-notation path to array data in result (e.g., 'customers.nodes')")
+        .meta({ cli: { char: "d" } }),
+      raw: z
+        .boolean()
+        .default(false)
+        .describe("Output raw JSON without pretty-printing")
+        .meta({ cli: { char: "r" } }),
     }),
-    variables: Flags.string({
-      char: "v",
-      description: "JSON string or @file.json containing query variables",
-    }),
-    output: Flags.string({
-      char: "o",
-      description: "Output format",
-      options: ["json", "yaml", "table"],
-      default: "json",
-    }),
-    columns: Flags.string({
-      char: "c",
-      description: "Comma-separated field paths for table columns (required for table output)",
-    }),
-    "data-path": Flags.string({
-      char: "d",
-      description: "Dot-notation path to array data in result (e.g., 'customers.nodes')",
-    }),
-    raw: Flags.boolean({
-      char: "r",
-      description: "Output raw JSON without pretty-printing",
-      default: false,
-    }),
-  };
-
-  private async readStdin(): Promise<string> {
-    return new Promise((resolve, reject) => {
-      let data = "";
-      process.stdin.setEncoding("utf8");
-      process.stdin.on("data", (chunk) => {
-        data += chunk;
-      });
-      process.stdin.on("end", () => {
-        resolve(data.trim());
-      });
-      process.stdin.on("error", reject);
-    });
-  }
-
-  private readVariables(variablesInput: string): Record<string, any> {
-    if (variablesInput.startsWith("@")) {
-      const filePath = variablesInput.slice(1);
-      const fileContent = readFileSync(filePath, { encoding: "utf-8" });
-      return JSON.parse(fileContent);
-    }
-
-    return JSON.parse(variablesInput);
-  }
-
-  private getNestedValue(obj: any, path: string): any {
-    return path.split(".").reduce((current, key) => current?.[key], obj);
-  }
-
-  private formatTableOutput(data: any, columns: string[]): void {
-    const items = Array.isArray(data) ? data : [data];
-
-    const columnDefs: Record<string, any> = {};
-    for (const col of columns) {
-      columnDefs[col] = {
-        header: col.toUpperCase(),
-        get: (row: any) => {
-          const value = this.getNestedValue(row, col);
-          return value !== undefined && value !== null ? String(value) : "";
-        },
-      };
-    }
-
-    ux.table(items, columnDefs);
-  }
-
-  async run() {
-    const { args, flags } = await this.parse(QueryCommand);
+  ),
+  async run(context) {
+    const { args, options: flags } = context;
 
     let queryString: string;
 
     if (flags.file && args.query) {
-      queryString = readFileSync(args.query, { encoding: "utf-8" });
+      queryString = await readFile(args.query, { encoding: "utf-8" });
     } else if (args.query) {
       queryString = args.query;
     } else {
       if (process.stdin.isTTY) {
-        this.error(
+        commandOutput.error(
           "No query provided. Please provide a query as an argument, use --file, or pipe via stdin.",
         );
       }
-      queryString = await this.readStdin();
+      queryString = await readStdin();
     }
 
     if (!queryString.trim()) {
-      this.error("Query string is empty");
+      commandOutput.error("Query string is empty");
     }
 
-    let variables: Record<string, any> | undefined;
+    let mutates = false;
+    try {
+      mutates = hasMutationOperation(queryString);
+    } catch (error) {
+      commandOutput.error(
+        `Invalid GraphQL document: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    if (mutates) assertMutationAllowed(context);
+
+    let variables: Record<string, unknown> | undefined;
     if (flags.variables) {
       try {
-        variables = this.readVariables(flags.variables);
+        variables = await readVariables(flags.variables);
       } catch (error) {
-        this.error(
+        commandOutput.error(
           `Failed to parse variables: ${error instanceof Error ? error.message : String(error)}`,
         );
       }
     }
 
-    let result: any;
+    let result: unknown;
     try {
       result = await gqlRequest({
         document: queryString,
         variables,
       });
     } catch (error) {
-      this.error(`GraphQL query failed: ${error instanceof Error ? error.message : String(error)}`);
+      commandOutput.error(
+        `GraphQL query failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
     }
+
+    if (context.agent && flags.output !== "table")
+      return { success: true as const, data: z.json().parse(result) };
 
     switch (flags.output) {
       case "yaml":
-        this.log(dumpYaml(result));
+        writeCommandOutput(dumpYaml(result));
         break;
 
       case "table": {
         if (!flags.columns) {
-          this.error("Table output requires --columns flag. Specify comma-separated field paths.");
+          commandOutput.error(
+            "Table output requires --columns flag. Specify comma-separated field paths.",
+          );
         }
-        const columns = flags.columns.split(",").map((c) => c.trim());
-        const data = flags["data-path"] ? this.getNestedValue(result, flags["data-path"]) : result;
-        this.formatTableOutput(data, columns);
+        const columns = flags.columns.split(",").map((c: string) => c.trim());
+        const data = flags["data-path"] ? getNestedValue(result, flags["data-path"]) : result;
+        const table = formatTableOutput(data, columns);
+        if (context.agent) return { success: true as const, data: z.json().parse(table) };
         break;
       }
       default:
         if (flags.raw) {
-          this.log(JSON.stringify(result));
+          writeCommandOutput(JSON.stringify(result));
         } else {
-          this.log(JSON.stringify(result, null, 2));
+          writeCommandOutput(JSON.stringify(result, null, 2));
         }
         break;
     }
-  }
-}
+    return { success: true as const, data: z.json().parse(result) };
+  },
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
+import AutocompleteCommand from "./commands/autocomplete/index.js";
+import AutocompleteScriptCommand from "./commands/autocomplete/script.js";
 import LoginCommand from "./commands/login/index.js";
 import LoginSwitchCommand from "./commands/login/switch.js";
 import LogoutCommand from "./commands/logout.js";
@@ -93,6 +95,8 @@ import { asOclifCommand } from "./migration-bridge.js";
 
 // During the stack, native commands run through incur while remaining commands keep oclif.
 export const NativeCommands = {
+  autocomplete: AutocompleteCommand,
+  "autocomplete:script": AutocompleteScriptCommand,
   login: LoginCommand,
   "login:switch": LoginSwitchCommand,
   logout: LogoutCommand,
@@ -183,10 +187,10 @@ export const NativeCommands = {
   "organization:users:update": OrganizationUsersUpdateCommand,
   "workflows:export": WorkflowsExportCommand,
   "workflows:import": WorkflowsImportCommand,
+  "graphql:query": GraphqlQueryCommand,
 };
 
 export const Commands = {
-  "graphql:query": GraphqlQueryCommand,
   ...Object.fromEntries(
     Object.entries(NativeCommands).map(([id, command]) => [id, asOclifCommand(id, command)]),
   ),

--- a/src/output.test.ts
+++ b/src/output.test.ts
@@ -1,0 +1,226 @@
+import { runCommandInput } from "./test-command.js";
+import { execFileSync } from "node:child_process";
+import { Cli, z } from "incur";
+import { describe, expect, it, vi } from "vitest";
+import { getStdout } from "../vitest.setup.js";
+import {
+  commandOutput,
+  defineCommand,
+  globalOptions,
+  environmentOptions,
+  commandVars,
+  commandMiddleware,
+} from "./command.js";
+import CreateCustomer from "./commands/customers/create.js";
+import DeployInstance from "./commands/instances/deploy.js";
+import ForkIntegration from "./commands/integrations/fork.js";
+import Me from "./commands/me/index.js";
+import Token from "./commands/me/token.js";
+import ExportWorkflow from "./commands/workflows/export.js";
+import { getAuthContext } from "./context.js";
+import { gqlRequest } from "./graphql.js";
+import { resourceOutput, resourceOutputSchema } from "./output.js";
+
+vi.mock(import("./graphql.js"), () => ({ gqlRequest: vi.fn() }));
+
+const context = (agent: boolean) => ({
+  agent,
+  args: {},
+  options: {},
+  globals: { yes: true },
+  formatExplicit: agent,
+});
+
+describe("resource results", () => {
+  it("preserves warnings alongside named results and incur CTAs", async () => {
+    const command = defineCommand({
+      output: resourceOutputSchema("integrationId"),
+      run(c) {
+        commandOutput.warn("Some config variables are missing");
+        return resourceOutput(c, "integrationId", "integration-1");
+      },
+    });
+    const writes: string[] = [];
+    await Cli.create("prism", {
+      globals: globalOptions,
+      env: environmentOptions,
+      vars: commandVars,
+    })
+      .use(commandMiddleware)
+      .command("test", command)
+      .serve(["test", "--json", "--full-output"], {
+        stdout: (value) => writes.push(value),
+        exit: () => {},
+      });
+    const result = JSON.parse(writes.join(""));
+    expect(result.data).toEqual({
+      integrationId: "integration-1",
+      warnings: ["Some config variables are missing"],
+    });
+    expect(command.output.safeParse(result.data).success).toBe(true);
+    expect(result.meta.cta.commands).toHaveLength(1);
+  });
+
+  it.each([
+    "QA Team",
+    "Ryan's Development",
+    "$(printf expanded)",
+  ])("keeps profile %s as one literal CTA argument", async (profile) => {
+    const command = defineCommand({
+      output: resourceOutputSchema("integrationId"),
+      run(c) {
+        return resourceOutput(
+          { ...c, globals: { ...c.globals, profile } },
+          "integrationId",
+          "integration-1",
+        );
+      },
+    });
+    const writes: string[] = [];
+    await Cli.create("prism", {
+      globals: globalOptions,
+      env: environmentOptions,
+      vars: commandVars,
+    })
+      .use(commandMiddleware)
+      .command("test", command)
+      .serve(["test", "--json", "--full-output"], {
+        stdout: (value) => writes.push(value),
+        exit: () => {},
+      });
+    const commandText = JSON.parse(writes.join("")).meta.cta.commands[0].command;
+    // Parse the rendered suggestion with a shell without executing the suggested command.
+    // Git for Windows supplies sh.exe on Windows CI.
+    const shell = process.platform === "win32" ? "sh.exe" : "/bin/sh";
+    const parsed = execFileSync(shell, ["-c", `set -- ${commandText}; printf '%s\\n' "$@"`], {
+      encoding: "utf8",
+    })
+      .trimEnd()
+      .split("\n");
+    expect(parsed).toEqual([
+      "prism",
+      "integrations",
+      "flows",
+      "list",
+      "integration-1",
+      "--profile",
+      profile,
+    ]);
+  });
+  it.each([
+    [
+      CreateCustomer,
+      { createCustomer: { customer: { id: "customer-1" } } },
+      "customerId",
+      "customer-1",
+      { options: { name: "Example" } },
+    ],
+    [
+      DeployInstance,
+      { deployInstance: { instance: { id: "instance-1" } } },
+      "instanceId",
+      "instance-1",
+      { args: { instance: "instance-1" } },
+    ],
+    [
+      ForkIntegration,
+      { forkIntegration: { integration: { id: "integration-1" } } },
+      "integrationId",
+      "integration-1",
+      {
+        args: { parent: "parent-1" },
+        options: { name: "Fork", description: "Forked integration" },
+      },
+    ],
+  ] as const)("returns a named resource through native human and agent execution", async (command, response, field, id, input) => {
+    vi.mocked(gqlRequest).mockResolvedValue(response);
+    const human = await runCommandInput(command, { ...context(false), ...input });
+    expect(getStdout()).toContain(id);
+    expect(human).toEqual({ [field]: id });
+    expect(command.output.safeParse(human).success).toBe(true);
+    const agent = await runCommandInput(command, { ...context(true), ...input });
+    expect(agent).toEqual({ [field]: id });
+    expect(getStdout()).toContain(id);
+  });
+
+  it("returns the access token directly with its type", async () => {
+    const result = await runCommandInput(Token, { ...context(true), options: { type: "access" } });
+    expect(result).toEqual({ token: "test-token", type: "access" });
+    expect(Token.output.safeParse(result).success).toBe(true);
+    expect(getStdout()).toBe("");
+  });
+
+  it("exports reusable YAML as a named definition", async () => {
+    vi.mocked(gqlRequest).mockResolvedValue({ workflow: { definition: "name: Example\n" } });
+    const result = await runCommandInput(ExportWorkflow, {
+      ...context(true),
+      args: { workflow: "workflow-1" },
+    });
+    expect(result).toEqual({ definition: "name: Example\n" });
+    expect(ExportWorkflow.output.safeParse(result).success).toBe(true);
+    expect(getStdout()).toBe("");
+    await runCommandInput(ExportWorkflow, { ...context(false), args: { workflow: "workflow-1" } });
+    expect(getStdout()).toContain("definition:");
+    expect(getStdout()).toContain("Example");
+  });
+
+  it("returns profile identity as fields without exposing authentication credentials", async () => {
+    vi.mocked(getAuthContext).mockResolvedValue({
+      source: "profile",
+      profileName: "development",
+      url: "https://example.com",
+      accessToken: "private-access",
+      refreshToken: "private-refresh",
+    });
+    vi.mocked(gqlRequest).mockResolvedValue({
+      authenticatedUser: {
+        name: "Example User",
+        email: "user@example.com",
+        tenantId: "tenant-1",
+        org: { id: "org-1", name: "Example Org" },
+        customer: null,
+      },
+    });
+    const result = await runCommandInput(Me, context(true));
+    expect(result).toEqual({
+      name: "Example User",
+      email: "user@example.com",
+      tenantId: "tenant-1",
+      organization: { id: "org-1", name: "Example Org" },
+      customer: undefined,
+      endpointUrl: "https://example.com",
+      authentication: "profile",
+      profile: "development",
+    });
+    expect(Me.output.safeParse(result).success).toBe(true);
+    expect(getStdout()).toBe("");
+  });
+
+  it("passes domain data and a read-only next command through incur", async () => {
+    const command = defineCommand({
+      output: resourceOutputSchema("integrationId"),
+      run(c) {
+        return resourceOutput(c, "integrationId", "integration-1");
+      },
+    });
+    const cli = Cli.create("prism-output-test", {
+      globals: globalOptions,
+      env: environmentOptions,
+      vars: commandVars,
+    })
+      .use(commandMiddleware)
+      .command("test", command);
+    const writes: string[] = [];
+    await cli.serve(["test", "--json", "--full-output"], {
+      stdout: (value) => writes.push(value),
+      exit: () => {},
+    });
+    const result = JSON.parse(writes.join(""));
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual({ integrationId: "integration-1" });
+    expect(result.meta.cta.commands[0].command).toContain("integrations flows list");
+    expect(result.meta.cta.commands[0].command).toContain("integration-1");
+    expect(getStdout()).toBe("");
+    expect(z.toJSONSchema(command.output).properties).toHaveProperty("integrationId");
+  });
+});


### PR DESCRIPTION
Migrate GraphQL and completion commands and verify structured results.

Part **22/24** of the native incur migration. This PR targets `incur-21-dev-run`; the stack integrates into the long-lived `agent` branch. Review this diff against its immediate base.

Validation: format/lint, TypeScript, bundle, and **490 passing tests** (3 skipped) on Node 24. CI also checks Node 22/24/26 and Windows.

Review size: **782 handwritten changed lines**; counts include additions and deletions.

The temporary migration bridge keeps unmigrated commands on oclif and delegates migrated commands to incur. It is removed by the native-cutover PR. Contract coverage grows with each migrated command family.

[Stack review guide](https://github.com/prismatic-io/prism/blob/incur-24-review-evidence/docs/incur-pr-stack.md). Merge bottom-up; rebase descendants after a squash merge.
