### PR TITLE
[incur 24/24] Document the incur review stack and preserve live compatibility evidence

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-Prism is Prismatic's CLI tool for building, deploying, and supporting integrations from the command line. It's a Node.js package built with TypeScript and the oclif CLI framework. The binary is distributed as `@prismatic-io/prism` on npm and provides the `prism` command.
+Prism is Prismatic's CLI tool for building, deploying, and supporting integrations from the command line. It's a Node.js package built with TypeScript and the incur CLI framework. The binary is distributed as `@prismatic-io/prism` on npm and provides the `prism` command.
 
 ## Build System & Development Commands
 
@@ -15,7 +15,7 @@ Prism is Prismatic's CLI tool for building, deploying, and supporting integratio
 # Clean build artifacts
 bun run clean
 
-# Full build (clean, format, lint, compile, bundle, manifest, copy templates)
+# Full build (clean, format, lint, compile, bundle, copy templates)
 bun run build
 
 # Build with source maps for debugging
@@ -41,11 +41,11 @@ bun run test:snapshots            # Update test snapshots
 
 ### Command Structure
 
-The codebase follows oclif's explicit command strategy:
-- All commands are registered in `src/index.ts` in the `Commands` export object
-- Commands use colon-separated topics (e.g., `components:init`, `integrations:import`)
-- All commands extend `PrismaticBaseCommand` from `src/baseCommand.ts`
-- Command files are in `src/commands/` organized by topic (alerts, components, customers, instances, integrations, etc.)
+The codebase uses incur with an explicit command catalog:
+- Commands are registered in `src/index.ts` and assembled into topic groups in `src/cli.ts`
+- Existing colon-separated topics remain supported (for example, `components:init`)
+- Commands define Zod-backed arguments and options through `defineCommand`
+- Command files and their tests are organized by domain under `src/commands/`
 
 ### Core Modules
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Using Prism
 
