### PR TITLE
Make configuration writes atomic and serialize profile mutations

### DIFF
--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -15,6 +15,7 @@ import {
   writeProfile,
 } from "./config.js";
 import { DEFAULT_PRISMATIC_URL } from "./env.js";
+import { fs } from "./fs.js";
 import { dumpYaml } from "./utils/serialize.js";
 
 const makeConfig = (overrides: Partial<Configuration> = {}): Configuration => ({
@@ -88,6 +89,67 @@ describe("config with PRISM_CONFIG_FILE override", () => {
     await writeActiveProfile(makeConfig());
     await deleteProfile(await getActiveProfileName());
     expect(await readConfigFile()).toBeNull();
+  });
+
+  it("preserves overlapping profile writes, default changes, and deletions", async () => {
+    const results = await Promise.allSettled([
+      writeProfile("first", makeProfile()),
+      writeActiveProfile(makeConfig({ accessToken: "second-token" }), "second"),
+      writeProfile("third", makeProfile()),
+      useProfile("second"),
+      deleteProfile("first"),
+    ]);
+    expect(results.map(({ status }) => status)).toEqual(Array(5).fill("fulfilled"));
+    const saved = await readConfigFile();
+    expect(saved?.defaultProfile).toBe("second");
+    expect(Object.keys(saved?.profiles ?? {})).toEqual(["second", "third"]);
+    expect(saved?.profiles.second.accessToken).toBe("second-token");
+  });
+
+  it("continues queued writes after validation fails", async () => {
+    const results = await Promise.allSettled([
+      writeProfile("invalid", makeProfile({ accessToken: "" })),
+      writeProfile("valid", makeProfile()),
+    ]);
+    expect(results.map(({ status }) => status)).toEqual(["rejected", "fulfilled"]);
+    expect(Object.keys((await readConfigFile())?.profiles ?? {})).toEqual(["valid"]);
+  });
+
+  it("preserves the file after failed replacement and allows the next write", async () => {
+    await writeProfile("original", makeProfile());
+    const original = await readFile(configPath, "utf8");
+    vi.spyOn(fs, "rename").mockRejectedValueOnce(new Error("rename failed"));
+    await expect(writeProfile("failed", makeProfile())).rejects.toThrow("rename failed");
+    expect(await readFile(configPath, "utf8")).toBe(original);
+    expect((await fs.readdir(tmpDir)).filter((name) => name.endsWith(".tmp"))).toEqual([]);
+    await writeProfile("recovered", makeProfile());
+    expect(Object.keys((await readConfigFile())?.profiles ?? {})).toEqual([
+      "original",
+      "recovered",
+    ]);
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "keeps credential files private after replacement",
+    async () => {
+      await writeProfile("first", makeProfile());
+      expect((await stat(configPath)).mode & 0o777).toBe(0o600);
+      await writeProfile("second", makeProfile());
+      expect((await stat(configPath)).mode & 0o777).toBe(0o600);
+    },
+  );
+
+  it("updates a symlink target without replacing the link", async () => {
+    const target = path.join(tmpDir, "target.yml");
+    await writeFile(target, "");
+    await fs.symlink(target, configPath);
+    try {
+      await writeProfile("first", makeProfile());
+      expect((await fs.lstat(configPath)).isSymbolicLink()).toBe(true);
+      expect(await readFile(target, "utf8")).toContain("defaultProfile: first");
+    } finally {
+      await rm(target, { force: true });
+    }
   });
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+import { devNull } from "node:os";
 import path from "path";
 import { z } from "zod";
 import { DEFAULT_PRISMATIC_URL, getEnv } from "./env.js";
@@ -64,6 +66,27 @@ const normalizeUnversionedConfig = (raw: Record<string, unknown>): unknown => ({
 
 const getConfigFilePath = (): string => getEnv().PRISM_CONFIG_FILE;
 
+// Resolve existing symlinks so replacement updates the target, not the link.
+// Missing files use the configured path; dangling links fail in realpath.
+const resolveConfigPath = async (filePath: string): Promise<string> => {
+  if (filePath === devNull) return devNull;
+  const entry = await fs.lstat(filePath).catch((error: NodeJS.ErrnoException) => {
+    if (error.code === "ENOENT") return null;
+    throw error;
+  });
+  return entry ? fs.realpath(filePath) : path.resolve(filePath);
+};
+
+// Keep each read/modify/write operation together when MCP requests overlap.
+// This queue coordinates this process only, not separate CLI processes.
+let configUpdates: Promise<unknown> = Promise.resolve();
+const queueConfigUpdate = <T>(update: () => Promise<T>): Promise<T> => {
+  const pending = configUpdates.then(update);
+  // Return the failure to its caller, but allow the next update to proceed.
+  configUpdates = pending.catch(() => {});
+  return pending;
+};
+
 const writeConfigFile = async (configFile: ConfigFile) => {
   const result = configFileSchema.safeParse(configFile);
   if (!result.success) {
@@ -71,10 +94,18 @@ const writeConfigFile = async (configFile: ConfigFile) => {
       `Prism could not save its configuration:\n${formatValidationError(result.error)}`,
     );
   }
-  const configFilePath = getConfigFilePath();
+  const configFilePath = await resolveConfigPath(getConfigFilePath());
+  if (configFilePath === devNull) return;
   await fs.mkdir(path.dirname(configFilePath), { recursive: true });
   const contents = dumpYaml(result.data, { skipInvalid: true });
-  await fs.writeFile(configFilePath, contents, { encoding: "utf-8" });
+  const temporaryPath = `${configFilePath}.${randomUUID()}.tmp`;
+  try {
+    await fs.writeFile(temporaryPath, contents, { encoding: "utf-8", mode: 0o600, flag: "wx" });
+    await fs.rename(temporaryPath, configFilePath);
+  } catch (error) {
+    await fs.rm(temporaryPath, { force: true }).catch(() => {});
+    throw error;
+  }
 };
 
 export const readConfigFile = async (): Promise<ConfigFile | null> => {
@@ -127,36 +158,39 @@ export const readProfileSelection = async (
 export const readProfile = async (name?: ProfileName): Promise<Profile | null> =>
   (await readProfileSelection(name)).profile;
 
-export const writeProfile = async (name: ProfileName, profile: Profile) => {
-  await writeConfigFile(withProfile(await readConfigFile(), name, profile));
-};
+export const writeProfile = (name: ProfileName, profile: Profile) =>
+  queueConfigUpdate(async () => {
+    await writeConfigFile(withProfile(await readConfigFile(), name, profile));
+  });
 
-export const deleteProfile = async (name: ProfileName) => {
-  const file = await readConfigFile();
-  if (!file || !hasProfile(file.profiles, name)) return { deleted: false } as const;
+export const deleteProfile = (name: ProfileName) =>
+  queueConfigUpdate(async () => {
+    const file = await readConfigFile();
+    if (!file || !hasProfile(file.profiles, name)) return { deleted: false } as const;
 
-  const { [name]: _removed, ...remaining } = file.profiles;
-  const remainingNames = Object.keys(remaining);
+    const { [name]: _removed, ...remaining } = file.profiles;
+    const remainingNames = Object.keys(remaining);
 
-  if (remainingNames.length === 0) {
-    await fs.unlink(getConfigFilePath());
-    return { deleted: true, isLast: true } as const;
-  }
+    if (remainingNames.length === 0) {
+      await fs.unlink(getConfigFilePath());
+      return { deleted: true, isLast: true } as const;
+    }
 
-  const defaultChanged = file.defaultProfile === name;
-  const defaultProfile = defaultChanged ? remainingNames[0] : file.defaultProfile;
-  await writeConfigFile({ version: CONFIG_VERSION, defaultProfile, profiles: remaining });
-  return { deleted: true, isLast: false, defaultChanged, defaultProfile } as const;
-};
+    const defaultChanged = file.defaultProfile === name;
+    const defaultProfile = defaultChanged ? remainingNames[0] : file.defaultProfile;
+    await writeConfigFile({ version: CONFIG_VERSION, defaultProfile, profiles: remaining });
+    return { deleted: true, isLast: false, defaultChanged, defaultProfile } as const;
+  });
 
-export const useProfile = async (name: ProfileName) => {
-  const file = await readConfigFile();
-  if (!file || !hasProfile(file.profiles, name)) {
-    throw new Error(`Profile "${name}" does not exist.`);
-  }
-  if (file.defaultProfile === name) return;
-  await writeConfigFile({ ...file, defaultProfile: name });
-};
+export const useProfile = (name: ProfileName) =>
+  queueConfigUpdate(async () => {
+    const file = await readConfigFile();
+    if (!file || !hasProfile(file.profiles, name)) {
+      throw new Error(`Profile "${name}" does not exist.`);
+    }
+    if (file.defaultProfile === name) return;
+    await writeConfigFile({ ...file, defaultProfile: name });
+  });
 
 export const listProfiles = async (): Promise<
   { name: ProfileName; prismaticUrl: string; tenantId?: string; isDefault: boolean }[]
@@ -171,9 +205,10 @@ export const listProfiles = async (): Promise<
   }));
 };
 
-export const writeActiveProfile = async (config: Configuration, name?: ProfileName) => {
-  const file = await readConfigFile();
-  const profileName = name ?? resolveActiveName(file);
-  const prismaticUrl = file?.profiles[profileName]?.prismaticUrl ?? resolveProfileUrl();
-  await writeConfigFile(withProfile(file, profileName, { ...config, prismaticUrl }));
-};
+export const writeActiveProfile = (config: Configuration, name?: ProfileName) =>
+  queueConfigUpdate(async () => {
+    const file = await readConfigFile();
+    const profileName = name ?? resolveActiveName(file);
+    const prismaticUrl = file?.profiles[profileName]?.prismaticUrl ?? resolveProfileUrl();
+    await writeConfigFile(withProfile(file, profileName, { ...config, prismaticUrl }));
+  });


### PR DESCRIPTION
This ended up being necessary for the new `mcp` mode `incur` provides.