-Prism is a NodeJS package, so it requires NodeJS and NPM to be installed.
+Prism requires Node.js 22 or newer and npm.
 You can download both from the [NodeJS Website](https://nodejs.org/).
 Prism works on MacOS, Linux, Windows and [WSL](https://docs.microsoft.com/en-us/windows/wsl/).
 
@@ -66,6 +66,50 @@ tenant switching still operate on the selected profile.
 
 For help with Prism, please see our [Prism documentation page](https://prismatic.io/docs/cli/).
 There, you will find information about the various subcommands you can run, troubleshooting tips, etc.
+
+### Automation and agents
+
+Prism automatically emits structured output when it detects a supported coding agent. You can also
+select the behavior explicitly with `--agent` or `--no-agent`. Use `--llms`, `--schema`, and
+`--format json` to discover commands and consume their results programmatically.
+
+Commands that can modify remote or local state require `--yes` in agent mode. Use `--read-only`, or
+set `PRISM_READ_ONLY=true` when starting an MCP server, to reject every state-changing command even
+when approval was supplied. MCP tool calls supply approval and profile controls through
+`context`, for example `{ "name": "Acme", "context": { "yes": true, "profile": "staging" } }`.
+Server launch defaults such as `prism --profile staging --mcp` are inherited by calls.
+A server started read-only cannot be made writable by a tool call.
+
+Authenticate a profile before starting an MCP server or using buffered agent output (`--json`,
+`--format json`, YAML, or explicit TOON). Run `prism login --url` in a terminal. Agent CLI login
+supports the default streaming format or `prism login --agent --yes --format jsonl`; it emits the
+browser challenge immediately and waits up to three minutes for authentication. MCP and buffered
+login calls return `AUTHENTICATION_REQUIRED` when authentication is needed. Already-authenticated
+profiles can still be checked in those modes.
+
+Paginated list commands return one page and a resumable `pageInfo.endCursor` in agent mode. Pass
+`--after <cursor>` to resume, `--first <count>` to bound the request, or `--all` to fetch every page.
+Human-readable invocations continue to fetch all pages by default.
+
+Agent list results include IDs and all available columns by default, with numbers, booleans,
+arrays, and objects preserved. Use `--columns` or incur's `--filter-output` to select fields.
+Resource commands return named fields such as `customerId`, `integrationId`, `executionId`,
+`path`, or `definition`. Follow-up suggestions retain the explicitly selected profile.
+
+Prism 11 uses incur's named command results by default, including human invocations.
+Use `--format json` in scripts and read fields such as `token` or `customerId` rather than
+assuming stdout contains a bare scalar. `FORCE_HUMAN_MODE=true` and `--no-agent` select human
+behavior; they do not restore Prism 10 result formatting. The public `--output json|csv|yaml`
+table formats remain available. Incur's `--format json|jsonl|yaml|toon|md` selects structured
+command results.
+Execution, listening, authentication, and development subprocess commands emit typed events.
+Use the default agent format or `--format jsonl` for incremental logs and payloads;
+explicit JSON, YAML, and TOON output is buffered until the command completes.
+
+Use `prism skills add --agent --yes` to install generated command skills, `prism mcp add --agent --yes`
+to register the MCP server, or `prism --mcp` to run it directly. `prism completions bash` and
+`prism completions zsh` print shell hooks; existing `autocomplete` entry points remain available.
+
 
 ## What is Prismatic?
 

--- a/docs/incur-native-adoption.md
+++ b/docs/incur-native-adoption.md
@@ -1,0 +1,111 @@
+# Native incur adoption
+
+The validated implementation below has been decomposed into a [reviewable PR stack](incur-pr-stack.md).
+
+The `incur-native-commands` branch follows `incur-agent-contracts`. It replaces the
+legacy command implementation while retaining the published commands, subcommands,
+positional arguments, option names, short aliases, defaults, and option relationships.
+Output presentation is allowed to follow incur's native behavior in Prism 11.
+
+## Command implementation
+
+Every public command declares native Zod inputs and an output schema. Handler inputs,
+`c.ok()` calls, and handler returns are checked against those declarations. Compiled
+negative type assertions prevent a future wrapper from silently erasing that inference.
+Named table schemas retain their field types and pagination shape. A single documented
+cast erases heterogeneous command types when mounting the dynamic command tree.
+
+Native middleware establishes each invocation's profile, environment, signal, and runtime
+state. Per-command declarations own mutation policy, output schemas, and examples. Domain
+operations are ordinary functions; commands no longer call another command's legacy
+`.invoke()` method or parse arrays through `.run(argv)`.
+
+The remaining command helper binds native generators to their invocation's async context,
+checks and normalizes results against their declared schemas, applies Prism's mutation
+policy, and handles the upstream MCP globals gap described below. It does not collect
+stdout into agent results, implement an alternate argument parser, or serialize commands
+behind a process-wide execution lock.
+
+## Public compatibility boundary
+
+`src/compatibility.ts` derives compatibility metadata from Zod schemas. The CLI entrypoint
+normalizes colon routes, historical camelCase names, attached aliases, spaced array values,
+and opaque delimiter arguments before incur parses them. Boolean and variadic positional
+arguments preserve native parser arity and expose meaningful schemas to MCP clients.
+
+Incur formats returned domain data by default. Human status messages use stderr. Table
+commands retain their dedicated renderer because `--columns`, `--filter`, `--sort`,
+`--csv`, `--output`, `--no-header`, and `--no-truncate` are public behaviors. GraphQL's
+formatting flags and completion-script output also retain their explicit renderers.
+`--no-agent` selects human behavior; it does not restore Prism 10's scalar result format.
+
+## Concurrent execution and streams
+
+Prism no longer changes the process working directory or environment during command
+execution. Generators, loaders, and subprocesses take explicit directories and environment
+snapshots. Profile writes serialize per configuration file and replace files atomically;
+independent read requests and different projects can run concurrently.
+
+Login, flow tests, listening, and development subprocesses use native async generators.
+They yield direct typed events, including completion, instead of nested message collectors.
+Polling and listener cleanup are local to the generator. Development subprocess streams
+apply backpressure, retain bounded failure diagnostics, and terminate children on cancellation.
+One-shot build/scaffolding subprocesses retain their ordinary completion interface.
+
+## Upstream verification
+
+Checked npm and GitHub on September 8, 2026. npm's `latest` tag is **incur 0.5.1**, published
+August 14. Installed and locked incur versions match. Upstream `main` is one workflow-only
+commit ahead of that release, with no unreleased runtime fix to adopt.
+
+- [Issue #229](https://github.com/wevm/incur/issues/229) remains open: globals are absent from
+  MCP tool schemas and OpenAPI parameters. [PR #195](https://github.com/wevm/incur/pull/195)
+  fixed CLI handler globals, not that transport gap. There is no documented supported
+  forwarding mechanism or linked fix in the issue. Prism exposes optional `context`
+  execution controls in each native tool input, avoiding incur's prohibition on options
+  that shadow globals. MCP callers use `context.yes`, `context.profile`, and
+  `context.readOnly`; CLI callers keep their existing global flags. MCP server launch
+  defaults are captured per server, and an inherited read-only policy cannot be disabled
+  by a tool call. The same declarations serve CLI, HTTP, and MCP.
+- [Issue #188](https://github.com/wevm/incur/issues/188) covers eager variable-schema parsing
+  before middleware. Prism declares middleware-populated variables optional and checks
+  initialization before handler execution; it does not downgrade Zod.
+- [PR #149](https://github.com/wevm/incur/pull/149) fixed CLI/HTTP stream terminal records.
+  The installed MCP implementation still discards generator return values and does not
+  forward MCP cancellation notifications to handlers. Prism yields completion data and
+  throws native errors for stream failures. HTTP cancellation is tested separately.
+- [Issue #225](https://github.com/wevm/incur/issues/225) describes the dynamic stdio SDK
+  import problem in compiled binaries. Prism's npm bundle declares the SDK directly and
+  verifies initialization from an installed packed package.
+- [PR #233](https://github.com/wevm/incur/pull/233) raises incur's minimum TOON dependency.
+  Prism's installed dependency and lockfile already resolve the patched TOON 2.3.1.
+
+Remaining upstream limitations are MCP cancellation forwarding and reduced metadata on
+MCP streaming errors. Authentication still uses the existing browser/PKCE flow; MCP callers
+bootstrap a profile before starting the server. Executing user-supplied component code can
+have arbitrary process side effects; Prism's own code no longer requires shared mutations.
+
+## Verification
+
+Tests exercise the actual native CLI, HTTP, and MCP entrypoints, including per-call approval,
+profiles, read-only enforcement, concurrent invocation isolation, schema-normalized results,
+streaming error semantics, listener cleanup, and subprocess cancellation. Contract tests
+compare public inputs with the published Prism 10.2.0 manifest. Live comparison scripts
+normalize identity presentation while comparing its underlying data; public table flags
+are compared directly. Live lifecycle tests create and remove only temporary audit customers.
+
+Final validation on September 8, 2026:
+
+- Clean format, lint, TypeScript compilation, bundle, and installed CLI smoke checks.
+- Final suite: **775 passed, 3 skipped**, across 47 test files on Node 24.19.0.
+  The preceding full suite also passed on Node 22.23.2 and 26.4.0 (774 tests before
+  the additional numeric log-severity regression). Minimum Node 22.0.0 smoke passed.
+- Final packed npm artifact successfully initialized MCP and listed its discovery tools
+  without stderr output. CLI, HTTP, and MCP context handling is covered by transport tests.
+- **56 live read-only comparisons matched** published Prism 10.2.0 against
+  `https://app.rwersal.prismatic-dev.io`; see
+  [read-only evidence](../test/fixtures/live-native-readonly.json).
+- **Two temporary-customer lifecycles passed**, including public aliases, create, update,
+  and delete, with the final packed artifact; see
+  [lifecycle evidence](../test/fixtures/live-native-lifecycle.json). A separate published-CLI
+  query confirmed no audit customers remained.

--- a/docs/incur-port-review.md
+++ b/docs/incur-port-review.md
@@ -1,0 +1,118 @@
+# Initial incur port review
+
+This records the initial three-branch review. The subsequent native implementation and
+current compatibility scope are documented in [Native incur adoption](incur-native-adoption.md).
+Its runtime limitations supersede the historical ones below.
+
+The stack targets Prism 11 while preserving the human CLI contract of the npm-published
+`@prismatic-io/prism@10.2.0`. It uses incur 0.5.1. The published tarball's 91 command
+definitions match `test/fixtures/legacy-cli-contract.json` exactly.
+
+## Review boundaries
+
+- `incur-port`: routing and parser compatibility, native incur discovery, agent execution,
+  authentication streaming, MCP transport isolation, execution events, and mutation guards.
+- `incur-codegen-v6`: generated typed GraphQL documents, explicit missing-parent errors,
+  and code-generation token capture independent of agent output mode.
+- `incur-agent-contracts`: named resource results and schemas, native table values and IDs,
+  preserved warnings, shell-safe follow-up commands, and reproducible live audit scripts.
+
+The release/help/Node changes previously stacked above the original port are incorporated
+in `incur-port`. The minimum runtime is Node 22; native incur help is an intentional major
+version presentation change. Unrelated existing API, polling, and result-file defects were
+kept outside this work.
+
+## Compatibility and execution checks
+
+Tests assert actual parsed values for each legacy option and short alias, not only parser
+acceptance. Differential probes against the published executable cover colon and space
+routes, attached short values, space-separated arrays, local `-v` and `-h` ownership,
+missing values, `--help`, positional booleans, literal marker-like arguments, and delimiter
+passthrough. Option values are never interpreted as command paths. The published global
+`--help` preemption remains available; command-local `-h` continues to mean its local option.
+
+Agent errors have stable status and structured output across JSON, JSONL, and TOON. Subprocess
+stdout/stderr cannot corrupt JSON or MCP framing, and failed subprocess diagnostics are bounded.
+Nested calls retain agent state, confirmation state, warnings, and the output sink. Streams emit
+typed execution, log, step-result, listening, and saved-payload events without replaying their
+transcripts. Native CLI and MCP tests check streaming failures through incur itself.
+
+The static mutation classification includes availability and marketplace updates. Dynamic
+GraphQL mutation detection still allows queries in read-only mode. Agent prerequisites are
+checked before enabling remote listening, and cleanup is active once listening starts.
+MCP/HTTP command calls cannot consume shared process stdin; ordinary CLI pipes still work.
+
+Independent subagents performed initial and adversarial reviews, implementation reviews
+across each other's changes, and final framework-entrypoint probes. Reproductions prompted
+additional checks for shell completion, native built-in routes, typed result warnings,
+CTA quoting, and MCP generator completion semantics.
+
+## Agent results
+
+Tables retain native values and include identifiers by default. Human table, CSV, YAML, and
+legacy JSON rendering remains unchanged. Explicit projections and legacy string-based
+filtering/sorting continue to work. Resource mutations and exports return named IDs,
+definitions, or paths. Identity output excludes authentication tokens; token commands expose
+only the explicitly requested token. Declared schemas include optional warning messages.
+
+GraphQL extraction was compared structurally: all 94 migrated inline documents preserve
+operations after removing operation names. Missing nullable parents now fail with `NOT_FOUND`;
+existing parents with zero children still return successful empty lists.
+
+## Live validation
+
+`test/fixtures/live-cli-audit.json` records hashes/counts from the development stack. It covers
+24 resource-list commands in human and agent modes, identity output, and seven bounded/resumable
+pagination cases: 56 matched checks. Agent data is rendered using the legacy cell representation
+before comparing it with the published CLI. No credentials or returned customer data are stored.
+
+`test/fixtures/live-cli-lifecycle.json` records create/update/delete validation on both release
+and port, including spaced label arrays, GraphQL's `-v` variables alias, and attached `-n=value`.
+Temporary customers use unique audit names and external IDs and are removed in `finally`.
+An independent query verifies that no audit customers remain. The API's existing lowercase
+label normalization is accounted for in the comparison.
+
+Reproduce against an explicitly selected development stack:
+
+```sh
+PRISMATIC_URL=https://app.example.prismatic-dev.io node scripts/audit-live-readonly.mjs
+PRISMATIC_URL=https://app.example.prismatic-dev.io PRISM_AUDIT_MUTATIONS=true node scripts/audit-live-lifecycle.mjs
+```
+
+`PRISM_LEGACY_BIN` and `PRISM_CANDIDATE_BIN` can select alternate executables. The lifecycle
+script refuses non-development hosts and modifies only the customers it creates. The
+read-only script reports absent fixtures and unavailable baseline operations separately
+from matches; those cases are not treated as validation coverage.
+
+## Runtime boundaries
+
+Authentication still requires the existing browser/PKCE interaction. Default agent CLI output
+and explicit JSONL deliver the challenge immediately. Unauthenticated MCP or buffered-format
+login returns `AUTHENTICATION_REQUIRED` before opening a listener, with instructions to
+bootstrap an authenticated profile. Authentication timeouts and stream cancellation close
+the listener. No new background authentication daemon or unverified OAuth grant was added.
+
+The adapter retains its execution lock because inherited command handlers change the process
+working directory and environment. A long-running operation can serialize other operations
+within one MCP process. CLI/HTTP generator cancellation reaches polling, subprocesses, and
+authentication, but incur 0.5.1 does not forward MCP cancellation to command handlers.
+Subprocess output is captured until the child exits. These limitations are explicit; the port
+does not claim concurrent MCP execution or incremental subprocess output.
+
+The bundled CLI declares the dynamically imported MCP server as a direct runtime dependency,
+so package managers do not need to hoist incur's transitive dependencies for MCP to start.
+Packed-package checks include actual production dependency installation and a stdio MCP
+initialize/tools-list exchange.
+
+## Final verification
+
+The final integrated build passes formatting, linting, TypeScript compilation, bundling,
+and installed CLI smoke checks. The full suite passes 750 tests with three skipped tests.
+Full suites also passed on Node 22.23.2 and 26.4.0 before the final native-command guard
+and completion additions; those additions receive focused subprocess checks on both runtimes.
+The minimum Node 22.0.0 runtime is covered by the installed CLI smoke check.
+
+This substantially adopts incur's agent-facing features: discovery, schemas, structured
+results, follow-up commands, streaming, MCP, skills, and completion. It does not eliminate
+every legacy abstraction: the compatibility descriptor adapter retains some `any` types
+and does not provide full end-to-end inference from incur command declarations.

--- a/docs/incur-pr-stack.md
+++ b/docs/incur-pr-stack.md
@@ -1,0 +1,88 @@
+# Incur review stack
+
+The first PR targets the long-lived `agent` branch. Each subsequent PR targets the
+preceding branch. Review and merge from the bottom of the stack upward. If a PR is
+squash-merged, rebase its descendants before merging the next PR.
+
+The original `incur-port`, `incur-codegen-v6`, `incur-agent-contracts`, and
+`incur-native-commands` bookmarks are preserved. `incur-validated-snapshot` identifies
+the validated implementation (`7caa46cd`) used to build this stack.
+
+## Review boundaries
+
+Changed lines count additions plus deletions. Artifact lines include generated TypeScript,
+lockfiles, and captured JSON fixtures. GitHub's generated-file attributes collapse these
+artifacts. Intermediate oclif manifest regeneration is deliberately excluded from commits.
+
+| PR | Branch | Scope | Handwritten lines | Artifact lines | Passing tests |
+| --- | --- | --- | ---: | ---: | ---: |
+| [#310](https://github.com/prismatic-io/prism/pull/310) | `incur-01-runtime` | Prepare Node 22+ CI and dependencies for incur | 63 | 506 | 298 |
+| [#311](https://github.com/prismatic-io/prism/pull/311) | `incur-02-graphql-artifacts` | Generate typed GraphQL operation artifacts | 1,459 | 12,177 | 299 |
+| [#312](https://github.com/prismatic-io/prism/pull/312) | `incur-03-graphql-transport` | Add typed GraphQL transport and shared API helpers | 622 | 0 | 299 |
+| [#313](https://github.com/prismatic-io/prism/pull/313) | `incur-04-graphql-client` | Use typed GraphQL documents and validate resource lookups | 2,195 | 0 | 313 |
+| [#314](https://github.com/prismatic-io/prism/pull/314) | `incur-05-command-runtime` | Introduce native incur schemas and request middleware | 1,202 | 0 | 332 |
+| [#315](https://github.com/prismatic-io/prism/pull/315) | `incur-06-auth-isolation` | Isolate authentication and profile state per invocation | 458 | 0 | 336 |
+| [#316](https://github.com/prismatic-io/prism/pull/316) | `incur-07-output-schemas` | Add native table schemas and structured output helpers | 518 | 0 | 338 |
+| [#317](https://github.com/prismatic-io/prism/pull/317) | `incur-08-subprocess-streams` | Stream subprocess output with bounded buffering and cancellation | 398 | 0 | 346 |
+| [#318](https://github.com/prismatic-io/prism/pull/318) | `incur-09-cli-profiles` | Mount native incur commands and migrate profiles | 995 | 7,482 | 349 |
+| [#319](https://github.com/prismatic-io/prism/pull/319) | `incur-10-auth-commands` | Migrate login and identity commands to native incur schemas | 561 | 0 | 359 |
+| [#320](https://github.com/prismatic-io/prism/pull/320) | `incur-11-customers` | Migrate customer and customer-user commands to native incur | 712 | 0 | 371 |
+| [#321](https://github.com/prismatic-io/prism/pull/321) | `incur-12-organization` | Migrate organization, on-premise, and log commands | 895 | 0 | 388 |
+| [#322](https://github.com/prismatic-io/prism/pull/322) | `incur-13-alerts` | Migrate alert commands to native incur schemas | 718 | 0 | 400 |
+| [#323](https://github.com/prismatic-io/prism/pull/323) | `incur-14-instances` | Migrate instance management and configuration commands | 664 | 0 | 409 |
+| [#324](https://github.com/prismatic-io/prism/pull/324) | `incur-15-integrations` | Migrate integration lifecycle and discovery commands | 940 | 0 | 422 |
+| [#325](https://github.com/prismatic-io/prism/pull/325) | `incur-16-component-runtime` | Migrate component commands with isolated project loading | 1,560 | 0 | 435 |
+| [#326](https://github.com/prismatic-io/prism/pull/326) | `incur-17-file-commands` | Migrate integration files, workflow, and execution result commands | 856 | 0 | 448 |
+| [#327](https://github.com/prismatic-io/prism/pull/327) | `incur-18-scaffolding` | Migrate scaffolding commands and isolate generator directories | 847 | 0 | 452 |
+| [#328](https://github.com/prismatic-io/prism/pull/328) | `incur-19-flow-tests` | Stream flow-test execution results through native incur generators | 1,107 | 0 | 460 |
+| [#329](https://github.com/prismatic-io/prism/pull/329) | `incur-20-listener` | Stream listener events with request-scoped cleanup | 680 | 0 | 465 |
+| [#330](https://github.com/prismatic-io/prism/pull/330) | `incur-21-dev-run` | Migrate component dev-run to native subprocess streams | 172 | 0 | 467 |
+| [#331](https://github.com/prismatic-io/prism/pull/331) | `incur-22-query-completion` | Migrate GraphQL and completion commands and verify structured results | 783 | 0 | 490 |
+| [#332](https://github.com/prismatic-io/prism/pull/332) | `incur-23-native-cutover` | Complete native incur cutover and verify the public CLI and MCP contracts | 1,874 | 8,030 | 775 |
+| [#333](https://github.com/prismatic-io/prism/pull/333) | `incur-24-review-evidence` | Review guide, CLI documentation, and live compatibility evidence | Documentation | Captured evidence | 775 |
+
+The largest handwritten changes are the resource-handler conversion (mostly removal of
+inline GraphQL queries), shared command runtime with tests, component/project isolation,
+and final native cutover with complete CLI/MCP contract coverage. The GraphQL artifact PR
+contains the extracted operation documents beside their generated typed nodes.
+
+## Intermediate behavior
+
+The early prerequisites retain the oclif CLI. From the profile migration onward, a small
+`migration-bridge.ts` registers migrated commands in that catalog and delegates execution
+to incur. Unmigrated commands continue using oclif. Contract tests grow with the native
+command catalog and verify published inputs and native schema discovery at each step.
+
+The native cutover removes the bridge, legacy table helpers, base command, and oclif
+dependencies. It installs the final parser compatibility, CLI entrypoint, public-contract
+tests, and real MCP transport tests. No transitional adapter remains at the tip.
+
+## Validation
+
+Every implementation boundary passed format/lint, TypeScript, bundle, and the test suite
+on Node 24. The table records the passing test counts; three tests were skipped at each
+boundary. The new CI task runs validation sequentially because build and test both clean
+scaffold fixtures. The intermediate dependency set also passed npm's Node 22 engine-strict
+dry run. GitHub CI checks Linux on Node 22/24/26 and runs a separate Windows test job.
+
+After rebuilding the history, production application source, package.json, bun.lock, and build.ts
+were compared directly with `incur-validated-snapshot` and matched exactly. The final
+sequential `mise run validate` passed with **775 tests, 3 skipped**, plus installed CLI
+smoke. History cleanup changed only generated manifest noise, generated-file attributes,
+and CI task ordering at the already-tested boundaries. GitHub CI additionally exposed
+a generated-manifest formatter check and Windows short/long-path comparison. The earliest
+relevant PRs now exclude that generated manifest from formatting and canonicalize both
+paths in the process-isolation assertion. Windows cold-start integration tests receive
+a 30-second timeout, and POSIX quoting assertions use Git for Windows' `sh.exe` there.
+GraphQL source scans exclude temporary scaffold output to avoid racing generator cleanup.
+No assertions are skipped or removed. Production behavior is unchanged.
+
+The preserved [native adoption report](incur-native-adoption.md) links the latest upstream
+incur findings and the live evidence: **56 read-only comparisons matched** published Prism
+10.2.0, and **two customer lifecycle checks passed** against the development stack, with
+cleanup independently verified. Those live checks remain applicable to the unchanged
+production application source at this stack's tip.
+
+Draft PRs [#310](https://github.com/prismatic-io/prism/pull/310) through
+[#333](https://github.com/prismatic-io/prism/pull/333) are published. Each PR links its
+GitHub CI runs; the complete stack starts at `agent` and ends at `incur-24-review-evidence`.

--- a/scripts/audit-live-lifecycle.mjs
+++ b/scripts/audit-live-lifecycle.mjs
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+assert.equal(
+  process.env.PRISM_AUDIT_MUTATIONS,
+  "true",
+  "Set PRISM_AUDIT_MUTATIONS=true to create and remove temporary audit customers",
+);
+const endpoint = new URL(process.env.PRISMATIC_URL);
+assert.ok(
+  endpoint.hostname.endsWith(".prismatic-dev.io"),
+  "This audit only runs on a development stack",
+);
+const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const legacy = process.env.PRISM_LEGACY_BIN ?? "prism";
+const candidate = process.env.PRISM_CANDIDATE_BIN ?? process.execPath;
+const prefix = process.env.PRISM_CANDIDATE_BIN ? [] : [path.join(root, "lib/run.js")];
+const env = { ...process.env, FORCE_HUMAN_MODE: "true" };
+const digest = (value) => createHash("sha256").update(JSON.stringify(value)).digest("hex");
+const run = (ported, args) => {
+  const result = spawnSync(ported ? candidate : legacy, [...(ported ? prefix : []), ...args], {
+    cwd: root,
+    env,
+    encoding: "utf8",
+    timeout: 60_000,
+  });
+  assert.equal(
+    result.status,
+    0,
+    `${args[0]} failed: status=${result.status}, outputHash=${digest([result.stdout, result.stderr])}`,
+  );
+  return result.stdout.trim();
+};
+const suffix = randomUUID();
+const cleanup = [];
+const checks = [];
+try {
+  for (const ported of [false, true]) {
+    const label = ported ? "port" : "release";
+    const externalId = `prism-incur-audit-${suffix}-${label}`;
+    const name = `Prism incur audit ${suffix} ${label}`;
+    const machine = ported ? ["--agent", "--yes", "--json"] : [];
+    const created = run(ported, [
+      "customers:create",
+      ...machine,
+      "--name",
+      name,
+      "--externalId",
+      externalId,
+      "--label",
+      "Compatibility A",
+      "Compatibility B",
+    ]);
+    const id = ported ? JSON.parse(created).customerId : created;
+    assert.ok(
+      typeof id === "string" && id.length > 0 && !id.includes("\n"),
+      "No created customer ID",
+    );
+    cleanup.push({ ported, id, deleted: false });
+    const query =
+      "query AuditCustomer($id: ID!) { customer(id: $id) { name externalId labels description } }";
+    const read = () =>
+      JSON.parse(run(ported, ["graphql:query", query, "-v", JSON.stringify({ id })])).customer;
+    const original = read();
+    assert.equal(original.name, name);
+    assert.equal(original.externalId, externalId);
+    assert.deepEqual([...original.labels].sort(), ["compatibility a", "compatibility b"]);
+    const updatedName = `${name} updated`;
+    run(ported, [
+      "customers:update",
+      id,
+      ...machine,
+      `-n=${updatedName}`,
+      "--description",
+      "Compatibility audit; safe to remove",
+    ]);
+    const updated = read();
+    assert.equal(updated.name, updatedName);
+    assert.equal(updated.description, "Compatibility audit; safe to remove");
+    run(ported, ["customers:delete", id, ...machine]);
+    cleanup.at(-1).deleted = true;
+    const remaining = JSON.parse(
+      run(ported, [
+        "customers:list",
+        "--columns",
+        "id",
+        "--filter",
+        `externalId=^${externalId}$`,
+        "--output",
+        "json",
+      ]),
+    );
+    assert.deepEqual(remaining, []);
+    checks.push({
+      cli: label,
+      create: true,
+      arrays: true,
+      variablesAlias: true,
+      attachedAlias: true,
+      update: true,
+      delete: true,
+    });
+  }
+} finally {
+  for (const item of cleanup.filter((entry) => !entry.deleted)) {
+    try {
+      run(item.ported, [
+        "customers:delete",
+        item.id,
+        ...(item.ported ? ["--agent", "--yes", "--json"] : []),
+      ]);
+      item.deleted = true;
+    } catch {
+      process.stderr.write(
+        `Cleanup required for audit customer ${item.id} on ${endpoint.origin}\n`,
+      );
+      process.exitCode = 1;
+    }
+  }
+}
+process.stdout.write(
+  `${JSON.stringify({ checkedAt: new Date().toISOString(), stack: endpoint.origin, checks, allTemporaryCustomersRemoved: cleanup.every((entry) => entry.deleted) }, null, 2)}\n`,
+);

--- a/scripts/audit-live-readonly.mjs
+++ b/scripts/audit-live-readonly.mjs
@@ -1,0 +1,249 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { spawn } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const legacy = process.env.PRISM_LEGACY_BIN ?? "prism";
+const candidate = process.env.PRISM_CANDIDATE_BIN ?? process.execPath;
+const candidatePrefix = process.env.PRISM_CANDIDATE_BIN ? [] : [path.join(root, "lib/run.js")];
+assert.ok(
+  process.env.PRISMATIC_URL,
+  "Set PRISMATIC_URL explicitly to the development stack to audit",
+);
+const endpoint = new URL(process.env.PRISMATIC_URL);
+const manifest = JSON.parse(
+  await readFile(path.join(root, "test/fixtures/legacy-cli-contract.json"), "utf8"),
+);
+const env = { ...process.env, FORCE_HUMAN_MODE: "true" };
+const checks = [];
+const records = new Map();
+const canonical = (value) => {
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  if (value !== null && typeof value === "object")
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonical(value[key])}`)
+      .join(",")}}`;
+  return JSON.stringify(value);
+};
+const sorted = (rows) => [...rows].sort((a, b) => canonical(a).localeCompare(canonical(b)));
+const digest = (value) => createHash("sha256").update(canonical(value)).digest("hex");
+const cell = (value) =>
+  value == null ? "" : typeof value === "object" ? JSON.stringify(value) : String(value);
+const run = (binary, prefix, args) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(binary, [...prefix, ...args], {
+      cwd: root,
+      env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "",
+      stderr = "";
+    const timer = setTimeout(() => child.kill("SIGTERM"), 60_000);
+    child.stdout.on("data", (data) => {
+      stdout += data;
+    });
+    child.stderr.on("data", (data) => {
+      stderr += data;
+    });
+    child.on("error", (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+    child.on("close", (status, signal) => {
+      clearTimeout(timer);
+      resolve({ status, signal, stdout: stdout.trim(), stderr: stderr.trim() });
+    });
+  });
+const oldRun = (args) => run(legacy, [], args);
+const newRun = (args) => run(candidate, candidatePrefix, args);
+const mustSucceed = (result, label) =>
+  assert.equal(
+    result.status,
+    0,
+    `${label} failed (status ${result.status}; output hash ${digest(result)})`,
+  );
+const versions = await Promise.all([oldRun(["--version"]), newRun(["--version"])]);
+versions.forEach((result) => {
+  mustSucceed(result, "version");
+});
+const identities = await Promise.all([oldRun(["me"]), newRun(["me", "--format", "json"])]);
+identities.forEach((result) => {
+  mustSucceed(result, "me");
+});
+const legacyIdentity = Object.fromEntries(
+  identities[0].stdout
+    .trim()
+    .split("\n")
+    .map((line) => {
+      const match = /^([^:]+):\s*(.*)$/.exec(line);
+      assert.ok(match, "Unrecognized published identity output");
+      return [match[1], match[2]];
+    }),
+);
+const identity = JSON.parse(identities[1].stdout);
+const nativeIdentity = {
+  Name: identity.name,
+  Email: identity.email,
+  ...(identity.organization
+    ? { Organization: identity.organization.name, "Organization ID": identity.organization.id }
+    : {}),
+  ...(identity.customer ? { Customer: identity.customer.name } : {}),
+  ...(identity.tenantId ? { "Tenant ID": identity.tenantId } : {}),
+  "Endpoint URL": identity.endpointUrl,
+  Authentication: identity.authentication === "environment" ? "Environment" : "Profile",
+  ...(identity.profile ? { Profile: identity.profile } : {}),
+};
+for (const identity of [legacyIdentity, nativeIdentity]) {
+  assert.equal(
+    new URL(identity["Endpoint URL"]).origin,
+    endpoint.origin,
+    "CLI is targeting a different stack",
+  );
+}
+assert.equal(canonical(legacyIdentity), canonical(nativeIdentity), "Identity data differs");
+checks.push({ command: "me", status: "matched", sha256: digest(nativeIdentity) });
+
+async function compare(command, args = []) {
+  const flags = manifest.commands[command].flags;
+  const display = [...(flags.extended ? ["--extended"] : []), "--output", "json"];
+  const [before, after] = await Promise.all([
+    oldRun([command, ...args, ...display]),
+    newRun([command, ...args, ...display]),
+  ]);
+  if (before.status !== 0) {
+    checks.push({
+      command,
+      status: "baseline-unavailable",
+      legacyExit: before.status,
+      candidateExit: after.status,
+      legacyErrorHash: digest(before.stderr),
+      candidateErrorHash: digest(after.stderr),
+    });
+    return;
+  }
+  mustSucceed(after, command);
+  const oldRows = sorted(JSON.parse(before.stdout));
+  const newRows = sorted(JSON.parse(after.stdout));
+  const same = canonical(oldRows) === canonical(newRows);
+  checks.push({
+    command,
+    mode: "human",
+    status: same ? "matched" : "mismatch",
+    count: oldRows.length,
+    legacyHash: digest(oldRows),
+    candidateHash: digest(newRows),
+  });
+  records.set(command, oldRows);
+  const schema = await newRun([command, "--schema", "--json"]);
+  mustSucceed(schema, `${command} schema`);
+  const paginated = Boolean(JSON.parse(schema.stdout).options?.properties?.all);
+  const agent = await newRun([
+    command,
+    ...args,
+    "--agent",
+    "--read-only",
+    "--json",
+    ...(paginated ? ["--all"] : []),
+  ]);
+  mustSucceed(agent, `${command} agent`);
+  const result = JSON.parse(agent.stdout);
+  assert.ok(Array.isArray(result.items), `${command} has no structured items`);
+  const rendered = sorted(
+    result.items.map((row) =>
+      Object.fromEntries(Object.entries(row).map(([key, value]) => [key, cell(value)])),
+    ),
+  );
+  const agentSame = canonical(oldRows) === canonical(rendered);
+  checks.push({
+    command,
+    mode: "agent",
+    status: agentSame ? "matched" : "mismatch",
+    count: result.items.length,
+    legacyHash: digest(oldRows),
+    candidateHash: digest(rendered),
+  });
+  if (paginated && oldRows.length > 1) {
+    const pageOne = await newRun([
+      command,
+      ...args,
+      "--agent",
+      "--read-only",
+      "--json",
+      "--first",
+      "1",
+    ]);
+    mustSucceed(pageOne, `${command} first page`);
+    const first = JSON.parse(pageOne.stdout);
+    assert.equal(first.items.length, 1, `${command} --first was not bounded`);
+    assert.equal(first.pageInfo.hasNextPage, true, `${command} lost next page`);
+    assert.ok(first.pageInfo.endCursor, `${command} lost cursor`);
+    const pageTwo = await newRun([
+      command,
+      ...args,
+      "--agent",
+      "--read-only",
+      "--json",
+      "--first",
+      "1",
+      "--after",
+      first.pageInfo.endCursor,
+    ]);
+    mustSucceed(pageTwo, `${command} second page`);
+    const second = JSON.parse(pageTwo.stdout);
+    assert.equal(second.items.length, 1);
+    assert.notEqual(canonical(first.items), canonical(second.items), `${command} did not advance`);
+    checks.push({ command, mode: "pagination", status: "matched" });
+  }
+  process.stderr.write(`Checked ${command}\n`);
+}
+
+for (const command of [
+  "customers:list",
+  "integrations:list",
+  "instances:list",
+  "components:list",
+  "on-prem-resources:list",
+  "alerts:groups:list",
+  "alerts:monitors:list",
+  "alerts:triggers:list",
+  "alerts:webhooks:list",
+  "customers:users:roles",
+  "logs:severities:list",
+  "organization:connections:list",
+  "organization:signing-keys:list",
+  "organization:users:list",
+  "organization:users:roles",
+])
+  await compare(command);
+
+const dependent = [
+  ["customers:list", "id", ["customers:users:list"]],
+  ["instances:list", "id", ["instances:config-vars:list", "instances:flow-configs:list"]],
+  ["integrations:list", "id", ["integrations:flows:list", "integrations:versions"]],
+  [
+    "components:list",
+    "key",
+    ["components:actions:list", "components:data-sources:list", "components:triggers:list"],
+  ],
+  ["alerts:monitors:list", "id", ["alerts:events:list"]],
+];
+for (const [source, key, commands] of dependent) {
+  const value = records.get(source)?.find((row) => row[key])?.[key];
+  for (const command of commands) {
+    if (value) await compare(command, [value]);
+    else checks.push({ command, status: "no-fixture", source });
+  }
+}
+const report = {
+  checkedAt: new Date().toISOString(),
+  stack: endpoint.origin,
+  legacy: versions[0].stdout,
+  candidate: versions[1].stdout,
+  checks,
+};
+process.stdout.write(`${JSON.stringify(report, null, 2)}\n`);
+if (checks.some((check) => check.status === "mismatch")) process.exitCode = 1;

--- a/scripts/smoke-live-readonly.mjs
+++ b/scripts/smoke-live-readonly.mjs
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const root = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const legacy = process.env.PRISM_LEGACY_BIN ?? "prism";
+const candidate = process.env.PRISM_CANDIDATE_BIN ?? process.execPath;
+const candidatePrefix = process.env.PRISM_CANDIDATE_BIN ? [] : [path.join(root, "lib/run.js")];
+
+const run = (binary, prefix, args) => {
+  const result = spawnSync(binary, [...prefix, ...args], {
+    cwd: root,
+    encoding: "utf8",
+    env: { ...process.env, FORCE_HUMAN_MODE: "true" },
+  });
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  return result.stdout.trim();
+};
+
+const canonical = (value) => JSON.stringify(value, Object.keys(value[0] ?? {}).sort(), 0);
+const digest = (value) => createHash("sha256").update(canonical(value)).digest("hex");
+const sorted = (value) =>
+  [...value].sort((left, right) => canonical([left]).localeCompare(canonical([right])));
+
+const checks = [
+  { command: "customers:list", columns: "name,description" },
+  { command: "integrations:list", columns: "name,description,versionNumber" },
+].map(({ command, columns }) => {
+  const oldValue = JSON.parse(run(legacy, [], [command, "--columns", columns, "--output", "json"]));
+  const newValue = JSON.parse(
+    run(candidate, candidatePrefix, [command, "--columns", columns, "--output", "json"]),
+  );
+  assert.deepEqual(sorted(newValue), sorted(oldValue), `${command} returned different records`);
+  return { command, count: newValue.length, sha256: digest(sorted(newValue)) };
+});
+
+const legacyMe = run(legacy, [], ["me"]);
+const candidateMe = run(candidate, candidatePrefix, ["me"]);
+assert.equal(candidateMe, legacyMe, "me returned different profile information");
+checks.unshift({
+  command: "me",
+  count: legacyMe.split("\n").length,
+  sha256: createHash("sha256").update(legacyMe).digest("hex"),
+});
+
+process.stdout.write(
+  `${JSON.stringify(
+    {
+      candidate: run(candidate, candidatePrefix, ["--version"]),
+      checks,
+      legacy: run(legacy, [], ["--version"]),
+    },
+    null,
+    2,
+  )}\n`,
+);

--- a/test/fixtures/live-cli-audit.json
+++ b/test/fixtures/live-cli-audit.json
@@ -1,0 +1,432 @@
+{
+  "checkedAt": "2026-09-08T18:12:45.043Z",
+  "stack": "https://app.rwersal.prismatic-dev.io",
+  "legacy": "@prismatic-io/prism/10.2.0 darwin-arm64 node-v24.19.0",
+  "candidate": "@prismatic-io/prism/11.0.0 darwin-arm64 node-v24.19.0",
+  "checks": [
+    {
+      "command": "me",
+      "status": "matched",
+      "sha256": "3b8dba3a319e1d09a95e72a6f34eb975a87f9531f662d6345b3a86cadb5c54a3"
+    },
+    {
+      "command": "customers:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 9,
+      "legacyHash": "dcc716f966afa21ba93df719f73ba3ed6eedf05f3a6b473c48694f84e05240db",
+      "candidateHash": "dcc716f966afa21ba93df719f73ba3ed6eedf05f3a6b473c48694f84e05240db"
+    },
+    {
+      "command": "customers:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 9,
+      "legacyHash": "dcc716f966afa21ba93df719f73ba3ed6eedf05f3a6b473c48694f84e05240db",
+      "candidateHash": "dcc716f966afa21ba93df719f73ba3ed6eedf05f3a6b473c48694f84e05240db"
+    },
+    {
+      "command": "customers:list",
+      "mode": "pagination",
+      "status": "matched"
+    },
+    {
+      "command": "integrations:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 16,
+      "legacyHash": "e04d33a98efd2601edcaa4b7f2d697c7c388774c9b1f69415910ce4401fafd35",
+      "candidateHash": "e04d33a98efd2601edcaa4b7f2d697c7c388774c9b1f69415910ce4401fafd35"
+    },
+    {
+      "command": "integrations:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 16,
+      "legacyHash": "e04d33a98efd2601edcaa4b7f2d697c7c388774c9b1f69415910ce4401fafd35",
+      "candidateHash": "e04d33a98efd2601edcaa4b7f2d697c7c388774c9b1f69415910ce4401fafd35"
+    },
+    {
+      "command": "integrations:list",
+      "mode": "pagination",
+      "status": "matched"
+    },
+    {
+      "command": "instances:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 7,
+      "legacyHash": "554795838225ada3744ac06cd48830c134f9208646394e491a2c5ac0def37a62",
+      "candidateHash": "554795838225ada3744ac06cd48830c134f9208646394e491a2c5ac0def37a62"
+    },
+    {
+      "command": "instances:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 7,
+      "legacyHash": "554795838225ada3744ac06cd48830c134f9208646394e491a2c5ac0def37a62",
+      "candidateHash": "554795838225ada3744ac06cd48830c134f9208646394e491a2c5ac0def37a62"
+    },
+    {
+      "command": "instances:list",
+      "mode": "pagination",
+      "status": "matched"
+    },
+    {
+      "command": "components:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 205,
+      "legacyHash": "528f9ac57549f158088153f3efa22a1acadcf0d49b229de8e3d5b288211a5dd7",
+      "candidateHash": "528f9ac57549f158088153f3efa22a1acadcf0d49b229de8e3d5b288211a5dd7"
+    },
+    {
+      "command": "components:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 205,
+      "legacyHash": "528f9ac57549f158088153f3efa22a1acadcf0d49b229de8e3d5b288211a5dd7",
+      "candidateHash": "528f9ac57549f158088153f3efa22a1acadcf0d49b229de8e3d5b288211a5dd7"
+    },
+    {
+      "command": "components:list",
+      "mode": "pagination",
+      "status": "matched"
+    },
+    {
+      "command": "on-prem-resources:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 1,
+      "legacyHash": "7c71910def5551c9930be5ee50c9df162f776fe2e51dd6f055c5e90c0135994a",
+      "candidateHash": "7c71910def5551c9930be5ee50c9df162f776fe2e51dd6f055c5e90c0135994a"
+    },
+    {
+      "command": "on-prem-resources:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 1,
+      "legacyHash": "7c71910def5551c9930be5ee50c9df162f776fe2e51dd6f055c5e90c0135994a",
+      "candidateHash": "7c71910def5551c9930be5ee50c9df162f776fe2e51dd6f055c5e90c0135994a"
+    },
+    {
+      "command": "alerts:groups:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 0,
+      "legacyHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+      "candidateHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+    },
+    {
+      "command": "alerts:groups:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 0,
+      "legacyHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+      "candidateHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+    },
+    {
+      "command": "alerts:monitors:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 2,
+      "legacyHash": "fa3e6860d444e995610bf195e6aae150beb811e1fd547e7fb2a7a4935603bcee",
+      "candidateHash": "fa3e6860d444e995610bf195e6aae150beb811e1fd547e7fb2a7a4935603bcee"
+    },
+    {
+      "command": "alerts:monitors:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 2,
+      "legacyHash": "fa3e6860d444e995610bf195e6aae150beb811e1fd547e7fb2a7a4935603bcee",
+      "candidateHash": "fa3e6860d444e995610bf195e6aae150beb811e1fd547e7fb2a7a4935603bcee"
+    },
+    {
+      "command": "alerts:monitors:list",
+      "mode": "pagination",
+      "status": "matched"
+    },
+    {
+      "command": "alerts:triggers:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 13,
+      "legacyHash": "e89c8a3bec8032e57bd53ba406ca6cbaec5b0a2ebfe4b18c346c18a5bc915a73",
+      "candidateHash": "e89c8a3bec8032e57bd53ba406ca6cbaec5b0a2ebfe4b18c346c18a5bc915a73"
+    },
+    {
+      "command": "alerts:triggers:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 13,
+      "legacyHash": "e89c8a3bec8032e57bd53ba406ca6cbaec5b0a2ebfe4b18c346c18a5bc915a73",
+      "candidateHash": "e89c8a3bec8032e57bd53ba406ca6cbaec5b0a2ebfe4b18c346c18a5bc915a73"
+    },
+    {
+      "command": "alerts:webhooks:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 1,
+      "legacyHash": "87ef17786063455dd462a1c43aad462520edd09b5ec861c8b783920d4f683fff",
+      "candidateHash": "87ef17786063455dd462a1c43aad462520edd09b5ec861c8b783920d4f683fff"
+    },
+    {
+      "command": "alerts:webhooks:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 1,
+      "legacyHash": "87ef17786063455dd462a1c43aad462520edd09b5ec861c8b783920d4f683fff",
+      "candidateHash": "87ef17786063455dd462a1c43aad462520edd09b5ec861c8b783920d4f683fff"
+    },
+    {
+      "command": "customers:users:roles",
+      "mode": "human",
+      "status": "matched",
+      "count": 4,
+      "legacyHash": "5d676a042316e9f77dc194dcd66657114dc960235674776fc0d58b874eb667e2",
+      "candidateHash": "5d676a042316e9f77dc194dcd66657114dc960235674776fc0d58b874eb667e2"
+    },
+    {
+      "command": "customers:users:roles",
+      "mode": "agent",
+      "status": "matched",
+      "count": 4,
+      "legacyHash": "5d676a042316e9f77dc194dcd66657114dc960235674776fc0d58b874eb667e2",
+      "candidateHash": "5d676a042316e9f77dc194dcd66657114dc960235674776fc0d58b874eb667e2"
+    },
+    {
+      "command": "logs:severities:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 7,
+      "legacyHash": "7986c8a162c94e5f6ffc93c11533865d2143f68462a7e6e6fdeee908eaf1c9b5",
+      "candidateHash": "7986c8a162c94e5f6ffc93c11533865d2143f68462a7e6e6fdeee908eaf1c9b5"
+    },
+    {
+      "command": "logs:severities:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 7,
+      "legacyHash": "7986c8a162c94e5f6ffc93c11533865d2143f68462a7e6e6fdeee908eaf1c9b5",
+      "candidateHash": "7986c8a162c94e5f6ffc93c11533865d2143f68462a7e6e6fdeee908eaf1c9b5"
+    },
+    {
+      "command": "organization:connections:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 26,
+      "legacyHash": "70b0b4ae2f9d6ba60595c2b8dd50af235811bd95a85e1cb6aa7afcc9a3ec0419",
+      "candidateHash": "70b0b4ae2f9d6ba60595c2b8dd50af235811bd95a85e1cb6aa7afcc9a3ec0419"
+    },
+    {
+      "command": "organization:connections:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 26,
+      "legacyHash": "70b0b4ae2f9d6ba60595c2b8dd50af235811bd95a85e1cb6aa7afcc9a3ec0419",
+      "candidateHash": "70b0b4ae2f9d6ba60595c2b8dd50af235811bd95a85e1cb6aa7afcc9a3ec0419"
+    },
+    {
+      "command": "organization:signing-keys:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 8,
+      "legacyHash": "811131984371f53130073d6602334fcbc247525bb0a42298ad28be0cede7c21a",
+      "candidateHash": "811131984371f53130073d6602334fcbc247525bb0a42298ad28be0cede7c21a"
+    },
+    {
+      "command": "organization:signing-keys:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 8,
+      "legacyHash": "811131984371f53130073d6602334fcbc247525bb0a42298ad28be0cede7c21a",
+      "candidateHash": "811131984371f53130073d6602334fcbc247525bb0a42298ad28be0cede7c21a"
+    },
+    {
+      "command": "organization:users:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 4,
+      "legacyHash": "269a931ea2c7a0f8867bf5a24a0b0a3d11941155151d03e17067ad33fdca1f8c",
+      "candidateHash": "269a931ea2c7a0f8867bf5a24a0b0a3d11941155151d03e17067ad33fdca1f8c"
+    },
+    {
+      "command": "organization:users:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 4,
+      "legacyHash": "269a931ea2c7a0f8867bf5a24a0b0a3d11941155151d03e17067ad33fdca1f8c",
+      "candidateHash": "269a931ea2c7a0f8867bf5a24a0b0a3d11941155151d03e17067ad33fdca1f8c"
+    },
+    {
+      "command": "organization:users:list",
+      "mode": "pagination",
+      "status": "matched"
+    },
+    {
+      "command": "organization:users:roles",
+      "mode": "human",
+      "status": "matched",
+      "count": 6,
+      "legacyHash": "157292e82f5987ccfb06dcbffbd5145f55d6176007013d18e0f807641bc56688",
+      "candidateHash": "157292e82f5987ccfb06dcbffbd5145f55d6176007013d18e0f807641bc56688"
+    },
+    {
+      "command": "organization:users:roles",
+      "mode": "agent",
+      "status": "matched",
+      "count": 6,
+      "legacyHash": "157292e82f5987ccfb06dcbffbd5145f55d6176007013d18e0f807641bc56688",
+      "candidateHash": "157292e82f5987ccfb06dcbffbd5145f55d6176007013d18e0f807641bc56688"
+    },
+    {
+      "command": "customers:users:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 3,
+      "legacyHash": "278877fc7dbbb217ff78c2c8505763c8b8a2a5542878994c11f44941f74b7a34",
+      "candidateHash": "278877fc7dbbb217ff78c2c8505763c8b8a2a5542878994c11f44941f74b7a34"
+    },
+    {
+      "command": "customers:users:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 3,
+      "legacyHash": "278877fc7dbbb217ff78c2c8505763c8b8a2a5542878994c11f44941f74b7a34",
+      "candidateHash": "278877fc7dbbb217ff78c2c8505763c8b8a2a5542878994c11f44941f74b7a34"
+    },
+    {
+      "command": "customers:users:list",
+      "mode": "pagination",
+      "status": "matched"
+    },
+    {
+      "command": "instances:config-vars:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 0,
+      "legacyHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+      "candidateHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+    },
+    {
+      "command": "instances:config-vars:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 0,
+      "legacyHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+      "candidateHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+    },
+    {
+      "command": "instances:flow-configs:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 1,
+      "legacyHash": "30dff89a8639b41c552eaefed77e441f3cb52cda03764591019b2e360ed84b58",
+      "candidateHash": "30dff89a8639b41c552eaefed77e441f3cb52cda03764591019b2e360ed84b58"
+    },
+    {
+      "command": "instances:flow-configs:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 1,
+      "legacyHash": "30dff89a8639b41c552eaefed77e441f3cb52cda03764591019b2e360ed84b58",
+      "candidateHash": "30dff89a8639b41c552eaefed77e441f3cb52cda03764591019b2e360ed84b58"
+    },
+    {
+      "command": "integrations:flows:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 1,
+      "legacyHash": "5c1fe24a1ea31a3da470ead2a99fbabb773ea691ff5e840bfba6dafa075b1aef",
+      "candidateHash": "5c1fe24a1ea31a3da470ead2a99fbabb773ea691ff5e840bfba6dafa075b1aef"
+    },
+    {
+      "command": "integrations:flows:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 1,
+      "legacyHash": "5c1fe24a1ea31a3da470ead2a99fbabb773ea691ff5e840bfba6dafa075b1aef",
+      "candidateHash": "5c1fe24a1ea31a3da470ead2a99fbabb773ea691ff5e840bfba6dafa075b1aef"
+    },
+    {
+      "command": "integrations:versions",
+      "mode": "human",
+      "status": "matched",
+      "count": 4,
+      "legacyHash": "58362b0c644e445b583288512093ce6bf779aa22558bb9457b645a0933d97e93",
+      "candidateHash": "58362b0c644e445b583288512093ce6bf779aa22558bb9457b645a0933d97e93"
+    },
+    {
+      "command": "integrations:versions",
+      "mode": "agent",
+      "status": "matched",
+      "count": 4,
+      "legacyHash": "58362b0c644e445b583288512093ce6bf779aa22558bb9457b645a0933d97e93",
+      "candidateHash": "58362b0c644e445b583288512093ce6bf779aa22558bb9457b645a0933d97e93"
+    },
+    {
+      "command": "components:actions:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 1,
+      "legacyHash": "e3b4d79a2229d59a480f557db6578afae3c67dcd0831f8375d3f1c867ce2cfa9",
+      "candidateHash": "e3b4d79a2229d59a480f557db6578afae3c67dcd0831f8375d3f1c867ce2cfa9"
+    },
+    {
+      "command": "components:actions:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 1,
+      "legacyHash": "e3b4d79a2229d59a480f557db6578afae3c67dcd0831f8375d3f1c867ce2cfa9",
+      "candidateHash": "e3b4d79a2229d59a480f557db6578afae3c67dcd0831f8375d3f1c867ce2cfa9"
+    },
+    {
+      "command": "components:data-sources:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 0,
+      "legacyHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+      "candidateHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+    },
+    {
+      "command": "components:data-sources:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 0,
+      "legacyHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+      "candidateHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+    },
+    {
+      "command": "components:triggers:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 0,
+      "legacyHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+      "candidateHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+    },
+    {
+      "command": "components:triggers:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 0,
+      "legacyHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+      "candidateHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+    },
+    {
+      "command": "alerts:events:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 100,
+      "legacyHash": "fefe08a74a9361158c679a22b30ab33894b50914cb62af741de79e0f0084ec80",
+      "candidateHash": "fefe08a74a9361158c679a22b30ab33894b50914cb62af741de79e0f0084ec80"
+    },
+    {
+      "command": "alerts:events:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 100,
+      "legacyHash": "fefe08a74a9361158c679a22b30ab33894b50914cb62af741de79e0f0084ec80",
+      "candidateHash": "fefe08a74a9361158c679a22b30ab33894b50914cb62af741de79e0f0084ec80"
+    }
+  ]
+}

--- a/test/fixtures/live-cli-lifecycle.json
+++ b/test/fixtures/live-cli-lifecycle.json
@@ -1,0 +1,25 @@
+{
+  "checkedAt": "2026-09-08T18:11:10.362Z",
+  "stack": "https://app.rwersal.prismatic-dev.io",
+  "checks": [
+    {
+      "cli": "release",
+      "create": true,
+      "arrays": true,
+      "variablesAlias": true,
+      "attachedAlias": true,
+      "update": true,
+      "delete": true
+    },
+    {
+      "cli": "port",
+      "create": true,
+      "arrays": true,
+      "variablesAlias": true,
+      "attachedAlias": true,
+      "update": true,
+      "delete": true
+    }
+  ],
+  "allTemporaryCustomersRemoved": true
+}

--- a/test/fixtures/live-cli-smoke.json
+++ b/test/fixtures/live-cli-smoke.json
@@ -1,0 +1,21 @@
+{
+  "candidate": "@prismatic-io/prism/11.0.0 darwin-arm64 node-v24.19.0",
+  "checks": [
+    {
+      "command": "me",
+      "count": 8,
+      "sha256": "6ed415e1c032ca607c94e0ba50b3b05572b4697c0c770ee150c772474a95a2ff"
+    },
+    {
+      "command": "customers:list",
+      "count": 9,
+      "sha256": "e9de6d7912913dce8cb89c9cc50e6c6468465ecd0771cfc3d9e038e0eee609ee"
+    },
+    {
+      "command": "integrations:list",
+      "count": 15,
+      "sha256": "e348a5046dac2977a9a96ea3f431e8c868a8234a7afa87032f9ba42952f1d9f5"
+    }
+  ],
+  "legacy": "@prismatic-io/prism/10.2.0 darwin-arm64 node-v24.19.0"
+}

--- a/test/fixtures/live-native-lifecycle.json
+++ b/test/fixtures/live-native-lifecycle.json
@@ -1,0 +1,25 @@
+{
+  "checkedAt": "2026-09-08T20:47:24.831Z",
+  "stack": "https://app.rwersal.prismatic-dev.io",
+  "checks": [
+    {
+      "cli": "release",
+      "create": true,
+      "arrays": true,
+      "variablesAlias": true,
+      "attachedAlias": true,
+      "update": true,
+      "delete": true
+    },
+    {
+      "cli": "port",
+      "create": true,
+      "arrays": true,
+      "variablesAlias": true,
+      "attachedAlias": true,
+      "update": true,
+      "delete": true
+    }
+  ],
+  "allTemporaryCustomersRemoved": true
+}

--- a/test/fixtures/live-native-readonly.json
+++ b/test/fixtures/live-native-readonly.json
@@ -1,0 +1,432 @@
+{
+  "checkedAt": "2026-09-08T20:47:08.639Z",
+  "stack": "https://app.rwersal.prismatic-dev.io",
+  "legacy": "@prismatic-io/prism/10.2.0 darwin-arm64 node-v24.19.0",
+  "candidate": "11.0.0",
+  "checks": [
+    {
+      "command": "me",
+      "status": "matched",
+      "sha256": "2d6debc126547a093293584b713a27eb451d9cb32c01ace5893989aaa3987eca"
+    },
+    {
+      "command": "customers:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 9,
+      "legacyHash": "dcc716f966afa21ba93df719f73ba3ed6eedf05f3a6b473c48694f84e05240db",
+      "candidateHash": "dcc716f966afa21ba93df719f73ba3ed6eedf05f3a6b473c48694f84e05240db"
+    },
+    {
+      "command": "customers:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 9,
+      "legacyHash": "dcc716f966afa21ba93df719f73ba3ed6eedf05f3a6b473c48694f84e05240db",
+      "candidateHash": "dcc716f966afa21ba93df719f73ba3ed6eedf05f3a6b473c48694f84e05240db"
+    },
+    {
+      "command": "customers:list",
+      "mode": "pagination",
+      "status": "matched"
+    },
+    {
+      "command": "integrations:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 16,
+      "legacyHash": "e04d33a98efd2601edcaa4b7f2d697c7c388774c9b1f69415910ce4401fafd35",
+      "candidateHash": "e04d33a98efd2601edcaa4b7f2d697c7c388774c9b1f69415910ce4401fafd35"
+    },
+    {
+      "command": "integrations:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 16,
+      "legacyHash": "e04d33a98efd2601edcaa4b7f2d697c7c388774c9b1f69415910ce4401fafd35",
+      "candidateHash": "e04d33a98efd2601edcaa4b7f2d697c7c388774c9b1f69415910ce4401fafd35"
+    },
+    {
+      "command": "integrations:list",
+      "mode": "pagination",
+      "status": "matched"
+    },
+    {
+      "command": "instances:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 7,
+      "legacyHash": "554795838225ada3744ac06cd48830c134f9208646394e491a2c5ac0def37a62",
+      "candidateHash": "554795838225ada3744ac06cd48830c134f9208646394e491a2c5ac0def37a62"
+    },
+    {
+      "command": "instances:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 7,
+      "legacyHash": "554795838225ada3744ac06cd48830c134f9208646394e491a2c5ac0def37a62",
+      "candidateHash": "554795838225ada3744ac06cd48830c134f9208646394e491a2c5ac0def37a62"
+    },
+    {
+      "command": "instances:list",
+      "mode": "pagination",
+      "status": "matched"
+    },
+    {
+      "command": "components:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 205,
+      "legacyHash": "528f9ac57549f158088153f3efa22a1acadcf0d49b229de8e3d5b288211a5dd7",
+      "candidateHash": "528f9ac57549f158088153f3efa22a1acadcf0d49b229de8e3d5b288211a5dd7"
+    },
+    {
+      "command": "components:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 205,
+      "legacyHash": "528f9ac57549f158088153f3efa22a1acadcf0d49b229de8e3d5b288211a5dd7",
+      "candidateHash": "528f9ac57549f158088153f3efa22a1acadcf0d49b229de8e3d5b288211a5dd7"
+    },
+    {
+      "command": "components:list",
+      "mode": "pagination",
+      "status": "matched"
+    },
+    {
+      "command": "on-prem-resources:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 1,
+      "legacyHash": "7c71910def5551c9930be5ee50c9df162f776fe2e51dd6f055c5e90c0135994a",
+      "candidateHash": "7c71910def5551c9930be5ee50c9df162f776fe2e51dd6f055c5e90c0135994a"
+    },
+    {
+      "command": "on-prem-resources:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 1,
+      "legacyHash": "7c71910def5551c9930be5ee50c9df162f776fe2e51dd6f055c5e90c0135994a",
+      "candidateHash": "7c71910def5551c9930be5ee50c9df162f776fe2e51dd6f055c5e90c0135994a"
+    },
+    {
+      "command": "alerts:groups:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 0,
+      "legacyHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+      "candidateHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+    },
+    {
+      "command": "alerts:groups:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 0,
+      "legacyHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+      "candidateHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+    },
+    {
+      "command": "alerts:monitors:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 2,
+      "legacyHash": "fa3e6860d444e995610bf195e6aae150beb811e1fd547e7fb2a7a4935603bcee",
+      "candidateHash": "fa3e6860d444e995610bf195e6aae150beb811e1fd547e7fb2a7a4935603bcee"
+    },
+    {
+      "command": "alerts:monitors:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 2,
+      "legacyHash": "fa3e6860d444e995610bf195e6aae150beb811e1fd547e7fb2a7a4935603bcee",
+      "candidateHash": "fa3e6860d444e995610bf195e6aae150beb811e1fd547e7fb2a7a4935603bcee"
+    },
+    {
+      "command": "alerts:monitors:list",
+      "mode": "pagination",
+      "status": "matched"
+    },
+    {
+      "command": "alerts:triggers:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 13,
+      "legacyHash": "e89c8a3bec8032e57bd53ba406ca6cbaec5b0a2ebfe4b18c346c18a5bc915a73",
+      "candidateHash": "e89c8a3bec8032e57bd53ba406ca6cbaec5b0a2ebfe4b18c346c18a5bc915a73"
+    },
+    {
+      "command": "alerts:triggers:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 13,
+      "legacyHash": "e89c8a3bec8032e57bd53ba406ca6cbaec5b0a2ebfe4b18c346c18a5bc915a73",
+      "candidateHash": "e89c8a3bec8032e57bd53ba406ca6cbaec5b0a2ebfe4b18c346c18a5bc915a73"
+    },
+    {
+      "command": "alerts:webhooks:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 1,
+      "legacyHash": "87ef17786063455dd462a1c43aad462520edd09b5ec861c8b783920d4f683fff",
+      "candidateHash": "87ef17786063455dd462a1c43aad462520edd09b5ec861c8b783920d4f683fff"
+    },
+    {
+      "command": "alerts:webhooks:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 1,
+      "legacyHash": "87ef17786063455dd462a1c43aad462520edd09b5ec861c8b783920d4f683fff",
+      "candidateHash": "87ef17786063455dd462a1c43aad462520edd09b5ec861c8b783920d4f683fff"
+    },
+    {
+      "command": "customers:users:roles",
+      "mode": "human",
+      "status": "matched",
+      "count": 4,
+      "legacyHash": "5d676a042316e9f77dc194dcd66657114dc960235674776fc0d58b874eb667e2",
+      "candidateHash": "5d676a042316e9f77dc194dcd66657114dc960235674776fc0d58b874eb667e2"
+    },
+    {
+      "command": "customers:users:roles",
+      "mode": "agent",
+      "status": "matched",
+      "count": 4,
+      "legacyHash": "5d676a042316e9f77dc194dcd66657114dc960235674776fc0d58b874eb667e2",
+      "candidateHash": "5d676a042316e9f77dc194dcd66657114dc960235674776fc0d58b874eb667e2"
+    },
+    {
+      "command": "logs:severities:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 7,
+      "legacyHash": "7986c8a162c94e5f6ffc93c11533865d2143f68462a7e6e6fdeee908eaf1c9b5",
+      "candidateHash": "7986c8a162c94e5f6ffc93c11533865d2143f68462a7e6e6fdeee908eaf1c9b5"
+    },
+    {
+      "command": "logs:severities:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 7,
+      "legacyHash": "7986c8a162c94e5f6ffc93c11533865d2143f68462a7e6e6fdeee908eaf1c9b5",
+      "candidateHash": "7986c8a162c94e5f6ffc93c11533865d2143f68462a7e6e6fdeee908eaf1c9b5"
+    },
+    {
+      "command": "organization:connections:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 26,
+      "legacyHash": "70b0b4ae2f9d6ba60595c2b8dd50af235811bd95a85e1cb6aa7afcc9a3ec0419",
+      "candidateHash": "70b0b4ae2f9d6ba60595c2b8dd50af235811bd95a85e1cb6aa7afcc9a3ec0419"
+    },
+    {
+      "command": "organization:connections:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 26,
+      "legacyHash": "70b0b4ae2f9d6ba60595c2b8dd50af235811bd95a85e1cb6aa7afcc9a3ec0419",
+      "candidateHash": "70b0b4ae2f9d6ba60595c2b8dd50af235811bd95a85e1cb6aa7afcc9a3ec0419"
+    },
+    {
+      "command": "organization:signing-keys:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 8,
+      "legacyHash": "811131984371f53130073d6602334fcbc247525bb0a42298ad28be0cede7c21a",
+      "candidateHash": "811131984371f53130073d6602334fcbc247525bb0a42298ad28be0cede7c21a"
+    },
+    {
+      "command": "organization:signing-keys:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 8,
+      "legacyHash": "811131984371f53130073d6602334fcbc247525bb0a42298ad28be0cede7c21a",
+      "candidateHash": "811131984371f53130073d6602334fcbc247525bb0a42298ad28be0cede7c21a"
+    },
+    {
+      "command": "organization:users:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 4,
+      "legacyHash": "269a931ea2c7a0f8867bf5a24a0b0a3d11941155151d03e17067ad33fdca1f8c",
+      "candidateHash": "269a931ea2c7a0f8867bf5a24a0b0a3d11941155151d03e17067ad33fdca1f8c"
+    },
+    {
+      "command": "organization:users:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 4,
+      "legacyHash": "269a931ea2c7a0f8867bf5a24a0b0a3d11941155151d03e17067ad33fdca1f8c",
+      "candidateHash": "269a931ea2c7a0f8867bf5a24a0b0a3d11941155151d03e17067ad33fdca1f8c"
+    },
+    {
+      "command": "organization:users:list",
+      "mode": "pagination",
+      "status": "matched"
+    },
+    {
+      "command": "organization:users:roles",
+      "mode": "human",
+      "status": "matched",
+      "count": 6,
+      "legacyHash": "157292e82f5987ccfb06dcbffbd5145f55d6176007013d18e0f807641bc56688",
+      "candidateHash": "157292e82f5987ccfb06dcbffbd5145f55d6176007013d18e0f807641bc56688"
+    },
+    {
+      "command": "organization:users:roles",
+      "mode": "agent",
+      "status": "matched",
+      "count": 6,
+      "legacyHash": "157292e82f5987ccfb06dcbffbd5145f55d6176007013d18e0f807641bc56688",
+      "candidateHash": "157292e82f5987ccfb06dcbffbd5145f55d6176007013d18e0f807641bc56688"
+    },
+    {
+      "command": "customers:users:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 3,
+      "legacyHash": "278877fc7dbbb217ff78c2c8505763c8b8a2a5542878994c11f44941f74b7a34",
+      "candidateHash": "278877fc7dbbb217ff78c2c8505763c8b8a2a5542878994c11f44941f74b7a34"
+    },
+    {
+      "command": "customers:users:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 3,
+      "legacyHash": "278877fc7dbbb217ff78c2c8505763c8b8a2a5542878994c11f44941f74b7a34",
+      "candidateHash": "278877fc7dbbb217ff78c2c8505763c8b8a2a5542878994c11f44941f74b7a34"
+    },
+    {
+      "command": "customers:users:list",
+      "mode": "pagination",
+      "status": "matched"
+    },
+    {
+      "command": "instances:config-vars:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 0,
+      "legacyHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+      "candidateHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+    },
+    {
+      "command": "instances:config-vars:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 0,
+      "legacyHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+      "candidateHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+    },
+    {
+      "command": "instances:flow-configs:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 1,
+      "legacyHash": "30dff89a8639b41c552eaefed77e441f3cb52cda03764591019b2e360ed84b58",
+      "candidateHash": "30dff89a8639b41c552eaefed77e441f3cb52cda03764591019b2e360ed84b58"
+    },
+    {
+      "command": "instances:flow-configs:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 1,
+      "legacyHash": "30dff89a8639b41c552eaefed77e441f3cb52cda03764591019b2e360ed84b58",
+      "candidateHash": "30dff89a8639b41c552eaefed77e441f3cb52cda03764591019b2e360ed84b58"
+    },
+    {
+      "command": "integrations:flows:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 1,
+      "legacyHash": "5c1fe24a1ea31a3da470ead2a99fbabb773ea691ff5e840bfba6dafa075b1aef",
+      "candidateHash": "5c1fe24a1ea31a3da470ead2a99fbabb773ea691ff5e840bfba6dafa075b1aef"
+    },
+    {
+      "command": "integrations:flows:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 1,
+      "legacyHash": "5c1fe24a1ea31a3da470ead2a99fbabb773ea691ff5e840bfba6dafa075b1aef",
+      "candidateHash": "5c1fe24a1ea31a3da470ead2a99fbabb773ea691ff5e840bfba6dafa075b1aef"
+    },
+    {
+      "command": "integrations:versions",
+      "mode": "human",
+      "status": "matched",
+      "count": 4,
+      "legacyHash": "58362b0c644e445b583288512093ce6bf779aa22558bb9457b645a0933d97e93",
+      "candidateHash": "58362b0c644e445b583288512093ce6bf779aa22558bb9457b645a0933d97e93"
+    },
+    {
+      "command": "integrations:versions",
+      "mode": "agent",
+      "status": "matched",
+      "count": 4,
+      "legacyHash": "58362b0c644e445b583288512093ce6bf779aa22558bb9457b645a0933d97e93",
+      "candidateHash": "58362b0c644e445b583288512093ce6bf779aa22558bb9457b645a0933d97e93"
+    },
+    {
+      "command": "components:actions:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 1,
+      "legacyHash": "e3b4d79a2229d59a480f557db6578afae3c67dcd0831f8375d3f1c867ce2cfa9",
+      "candidateHash": "e3b4d79a2229d59a480f557db6578afae3c67dcd0831f8375d3f1c867ce2cfa9"
+    },
+    {
+      "command": "components:actions:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 1,
+      "legacyHash": "e3b4d79a2229d59a480f557db6578afae3c67dcd0831f8375d3f1c867ce2cfa9",
+      "candidateHash": "e3b4d79a2229d59a480f557db6578afae3c67dcd0831f8375d3f1c867ce2cfa9"
+    },
+    {
+      "command": "components:data-sources:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 0,
+      "legacyHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+      "candidateHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+    },
+    {
+      "command": "components:data-sources:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 0,
+      "legacyHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+      "candidateHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+    },
+    {
+      "command": "components:triggers:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 0,
+      "legacyHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+      "candidateHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+    },
+    {
+      "command": "components:triggers:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 0,
+      "legacyHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945",
+      "candidateHash": "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+    },
+    {
+      "command": "alerts:events:list",
+      "mode": "human",
+      "status": "matched",
+      "count": 100,
+      "legacyHash": "fefe08a74a9361158c679a22b30ab33894b50914cb62af741de79e0f0084ec80",
+      "candidateHash": "fefe08a74a9361158c679a22b30ab33894b50914cb62af741de79e0f0084ec80"
+    },
+    {
+      "command": "alerts:events:list",
+      "mode": "agent",
+      "status": "matched",
+      "count": 100,
+      "legacyHash": "fefe08a74a9361158c679a22b30ab33894b50914cb62af741de79e0f0084ec80",
+      "candidateHash": "fefe08a74a9361158c679a22b30ab33894b50914cb62af741de79e0f0084ec80"
+    }
+  ]
+}


### PR DESCRIPTION
Document the incur review stack and preserve live compatibility evidence.

Part **24/24** of the native incur migration. This PR targets `incur-23-native-cutover`; the stack integrates into the long-lived `agent` branch. Review this diff against its immediate base.

Preserves the upstream incur findings and development-stack evidence: 56 matching read-only comparisons with published Prism 10.2.0, plus two temporary-customer lifecycle checks with cleanup. The final implementation and lockfile match the validated snapshot; the final sequential validation task passes 775 tests (3 skipped).

[Stack review guide](https://github.com/prismatic-io/prism/blob/incur-24-review-evidence/docs/incur-pr-stack.md). Merge bottom-up; rebase descendants after a squash merge.
